### PR TITLE
Update item syntax to 21w19a

### DIFF
--- a/src/data/CommandTree1.17.ts
+++ b/src/data/CommandTree1.17.ts
@@ -697,7 +697,7 @@ export const CommandTree: ICommandTree = {
                     children: {
                         name: {
                             parser: new IdentityArgumentParser('$function', true),
-                            executable: true,
+                            executable: true
                         }
                     }
                 }
@@ -1063,52 +1063,69 @@ export const CommandTree: ICommandTree = {
         item: {
             parser: new LiteralArgumentParser('item'),
             children: {
-                target: {
-                    template: 'item_holder',
+                [Switchable]: true,
+                modify: {
+                    parser: new LiteralArgumentParser('modify'),
                     children: {
-                        slot: {
-                            parser: new ItemSlotArgumentParser(),
+                        source: {
+                            template: 'item_holder',
                             children: {
-                                [Switchable]: true,
-                                copy: {
-                                    parser: new LiteralArgumentParser('copy'),
-                                    children: {
-                                        source: {
-                                            template: 'item_holder',
-                                            children: {
-                                                slot: {
-                                                    parser: new ItemSlotArgumentParser(),
-                                                    executable: true,
-                                                    children: {
-                                                        modifier: {
-                                                            parser: new IdentityArgumentParser('$item_modifier'),
-                                                            executable: true
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
-                                },
-                                modify: {
-                                    parser: new LiteralArgumentParser('modify'),
+                                slot: {
+                                    parser: new ItemSlotArgumentParser(),
+                                    executable: true,
                                     children: {
                                         modifier: {
                                             parser: new IdentityArgumentParser('$item_modifier'),
                                             executable: true
                                         }
                                     }
-                                },
-                                replace: {
-                                    parser: new LiteralArgumentParser('replace'),
+                                }
+                            }
+                        }
+                    }  
+                },
+                replace: {
+                    parser: new LiteralArgumentParser('replace'),
+                    children: {
+                        source: {
+                            template: 'item_holder',
+                            children: {
+                                slot: {
+                                    parser: new ItemSlotArgumentParser(),
                                     children: {
-                                        item: {
-                                            parser: new ItemArgumentParser(false),
-                                            executable: true,
+                                        [Switchable]: true,
+                                        width: {
+                                            parser: new LiteralArgumentParser('with'),
                                             children: {
-                                                count: {
-                                                    parser: new NumberArgumentParser('integer', 0, 64),
-                                                    executable: true
+                                                item: {
+                                                    parser: new ItemArgumentParser(false),
+                                                    executable: true,
+                                                    children: {
+                                                        count: {
+                                                            parser: new NumberArgumentParser('integer', 0, 64),
+                                                            executable: true
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        from: {
+                                            parser: new LiteralArgumentParser('from'),
+                                            children: {
+                                                source: {
+                                                    template: 'item_holder',
+                                                    children: {
+                                                        slot: {
+                                                            parser: new ItemSlotArgumentParser(),
+                                                            executable: true,
+                                                            children: {
+                                                                modifier: {
+                                                                    parser: new IdentityArgumentParser('$item_modifier'),
+                                                                    executable: true
+                                                                }
+                                                            }
+                                                        }
+                                                    }
                                                 }
                                             }
                                         }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -34,7 +34,7 @@
     "argument-type.vector.4D": "4D vector",
     "boolean": "a boolean",
     "code-action.block-state-sort-keys": "Sort block state",
-    "code-action.command-replaceitem": "Update this command to /item ... replace",
+    "code-action.command-replaceitem": "Update this command to /item replace ...",
     "code-action.fix-file": "Fix all auto-fixable problems in this file",
     "code-action.fix-workspace": "Fix all auto-fixable problems in the workspace",
     "code-action.id-attribute-datafix": "Update this attribute name to 1.16",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -34,7 +34,7 @@
     "argument-type.vector.4D": "4D vector",
     "boolean": "boolean型",
     "code-action.block-state-sort-keys": "block stateをソートする",
-    "code-action.command-replaceitem": "このコマンドを/item ... replaceに更新します",
+    "code-action.command-replaceitem": "このコマンドを/item replace ...に更新します",
     "code-action.fix-file": "このファイルの修正可能な問題を一括修正する",
     "code-action.fix-workspace": "このワークスペース内のすべての修正可能な問題を一括修正する",
     "code-action.id-attribute-datafix": "このattributeのnameを1.16に更新する",

--- a/src/locales/zh-cn.json
+++ b/src/locales/zh-cn.json
@@ -34,7 +34,7 @@
     "argument-type.vector.4D": "四维向量",
     "boolean": "一个布尔值",
     "code-action.block-state-sort-keys": "将方块状态按键排序",
-    "code-action.command-replaceitem": "将该命令升级为 /item ... replace",
+    "code-action.command-replaceitem": "将该命令升级为 /item replace ...",
     "code-action.fix-file": "修复当前文件中所有可自动修复的问题",
     "code-action.fix-workspace": "修复当前工作空间中所有可自动修复的问题",
     "code-action.id-attribute-datafix": "将该属性名更新到 1.16",

--- a/src/locales/zh-tw.json
+++ b/src/locales/zh-tw.json
@@ -34,7 +34,7 @@
     "argument-type.vector.4D": "四維向量",
     "boolean": "一個布林值",
     "code-action.block-state-sort-keys": "將方塊狀態按鍵排序",
-    "code-action.command-replaceitem": "將該指令升級到 /item ... replace",
+    "code-action.command-replaceitem": "將該指令升級到 /item replace ...",
     "code-action.fix-file": "修復當前檔案中所有可自動修復的問題",
     "code-action.fix-workspace": "修復當前工作區中所有可自動修復的問題",
     "code-action.id-attribute-datafix": "將該屬性名更新至 1.16",

--- a/src/services/onCodeAction.ts
+++ b/src/services/onCodeAction.ts
@@ -84,7 +84,7 @@ export function fixCommandComponent(ans: CodeAction[], ctx: ParsingContext, node
             ans.push(getCodeAction(
                 'command-replaceitem', commandReplaceitem,
                 ctx.textDoc, { start: startLiteral.range.start, end: count ? count.range.end : item.range.end },
-                `item ${target1.data} ${(target2.data as ArgumentNode)[GetFormattedString](ctx.config.lint)} ${slot.data} replace ${(item.data as ArgumentNode)[GetFormattedString](ctx.config.lint)}${count ? ` ${count.data}` : ''}`
+                `item replace ${target1.data} ${(target2.data as ArgumentNode)[GetFormattedString](ctx.config.lint)} ${slot.data} with ${(item.data as ArgumentNode)[GetFormattedString](ctx.config.lint)}${count ? ` ${count.data}` : ''}`
             ))
         }
     }


### PR DESCRIPTION
Also updates the existing code action.
Does *not* add a new code action to convert from the old /item syntax.
