### PR TITLE
🐛 Allow doc comments on mcdoc dispatch statements

### DIFF
--- a/packages/mcdoc/src/node/index.ts
+++ b/packages/mcdoc/src/node/index.ts
@@ -48,7 +48,7 @@ export interface DispatchStatementNode extends AstNode {
 	type: 'mcdoc:dispatch_statement'
 	children: (
 		| CommentNode
-		| AttributeNode
+		| PrelimNode
 		| LiteralNode
 		| ResourceLocationNode
 		| IndexBodyNode

--- a/packages/mcdoc/src/parser/index.ts
+++ b/packages/mcdoc/src/parser/index.ts
@@ -646,28 +646,6 @@ const typeParamBlock: InfallibleParser<TypeParamBlockNode> = setType(
 
 const noop: InfallibleParser<undefined> = () => undefined
 
-const optionalTypeParamBlock: InfallibleParser<TypeParamBlockNode | undefined> =
-	select([{ prefix: '<', parser: typeParamBlock }, { parser: noop }])
-
-export const dispatchStatement: Parser<DispatchStatementNode> = setType(
-	'mcdoc:dispatch_statement',
-	syntax(
-		[
-			attributes,
-			keyword('dispatch'),
-			resLoc({
-				category: 'mcdoc/dispatcher',
-				accessType: SymbolAccessType.Write,
-			}),
-			indexBody({ noDynamic: true }),
-			optionalTypeParamBlock,
-			literal('to'),
-			{ get: () => type },
-		],
-		true,
-	),
-)
-
 export const docComment: Parser<CommentNode> = core.comment({
 	singleLinePrefixes: new Set(['///']),
 	includesEol: true,
@@ -683,6 +661,28 @@ export const docComments: InfallibleParser<DocCommentsNode> = setType(
 
 const prelim: InfallibleParser<SyntaxUtil<DocCommentsNode | AttributeNode>> =
 	syntax([optional(failOnEmpty(docComments)), attributes])
+
+const optionalTypeParamBlock: InfallibleParser<TypeParamBlockNode | undefined> =
+	select([{ prefix: '<', parser: typeParamBlock }, { parser: noop }])
+
+export const dispatchStatement: Parser<DispatchStatementNode> = setType(
+	'mcdoc:dispatch_statement',
+	syntax(
+		[
+			prelim,
+			keyword('dispatch'),
+			resLoc({
+				category: 'mcdoc/dispatcher',
+				accessType: SymbolAccessType.Write,
+			}),
+			indexBody({ noDynamic: true }),
+			optionalTypeParamBlock,
+			literal('to'),
+			{ get: () => type },
+		],
+		true,
+	),
+)
 
 const enumType: InfallibleParser<LiteralNode> = literal(
 	['byte', 'short', 'int', 'long', 'string', 'float', 'double'],


### PR DESCRIPTION
It came up that it would be really useful to allow doc comments in front of dispatch statements, which would simply target the dispatched type.

## Todo
- [x] Update the parser and nodes
- [ ] Update the spec