### PR TITLE
✨ Add simple macro parser and colorizer

### DIFF
--- a/packages/mcfunction/src/colorizer/index.ts
+++ b/packages/mcfunction/src/colorizer/index.ts
@@ -1,10 +1,15 @@
 import * as core from '@spyglassmc/core'
 import type {
+	CommandMacroNode,
 	LiteralCommandChildNode,
 	TrailingCommandChildNode,
 } from '../node/index.js'
 
 export function register(meta: core.MetaRegistry) {
+	meta.registerColorizer<CommandMacroNode>(
+		'mcfunction:command_macro',
+		macro,
+	)
 	meta.registerColorizer<LiteralCommandChildNode>(
 		'mcfunction:command_child/literal',
 		core.colorizer.literal,
@@ -13,4 +18,8 @@ export function register(meta: core.MetaRegistry) {
 		'mcfunction:command_child/trailing',
 		core.colorizer.error,
 	)
+}
+
+export const macro: core.Colorizer<CommandMacroNode> = (node, ctx) => {
+	return [core.ColorToken.create(node, 'string')]
 }

--- a/packages/mcfunction/src/completer/index.ts
+++ b/packages/mcfunction/src/completer/index.ts
@@ -1,6 +1,7 @@
 import type { DeepReadonly } from '@spyglassmc/core'
 import * as core from '@spyglassmc/core'
 import type { McfunctionNode } from '../node/index.js'
+import { CommandMacroNode } from '../node/index.js'
 import { CommandNode } from '../node/index.js'
 import type { ArgumentTreeNode, RootTreeNode } from '../tree/index.js'
 import {
@@ -26,7 +27,7 @@ export function entry(
 	return (node, ctx) => {
 		const tree = CommandTreeRegistry.instance.get(commandTreeName)
 		const childNode = core.AstNode.findChild(node, ctx.offset, true)
-		if (core.CommentNode.is(childNode)) {
+		if (core.CommentNode.is(childNode) || CommandMacroNode.is(childNode)) {
 			return []
 		} else {
 			return command(tree, getMockNodes)(

--- a/packages/mcfunction/src/node/command.ts
+++ b/packages/mcfunction/src/node/command.ts
@@ -19,6 +19,19 @@ export namespace CommandNode {
 	}
 }
 
+export interface CommandMacroNode extends core.AstNode {
+	type: 'mcfunction:command_macro'
+}
+
+export const CommandMacroNode = Object.freeze({
+	is<T extends core.DeepReadonly<core.AstNode> | undefined>(
+		obj: T,
+	): obj is core.NodeIsHelper<CommandMacroNode, T> {
+		return (obj as CommandMacroNode | undefined)?.type ===
+			'mcfunction:command_macro'
+	},
+})
+
 export interface CommandChildNode extends core.AstNode {
 	type: 'mcfunction:command_child'
 	/**

--- a/packages/mcfunction/src/node/entry.ts
+++ b/packages/mcfunction/src/node/entry.ts
@@ -1,8 +1,8 @@
 import type * as core from '@spyglassmc/core'
-import type { CommandNode } from './command.js'
+import type { CommandMacroNode, CommandNode } from './command.js'
 
 export interface McfunctionNode
-	extends core.SequenceNode<CommandNode | core.CommentNode>
+	extends core.SequenceNode<CommandNode | CommandMacroNode | core.CommentNode>
 {
 	type: 'mcfunction:entry'
 }

--- a/packages/mcfunction/src/parser/entry.ts
+++ b/packages/mcfunction/src/parser/entry.ts
@@ -1,5 +1,9 @@
 import * as core from '@spyglassmc/core'
-import type { CommandNode, McfunctionNode } from '../node/index.js'
+import type {
+	CommandMacroNode,
+	CommandNode,
+	McfunctionNode,
+} from '../node/index.js'
 import { CommandTreeRegistry } from '../tree/index.js'
 import type { ArgumentParserGetter } from './argument.js'
 import { command } from './command.js'
@@ -19,9 +23,16 @@ export function entry(
 		}
 
 		while (src.skipWhitespace().canReadInLine()) {
-			let result: core.CommentNode | CommandNode
+			let result: core.CommentNode | CommandNode | CommandMacroNode
 			if (src.peek() === '#') {
 				result = comment(src, ctx) as core.CommentNode
+			} else if (src.peek() === '$') {
+				const start = src.cursor
+				src.skipLine()
+				result = {
+					type: 'mcfunction:command_macro',
+					range: core.Range.create(start, src),
+				}
 			} else {
 				result = command(
 					CommandTreeRegistry.instance.get(commandTreeName),


### PR DESCRIPTION
Simply removes the parse error and adds a simple string colorizer for macro lines
![image](https://github.com/SpyglassMC/Spyglass/assets/17352009/9dc54a5e-8779-4e95-94f7-bf57d2e6ed84)
