### PR TITLE
:sparkles: Support new `/damage` commands

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
                 "@mcschema/java-1.18.2": "^0.1.17",
                 "@mcschema/java-1.19": "^0.1.41",
                 "@mcschema/java-1.19.3": "^0.0.3",
-                "@mcschema/java-1.19.4": "^0.1.1",
+                "@mcschema/java-1.19.4": "^0.1.3",
                 "@mcschema/locales": "^0.1.75",
                 "appdata-path": "^1.0.0",
                 "clone": "^2.1.2",
@@ -770,9 +770,10 @@
             }
         },
         "node_modules/@mcschema/java-1.19.4": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/@mcschema/java-1.19.4/-/java-1.19.4-0.1.1.tgz",
-            "integrity": "sha512-tuuOEI5uZv0VCL1FSJLtMQp8VIJlDIMLERaTSFPEZHd03gTwucGjKTYqYvB05gamhqVxWVRoSQl1Pv0MU0U5ig==",
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/@mcschema/java-1.19.4/-/java-1.19.4-0.1.3.tgz",
+            "integrity": "sha512-e/NEw4YzPdXgN6o4AlHCoptF6XpdtAkhfQeYBG6SL94B6LdRdHAdTrQWcXr+/Y+xRrO2EqIxCQKvTpWxa8kMHA==",
+            "license": "MIT",
             "dependencies": {
                 "@mcschema/core": "^0.12.38"
             }
@@ -10112,11 +10113,6 @@
                 "safer-buffer": "^2.0.2",
                 "tweetnacl": "~0.14.0"
             },
-            "bin": {
-                "sshpk-conv": "bin/sshpk-conv",
-                "sshpk-sign": "bin/sshpk-sign",
-                "sshpk-verify": "bin/sshpk-verify"
-            },
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -14562,9 +14558,9 @@
             }
         },
         "@mcschema/java-1.19.4": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/@mcschema/java-1.19.4/-/java-1.19.4-0.1.1.tgz",
-            "integrity": "sha512-tuuOEI5uZv0VCL1FSJLtMQp8VIJlDIMLERaTSFPEZHd03gTwucGjKTYqYvB05gamhqVxWVRoSQl1Pv0MU0U5ig==",
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/@mcschema/java-1.19.4/-/java-1.19.4-0.1.3.tgz",
+            "integrity": "sha512-e/NEw4YzPdXgN6o4AlHCoptF6XpdtAkhfQeYBG6SL94B6LdRdHAdTrQWcXr+/Y+xRrO2EqIxCQKvTpWxa8kMHA==",
             "requires": {
                 "@mcschema/core": "^0.12.38"
             }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
         "@mcschema/java-1.18.2": "^0.1.17",
         "@mcschema/java-1.19": "^0.1.41",
         "@mcschema/java-1.19.3": "^0.0.3",
-        "@mcschema/java-1.19.4": "^0.1.1",
+        "@mcschema/java-1.19.4": "^0.1.3",
         "@mcschema/locales": "^0.1.75",
         "appdata-path": "^1.0.0",
         "clone": "^2.1.2",

--- a/src/data/CommandTree1.19.4.ts
+++ b/src/data/CommandTree1.19.4.ts
@@ -643,6 +643,47 @@ export const CommandTree: ICommandTree = {
                 }
             }
         },
+        damage: {
+            parser: new LiteralArgumentParser('damage'),
+            children: {
+                target: {
+                    parser: new EntityArgumentParser('multiple', 'entities'),
+                    children: {
+                        damageType: {
+                            parser: new IdentityArgumentParser('$damage_type'),
+                            executable: true,
+                            children: {
+                                [Switchable]: true,
+                                at: {
+                                    parser: new LiteralArgumentParser('at'),
+                                    children: {
+                                        location: {
+                                            parser: new VectorArgumentParser(3, 'float', true, true),
+                                            executable: true
+                                        }
+                                    }
+                                },
+                                by: {
+                                    parser: new LiteralArgumentParser('by'),
+                                    children: {
+                                        entity: {
+                                            parser: new EntityArgumentParser('single', 'entities'),
+                                            executable: true,
+                                            children: {
+                                                cause: {
+                                                    parser: new EntityArgumentParser('single', 'entities'),
+                                                    executable: true
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         data: {
             parser: new LiteralArgumentParser('data'),
             children: {

--- a/src/data/JsonSchema.ts
+++ b/src/data/JsonSchema.ts
@@ -9,6 +9,7 @@ export const FallbackJsonSchemaRegistry = getFallbackSchemas(setUpJsonCollection
 
 export type JsonSchemaType =
     | 'advancement'
+    | 'damage_type'
     | 'dimension'
     | 'dimension_type'
     | 'item_modifier'
@@ -17,6 +18,7 @@ export type JsonSchemaType =
     | 'recipe'
     /* tag */
     | 'block_tag'
+    | 'damage_type_tag'
     | 'entity_type_tag'
     | 'fluid_tag'
     | 'function_tag'
@@ -59,6 +61,7 @@ export type JsonSchemaType =
 
 const globPatterns: Record<JsonSchemaType, string> = {
     advancement: PathPatterns.advancement,
+    damage_type: PathPatterns.damage_type,
     dimension: PathPatterns.dimension,
     dimension_type: PathPatterns.dimension_type,
     item_modifier: PathPatterns.item_modifier,
@@ -67,6 +70,7 @@ const globPatterns: Record<JsonSchemaType, string> = {
     recipe: PathPatterns.recipe,
     /* tag */
     block_tag: PathPatterns['tag/block'],
+    damage_type_tag: PathPatterns['tag/damage_type'],
     entity_type_tag: PathPatterns['tag/entity_type'],
     fluid_tag: PathPatterns['tag/fluid'],
     function_tag: PathPatterns['tag/function'],

--- a/src/types/ClientCache.ts
+++ b/src/types/ClientCache.ts
@@ -40,6 +40,7 @@ export const WorldgenFileTypes = [
 ] as const
 export const TagFileTypes = [
     'tag/block',
+    'tag/damage_type',
     'tag/entity_type',
     'tag/fluid',
     'tag/function',
@@ -65,6 +66,7 @@ export const TagFileTypes = [
 ] as const
 export const FileTypes = [
     'advancement',
+    'damage_type',
     'dimension',
     'dimension_type',
     'function',

--- a/src/utils/PathPatterns.ts
+++ b/src/utils/PathPatterns.ts
@@ -4,6 +4,7 @@ export const GeneralPathPattern = 'data/**/*.{json,mcfunction,nbt}'
 
 export const PathPatterns: Record<FileType, string> = {
     advancement: 'data/*/advancements/**/*.json',
+    damage_type: 'data/*/damage_type/**/*.json',
     dimension: 'data/*/dimension/**/*.json',
     dimension_type: 'data/*/dimension_type/**/*.json',
     function: 'data/*/functions/**/*.mcfunction',
@@ -13,6 +14,7 @@ export const PathPatterns: Record<FileType, string> = {
     recipe: 'data/*/recipes/**/*.json',
     structure: 'data/*/structures/**/*.nbt',
     'tag/block': 'data/*/tags/blocks/**/*.json',
+    'tag/damage_type': 'data/*/tags/damage_type/**/*.json',
     'tag/entity_type': 'data/*/tags/entity_types/**/*.json',
     'tag/fluid': 'data/*/tags/fluids/**/*.json',
     'tag/function': 'data/*/tags/functions/**/*.json',


### PR DESCRIPTION
Accompanying `damage_type` and `tags/damage_type` support has also been added.