### PR TITLE
[DO NOT MERGE] bug: `StateProxy` prevents modification of object array properties

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,9 @@
 			"request": "launch",
 			"name": "Launch Client",
 			"runtimeExecutable": "${execPath}",
-			"args": ["--extensionDevelopmentPath=${workspaceRoot}/packages/vscode-extension"],
+			"args": [
+				"--extensionDevelopmentPath=${workspaceRoot}/packages/vscode-extension"
+			],
 			"outFiles": ["${workspaceRoot}/packages/vscode-extension/dist/**/*.js"],
 			"preLaunchTask": "npm: watch - packages/vscode-extension"
 		},
@@ -20,6 +22,23 @@
 			"restart": true,
 			"timeout": 180000,
 			"outFiles": ["${workspaceRoot}/packages/vscode-extension/dist/**/*.js"]
+		},
+		{
+			"type": "node",
+			"request": "launch",
+			"name": "Mocha Current File",
+			"program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
+			"args": [
+				"-r",
+				"ts-node/register",
+				"--timeout",
+				"999999",
+				"--colors",
+				"${file}"
+			],
+			"console": "integratedTerminal",
+			"internalConsoleOptions": "neverOpen"
+			// "skipFiles": ["<node_internals>/**/*.js"]
 		}
 	],
 	"compounds": [

--- a/__snapshots__/packages/json/test-out/checker/primitives/util.spec.js
+++ b/__snapshots__/packages/json/test-out/checker/primitives/util.spec.js
@@ -37,10 +37,6 @@ exports['utils for JSON checkers any(boolean, string) Check ""foo"" 1'] = {
       {
         "type": "json:boolean",
         "typedoc": "Boolean"
-      },
-      {
-        "type": "json:boolean",
-        "typedoc": "Boolean"
       }
     ]
   },
@@ -66,10 +62,6 @@ exports['utils for JSON checkers any(boolean, string) Check "true" 1'] = {
     },
     "value": true,
     "expectation": [
-      {
-        "type": "json:boolean",
-        "typedoc": "Boolean"
-      },
       {
         "type": "json:boolean",
         "typedoc": "Boolean"
@@ -193,10 +185,6 @@ exports['utils for JSON checkers any(string, boolean) Check ""foo"" 1'] = {
       {
         "type": "json:string",
         "typedoc": "String"
-      },
-      {
-        "type": "json:string",
-        "typedoc": "String"
       }
     ]
   },
@@ -213,10 +201,6 @@ exports['utils for JSON checkers any(string, boolean) Check "true" 1'] = {
     },
     "value": true,
     "expectation": [
-      {
-        "type": "json:string",
-        "typedoc": "String"
-      },
       {
         "type": "json:string",
         "typedoc": "String"

--- a/__snapshots__/packages/json/test-out/checker/primitives/util.spec.js
+++ b/__snapshots__/packages/json/test-out/checker/primitives/util.spec.js
@@ -1,0 +1,237 @@
+exports['utils for JSON checkers any(boolean, string) Check ""foo"" 1'] = {
+  "node": {
+    "type": "json:string",
+    "range": {
+      "start": 0,
+      "end": 5
+    },
+    "options": {
+      "escapable": {
+        "characters": [
+          "b",
+          "f",
+          "n",
+          "r",
+          "t"
+        ],
+        "unicode": true
+      },
+      "quotes": [
+        "\""
+      ]
+    },
+    "value": "foo",
+    "valueMap": [
+      {
+        "inner": {
+          "start": 0,
+          "end": 0
+        },
+        "outer": {
+          "start": 1,
+          "end": 1
+        }
+      }
+    ],
+    "expectation": [
+      {
+        "type": "json:boolean",
+        "typedoc": "Boolean"
+      },
+      {
+        "type": "json:boolean",
+        "typedoc": "Boolean"
+      }
+    ]
+  },
+  "parserErrors": [],
+  "checkerErrors": [
+    {
+      "range": {
+        "start": 0,
+        "end": 5
+      },
+      "message": "Expected a boolean or a boolean",
+      "severity": 3
+    }
+  ]
+}
+
+exports['utils for JSON checkers any(boolean, string) Check "true" 1'] = {
+  "node": {
+    "type": "json:boolean",
+    "range": {
+      "start": 0,
+      "end": 4
+    },
+    "value": true,
+    "expectation": [
+      {
+        "type": "json:boolean",
+        "typedoc": "Boolean"
+      },
+      {
+        "type": "json:boolean",
+        "typedoc": "Boolean"
+      }
+    ]
+  },
+  "parserErrors": [],
+  "checkerErrors": []
+}
+
+exports['utils for JSON checkers any(string) Check ""foo"" 1'] = {
+  "node": {
+    "type": "json:string",
+    "range": {
+      "start": 0,
+      "end": 5
+    },
+    "options": {
+      "escapable": {
+        "characters": [
+          "b",
+          "f",
+          "n",
+          "r",
+          "t"
+        ],
+        "unicode": true
+      },
+      "quotes": [
+        "\""
+      ]
+    },
+    "value": "foo",
+    "valueMap": [
+      {
+        "inner": {
+          "start": 0,
+          "end": 0
+        },
+        "outer": {
+          "start": 1,
+          "end": 1
+        }
+      }
+    ],
+    "expectation": [
+      {
+        "type": "json:string",
+        "typedoc": "String"
+      }
+    ]
+  },
+  "parserErrors": [],
+  "checkerErrors": []
+}
+
+exports['utils for JSON checkers any(string) Check "true" 1'] = {
+  "node": {
+    "type": "json:boolean",
+    "range": {
+      "start": 0,
+      "end": 4
+    },
+    "value": true,
+    "expectation": [
+      {
+        "type": "json:string",
+        "typedoc": "String"
+      }
+    ]
+  },
+  "parserErrors": [],
+  "checkerErrors": [
+    {
+      "range": {
+        "start": 0,
+        "end": 4
+      },
+      "message": "Expected a string",
+      "severity": 3
+    }
+  ]
+}
+
+exports['utils for JSON checkers any(string, boolean) Check ""foo"" 1'] = {
+  "node": {
+    "type": "json:string",
+    "range": {
+      "start": 0,
+      "end": 5
+    },
+    "options": {
+      "escapable": {
+        "characters": [
+          "b",
+          "f",
+          "n",
+          "r",
+          "t"
+        ],
+        "unicode": true
+      },
+      "quotes": [
+        "\""
+      ]
+    },
+    "value": "foo",
+    "valueMap": [
+      {
+        "inner": {
+          "start": 0,
+          "end": 0
+        },
+        "outer": {
+          "start": 1,
+          "end": 1
+        }
+      }
+    ],
+    "expectation": [
+      {
+        "type": "json:string",
+        "typedoc": "String"
+      },
+      {
+        "type": "json:string",
+        "typedoc": "String"
+      }
+    ]
+  },
+  "parserErrors": [],
+  "checkerErrors": []
+}
+
+exports['utils for JSON checkers any(string, boolean) Check "true" 1'] = {
+  "node": {
+    "type": "json:boolean",
+    "range": {
+      "start": 0,
+      "end": 4
+    },
+    "value": true,
+    "expectation": [
+      {
+        "type": "json:string",
+        "typedoc": "String"
+      },
+      {
+        "type": "json:string",
+        "typedoc": "String"
+      }
+    ]
+  },
+  "parserErrors": [],
+  "checkerErrors": [
+    {
+      "range": {
+        "start": 0,
+        "end": 4
+      },
+      "message": "Expected a string or a string",
+      "severity": 3
+    }
+  ]
+}

--- a/packages/core/src/common/Operations.ts
+++ b/packages/core/src/common/Operations.ts
@@ -21,7 +21,13 @@ export class Operations {
 	): void {
 		const oldValue = Reflect.get(obj, key, receiver)
 		const op = () => {
-			Reflect.set(obj, key, value, receiver)
+			if (Array.isArray(oldValue) && Array.isArray(value)) {
+				console.log({ obj, key, oldValue, value, receiver })
+				Reflect.set(obj, key, Array.from(value), receiver)
+				// obj[key] = value
+			} else {
+				Reflect.set(obj, key, value, receiver)
+			}
 		}
 		const undoOp = () => {
 			Reflect.set(obj, key, oldValue, receiver)

--- a/packages/core/test/common/StateProxy.spec.ts
+++ b/packages/core/test/common/StateProxy.spec.ts
@@ -21,7 +21,7 @@ const getTestObj = () => ({
 	},
 })
 
-describe('StateProxy', () => {
+describe.only('StateProxy', () => {
 	it('Should create enumerable proxy', () => {
 		const testObj = getTestObj()
 		const proxy = StateProxy.create(testObj)
@@ -84,6 +84,25 @@ describe('StateProxy', () => {
 			StateProxy.dereference(proxy.node.children[0]),
 			testObj.node.children[0],
 		)
+	})
+	it.only('Sigma balls', () => {
+		// const testObj = getTestObj() as any
+		const testObj = { node: { children: [{ type: 'symbol' }] } }
+		const proxy = StateProxy.create(testObj) as StateProxy<any>
+		// const proxy = testObj
+
+		assert.strictEqual(proxy.node.children[0].type, 'symbol')
+		proxy.node.children[0].type = 'newSymbol'
+		assert.strictEqual(proxy.node.children[0].type, 'newSymbol')
+
+		const newChild = [{ type: 'newSymbol1' }]
+		proxy.node.children = newChild
+		assert.strictEqual(proxy.node.children[0].type, 'newSymbol1')
+
+		const newChildren = { type: 'newSymbol2' }
+		assert.strictEqual(proxy.node.children[0].type, 'newSymbol1')
+		proxy.node.children = newChildren
+		assert.strictEqual(proxy.node.children.type, 'newSymbol2')
 	})
 	it('Should undo and redo changes correctly', () => {
 		const testObj = getTestObj() as any

--- a/packages/json/src/checker/primitives/boolean.ts
+++ b/packages/json/src/checker/primitives/boolean.ts
@@ -5,6 +5,7 @@ import type { JsonCheckerContext } from '../JsonChecker.js'
 
 export function boolean(node: JsonNode, ctx: JsonCheckerContext) {
 	node.expectation = [{ type: 'json:boolean', typedoc: 'Boolean' }]
+	console.log('ne', node.expectation[0]!.type)
 
 	if (!JsonBooleanNode.is(node)) {
 		ctx.err.report(localize('expected', localize('boolean')), node)

--- a/packages/json/src/checker/primitives/string.ts
+++ b/packages/json/src/checker/primitives/string.ts
@@ -65,6 +65,10 @@ export function string(
 		node.expectation = [
 			{ type: 'json:string', typedoc: typedoc(name), ...expectation },
 		]
+		node.expectation = {
+			0: { type: 'json:string', typedoc: typedoc(name), ...expectation },
+		} as any
+		// console.log('ne', node.expectation[0]!.type)
 		if (!JsonStringNode.is(node)) {
 			ctx.err.report(localize('expected', localize('string')), node)
 		} else if (parser) {

--- a/packages/json/test/checker/primitives/util.spec.ts
+++ b/packages/json/test/checker/primitives/util.spec.ts
@@ -10,17 +10,17 @@ describe('utils for JSON checkers', () => {
 	testGrid(
 		[
 			{ content: 'true' },
-			{ content: '"foo"' },
+			// { content: '"foo"' },
 		],
 		[
-			{
-				name: 'any(string)',
-				checker: any([simpleString]),
-			},
-			{
-				name: 'any(string, boolean)',
-				checker: any([simpleString, boolean]),
-			},
+			// {
+			// 	name: 'any(string)',
+			// 	checker: any([simpleString]),
+			// },
+			// {
+			// 	name: 'any(string, boolean)',
+			// 	checker: any([simpleString, boolea n]),
+			// },
 			{
 				name: 'any(boolean, string)',
 				checker: any([boolean, simpleString]),

--- a/packages/json/test/checker/primitives/util.spec.ts
+++ b/packages/json/test/checker/primitives/util.spec.ts
@@ -1,0 +1,30 @@
+import { describe } from 'mocha'
+import {
+	any,
+	boolean,
+	simpleString,
+} from '../../../lib/checker/primitives/index.js'
+import { testGrid } from '../../utils.js'
+
+describe('utils for JSON checkers', () => {
+	testGrid(
+		[
+			{ content: 'true' },
+			{ content: '"foo"' },
+		],
+		[
+			{
+				name: 'any(string)',
+				checker: any([simpleString]),
+			},
+			{
+				name: 'any(string, boolean)',
+				checker: any([simpleString, boolean]),
+			},
+			{
+				name: 'any(boolean, string)',
+				checker: any([boolean, simpleString]),
+			},
+		],
+	)
+})

--- a/packages/json/test/utils.ts
+++ b/packages/json/test/utils.ts
@@ -47,13 +47,15 @@ export function testChecker(
 		{ doc, src },
 	)
 	const result = parser(src, parserCtx)
-	if (result !== Failure) {
-		const proxy = StateProxy.create(result) as JsonNode
+	const proxy = result !== Failure
+		? StateProxy.create(result) as JsonNode
+		: void 0
+	if (proxy) {
 		checker(proxy, { ...checkerCtx, context: '' })
 	}
 
 	return {
-		node: result === Failure ? 'FAILURE' : result,
+		node: result === Failure ? 'FAILURE' : proxy!,
 		parserErrors: parserCtx.err.dump(),
 		checkerErrors: checkerCtx.err.dump(),
 	}

--- a/packages/json/test/utils.ts
+++ b/packages/json/test/utils.ts
@@ -11,6 +11,7 @@ import {
 	Failure,
 	ParserContext,
 	Source,
+	StateProxy,
 	SymbolUtil,
 } from '@spyglassmc/core'
 import { NodeJsExternals } from '@spyglassmc/core/lib/nodejs.js'
@@ -47,7 +48,8 @@ export function testChecker(
 	)
 	const result = parser(src, parserCtx)
 	if (result !== Failure) {
-		checker(result, { ...checkerCtx, context: '' })
+		const proxy = StateProxy.create(result) as JsonNode
+		checker(proxy, { ...checkerCtx, context: '' })
 	}
 
 	return {


### PR DESCRIPTION
# context

this PR is purely to document a bug I noticed and went pretty deep to try and fix, but had failed at time of writing

the high-level error was surfacing as this:

![image](https://github.com/SpyglassMC/Spyglass/assets/13565346/e35b27b0-18dd-4090-abe8-62bfb4c5dcd4)

this was fixed in https://github.com/SpyglassMC/Spyglass/pull/1127 by removing that code path, but the root-cause of it may still cause issues in the future? tbd

---

## `StateProxy`

`StateProxy` uses JS [Proxy's](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy) to give us redo/undo operations on objects

from my understanding `StateProxy.create(obj)` basically returns `obj` with some extra methods on it

you can still modify `obj`'s properties as you'd expect, for example:

```ts
const obj = {}
const proxy = StateProxy.create(obj)

proxy.x = 2
// obj.x === 2
// proxy.x === 2
```

## the bug

if an object has a pre-existing array property, however, that property seems to silently fail to be modified?

```ts
const obj = { arr: [1] }
const proxy = StateProxy.create(obj)

proxy.arr = [2]
// proxy.arr is still `[1]` ???

proxy.arr[0] = 3
// `proxy.arr[0]` is still `1` ?????
```

i didn't test deeper if this was an issue specific to `StateProxy`s (something custom to Spyglass) or JS's `Proxy`'s generally, but am dropping investigation on this for now since https://github.com/SpyglassMC/Spyglass/pull/1127 fixes the original bug i was looking into anyway