### PR TITLE
🔨 Fix debug breakpoints not binding

### DIFF
--- a/packages/playground/esbuild.js
+++ b/packages/playground/esbuild.js
@@ -8,7 +8,6 @@ try {
 	}
 
 	const isDev = mode !== 'prod'
-	const isWatch = mode === 'watch'
 	console.info('Start building...')
 	const result = await esbuild.build({
 		entryPoints: ['./out/index.js'],

--- a/packages/playground/esbuild.js
+++ b/packages/playground/esbuild.js
@@ -23,11 +23,11 @@ try {
 	logResult(result)
 } catch (e) {
 	console.error(e)
-	process.exitCode = 1;
+	process.exitCode = 1
 }
 
 /**
- * @param {esbuild.BuildResult} result 
+ * @param {esbuild.BuildResult} result
  */
 function logResult(result) {
 	if (result.errors.length === 0) {

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -13,7 +13,7 @@
     "deploy": "node deploy.js",
     "release": "echo TODO",
     "release:dry": "echo TODO",
-    "watch": "npm run build --watch"
+    "watch": "npm run build:dev --watch"
   },
   "wireit": {
     "build": {

--- a/packages/vscode-extension/esbuild.mjs
+++ b/packages/vscode-extension/esbuild.mjs
@@ -8,7 +8,6 @@ try {
 	}
 
 	const isDev = mode !== 'prod'
-	const isWatch = mode === 'watch'
 	console.info('Start building...')
 	const result = await esbuild.build({
 		entryPoints: ['./out/extension.mjs', '../language-server/lib/server.js'],

--- a/packages/vscode-extension/esbuild.mjs
+++ b/packages/vscode-extension/esbuild.mjs
@@ -24,11 +24,11 @@ try {
 	logResult(result)
 } catch (e) {
 	console.error(e)
-	process.exitCode = 1;
+	process.exitCode = 1
 }
 
 /**
- * @param {esbuild.BuildResult} result 
+ * @param {esbuild.BuildResult} result
  */
 function logResult(result) {
 	if (result.errors.length === 0) {

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -11,7 +11,7 @@
     "build:dev": "wireit",
     "release": "echo \"DO NOT PUBLISH\"",
     "release:dry": "echo \"DO NOT PUBLISH (DRY)\"",
-    "watch": "npm run build --watch"
+    "watch": "npm run build:dev --watch"
   },
   "wireit": {
     "build": {


### PR DESCRIPTION
This PR re-enables debugging through VSCode's builtin debugger with **breakpoints**

**before**: setting a breakpoint in a `.ts` file wouldn't actually bind and the language server would not hit it

**after**: setting a breakpoint catches successfully and pauses the server when it is hit

|before|
|-|
| ![image](https://github.com/SpyglassMC/Spyglass/assets/13565346/15051881-e671-4187-889d-7179e7e1b3e9) |
|after|
| ![image](https://github.com/SpyglassMC/Spyglass/assets/13565346/cb0b2295-e96e-4689-963f-77ef6fc37062) |

## explanation

since `packages/vscode-extension`'s `watch` script was calling `npm run build` (instead of `npm run build:dev`), it was calling `esbuild.mjs` with the `prod` arg (instead of `dev`).

https://github.com/SpyglassMC/Spyglass/blob/3f4cc126ab8f096988b45aed2904dca024f08bab/packages/vscode-extension/package.json#L17-L18

this made esbuild not utilize our source maps, which broke the debugger

https://github.com/SpyglassMC/Spyglass/blob/02952bf383d5b6dc278c0be1b6b62be9f88cdcf6/packages/vscode-extension/esbuild.mjs#L10

https://github.com/SpyglassMC/Spyglass/blob/02952bf383d5b6dc278c0be1b6b62be9f88cdcf6/packages/vscode-extension/esbuild.mjs#L21

when we switch to `"watch": "npm run build:dev --watch"`, it calls the esbuild script with `dev` instead

https://github.com/SpyglassMC/Spyglass/blob/3f4cc126ab8f096988b45aed2904dca024f08bab/packages/vscode-extension/package.json#L31-L32

then source maps are enabled, and debug breakpoints work 🎉 

---

supplementarily: some minor cleanup (surprised this isn't caught by the formatter/linter in CI)