### PR TITLE
:no_entry_sign: Specify Node 16 in tsconfig.json

### DIFF
--- a/packages/core/src/tsconfig.json
+++ b/packages/core/src/tsconfig.json
@@ -1,6 +1,7 @@
 {
 	"extends": "../../tsconfig-base",
 	"compilerOptions": {
+		"module": "Node16",
 		"outDir": "../lib"
 	}
 }


### PR DESCRIPTION
In `Spyglass\packages\core\src\tsconfig.json` the module should be set to Node 16 to avoid issues when trying to build the extension.