### PR TITLE
🐛 Fix doc comment parsing in mcdoc

### DIFF
--- a/packages/core/src/parser/resourceLocation.ts
+++ b/packages/core/src/parser/resourceLocation.ts
@@ -127,7 +127,7 @@ export function resourceLocation(
 
 			if (ans.isTag && !options.allowTag) {
 				ctx.err.report(
-					localize('parser.resource-location.tag-diallowed'),
+					localize('parser.resource-location.tag-disallowed'),
 					ans,
 				)
 			}

--- a/packages/java-edition/src/mcfunction/tree/patch.ts
+++ b/packages/java-edition/src/mcfunction/tree/patch.ts
@@ -565,7 +565,7 @@ export function getPatch(release: ReleaseVersion): PartialRootTreeNode {
 			 * 2. `teleport <location: vec3>`
 			 * 3. `teleport <targets: entity(multiple)> <...arguments>`
 			 *
-			 * It is impossible for Spyglass to differentiate between (1) and (3) when it encouters a single entity
+			 * It is impossible for Spyglass to differentiate between (1) and (3) when it encounters a single entity
 			 * at the position of the first argument, due to its lack of ability to backtrack.
 			 *
 			 * Therefore, we have compromised to patch the trees to something like this:

--- a/packages/mcdoc-cli/package.json
+++ b/packages/mcdoc-cli/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "release": "npm publish",
     "release:dry": "npm publish --dry-run",
-    "test": "rm -rf vanilla-mcdoc && rm -rf src/out && git clone https://github.com/SpyglassMC/vanilla-mcdoc && cd src && ./index.ts generate ../vanilla-mcdoc/ -p -m -l"
+    "test": "rm -rf vanilla-mcdoc && rm -rf src/out && git clone https://github.com/SpyglassMC/vanilla-mcdoc && npx tsx src/index.mts generate ../vanilla-mcdoc/ -p -m -l"
   },
   "dependencies": {
     "fs-extra": "^11.1.1",

--- a/packages/mcdoc-cli/src/index.mts
+++ b/packages/mcdoc-cli/src/index.mts
@@ -253,7 +253,9 @@ await CLI.scriptName('mcdoc')
 									internal_locales[parent]
 								) {
 									locales[
-										`mcdoc.${resource.replace(/[\/\\]/g, '.')}.map_key`
+										`mcdoc.${
+											resource.replace(/[\/\\]/g, '.')
+										}.map_key`
 									] = internal_locales[parent].join('\n')
 
 									delete internal_locales[parent]

--- a/packages/mcdoc-cli/src/index.mts
+++ b/packages/mcdoc-cli/src/index.mts
@@ -281,6 +281,7 @@ await CLI.scriptName('mcdoc')
 											`known error: orphaned doc comment\n${comment}`,
 										)
 										console.log(_parent?.type)
+										console.log(_parent?.children)
 										known_error = true
 									}
 								}

--- a/packages/mcdoc-cli/src/index.mts
+++ b/packages/mcdoc-cli/src/index.mts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S ts-node --esm
+#!/usr/bin/env -S tsx
 import { dirname, join, parse, resolve } from 'path'
 import { fileURLToPath, pathToFileURL } from 'url'
 
@@ -161,7 +161,7 @@ await CLI.scriptName('mcdoc')
 						const resource = join(
 							path.dir.replace(`${projectPath}`, ''),
 							path.name,
-						).replace(/^\//, '')
+						).replace(/\\/g, '/').replace(/^\//, '')
 
 						logger.info(`parsing ${resource}\n`)
 
@@ -206,6 +206,22 @@ await CLI.scriptName('mcdoc')
 
 								child.type = _child.type
 
+								if (child.type === 'resource_location') {
+									/* @ts-ignore */
+									child.namespace = _child.namespace
+									/* @ts-ignore */
+									child.path = _child.path
+									/* @ts-ignore */
+									// if (_child.path?.[0] === 'item') {
+									// 	const arrow = { ..._child?.symbol?.members?.['compass'] }
+
+									// 	delete arrow.parentSymbol
+									// 	delete arrow.parentMap
+									// 	/* @ts-ignore */
+									// 	if (arrow.data?.typeDef?.fields) console.log(JSON.stringify(arrow.data?.typeDef?.fields, undefined, 3))
+									// }
+								}
+
 								if (Object.hasOwn(_child, 'isOptional')) {
 									/* @ts-ignore */
 									child.isOptional = _child.isOptional
@@ -224,7 +240,7 @@ await CLI.scriptName('mcdoc')
 									if (internal_locales[parent]) {
 										locales[
 											`mcdoc.${
-												resource.replace(/\//g, '.')
+												resource.replace(/[\/\\]/g, '.')
 											}.${child.value}`
 										] = internal_locales[parent].join('\n')
 
@@ -237,7 +253,7 @@ await CLI.scriptName('mcdoc')
 									internal_locales[parent]
 								) {
 									locales[
-										`mcdoc.${resource.replace(/\//g, '.')}.map_key`
+										`mcdoc.${resource.replace(/[\/\\]/g, '.')}.map_key`
 									] = internal_locales[parent].join('\n')
 
 									delete internal_locales[parent]
@@ -254,7 +270,7 @@ await CLI.scriptName('mcdoc')
 									) {
 										const key = parent.replace(/\[\d+\]$/, '')
 
-										if (!internal_locales.key) {
+										if (!internal_locales[key]) {
 											internal_locales[key] = []
 										}
 
@@ -262,8 +278,9 @@ await CLI.scriptName('mcdoc')
 									} else if (comment.startsWith('/ ')) {
 										child.type = 'error'
 										console.warn(
-											`known error: orphaned dispatch comment`,
+											`known error: orphaned doc comment\n${comment}`,
 										)
+										console.log(_parent?.type)
 										known_error = true
 									}
 								}

--- a/packages/mcdoc-cli/src/index.mts
+++ b/packages/mcdoc-cli/src/index.mts
@@ -281,7 +281,6 @@ await CLI.scriptName('mcdoc')
 											`known error: orphaned doc comment\n${comment}`,
 										)
 										console.log(_parent?.type)
-										console.log(_parent?.children)
 										known_error = true
 									}
 								}

--- a/packages/mcdoc/src/binder/index.ts
+++ b/packages/mcdoc/src/binder/index.ts
@@ -816,8 +816,6 @@ function convertType(node: TypeNode, ctx: McdocBinderContext): McdocType {
 			return convertTuple(node, ctx)
 		case 'mcdoc:type/union':
 			return convertUnion(node, ctx)
-		case 'mcdoc:type_alias':
-			return convertTypeAlias(node, ctx)
 		default:
 			return Dev.assertNever(node)
 	}
@@ -1033,43 +1031,6 @@ function convertEnumValue(
 		return value.value
 	}
 	return node.value
-}
-
-function convertTypeAlias(node: TypeAliasNode, ctx: McdocBinderContext): McdocType {
-	const { typeParams, rhs, identifier } = TypeAliasNode.destruct(node)
-
-	// Shortcut if the typeDef has been added to the struct symbol.
-	const symbol = identifier?.symbol ?? node.symbol
-	if (
-		symbol &&
-		TypeDefSymbolData.is(symbol.data)
-	) {
-		return symbol.data.typeDef
-	}
-
-	return wrapType(
-		node,
-		{
-			kind: 'reference',
-			fields: convertTypeBlock(typeParams, ctx),
-		},
-		ctx,
-	)
-}
-
-function convertTypeBlock(
-	node: TypeParamBlockNode,
-	ctx: McdocBinderContext,
-): TypeParamNode[] {
-	const { params } = TypeParamBlockNode.destruct(node)
-	return params.map((n) => convertTypeParam(n, ctx))
-}
-
-function convertTypeParam(
-	node: TypeParamNode,
-	ctx: McdocBinderContext,
-): TypeParamNode {
-	return node
 }
 
 function convertStruct(node: StructNode, ctx: McdocBinderContext): McdocType {

--- a/packages/mcdoc/src/node/index.ts
+++ b/packages/mcdoc/src/node/index.ts
@@ -199,7 +199,8 @@ export namespace TypeNode {
 			StructNode.is(node) ||
 			ReferenceTypeNode.is(node) ||
 			DispatcherTypeNode.is(node) ||
-			UnionTypeNode.is(node)
+			UnionTypeNode.is(node) ||
+			TypeAliasNode.is(node)
 		)
 	}
 }

--- a/packages/mcdoc/src/node/index.ts
+++ b/packages/mcdoc/src/node/index.ts
@@ -208,7 +208,6 @@ export namespace TypeNode {
 export interface TypeBaseNode<CN extends AstNode> extends AstNode {
 	type: `mcdoc:${string}`
 	children: (
-		| DocCommentsNode
 		| AttributeNode
 		| CommentNode
 		| IndexBodyNode

--- a/packages/mcdoc/src/node/index.ts
+++ b/packages/mcdoc/src/node/index.ts
@@ -199,8 +199,7 @@ export namespace TypeNode {
 			StructNode.is(node) ||
 			ReferenceTypeNode.is(node) ||
 			DispatcherTypeNode.is(node) ||
-			UnionTypeNode.is(node) ||
-			TypeAliasNode.is(node)
+			UnionTypeNode.is(node)
 		)
 	}
 }

--- a/packages/mcdoc/src/node/index.ts
+++ b/packages/mcdoc/src/node/index.ts
@@ -207,6 +207,7 @@ export namespace TypeNode {
 export interface TypeBaseNode<CN extends AstNode> extends AstNode {
 	type: `mcdoc:${string}`
 	children: (
+		| DocCommentsNode
 		| AttributeNode
 		| CommentNode
 		| IndexBodyNode

--- a/packages/mcdoc/src/node/index.ts
+++ b/packages/mcdoc/src/node/index.ts
@@ -47,8 +47,8 @@ export namespace TopLevelNode {
 export interface DispatchStatementNode extends AstNode {
 	type: 'mcdoc:dispatch_statement'
 	children: (
+		| PrelimNode
 		| CommentNode
-		| AttributeNode
 		| LiteralNode
 		| ResourceLocationNode
 		| IndexBodyNode
@@ -207,8 +207,9 @@ export namespace TypeNode {
 export interface TypeBaseNode<CN extends AstNode> extends AstNode {
 	type: `mcdoc:${string}`
 	children: (
-		| CommentNode
+		| DocCommentsNode
 		| AttributeNode
+		| CommentNode
 		| IndexBodyNode
 		| TypeArgBlockNode
 		| CN

--- a/packages/mcdoc/src/parser/index.ts
+++ b/packages/mcdoc/src/parser/index.ts
@@ -656,8 +656,11 @@ export const docComment: Parser<CommentNode> = core.comment({
 
 export const docComments: InfallibleParser<DocCommentsNode> = setType(
 	'mcdoc:doc_comments',
-	repeat(docComment, (src) => {
+	repeat(docComment, (src/*, ctx*/) => {
 		src.skipWhitespace()
+		// if (src.peekLine().includes('An item that can be placed as a block')) {
+		// 	ctx.logger.info('type parser @ test_1 isn\'t being greedy!')
+		// }
 		return []
 	}),
 )

--- a/packages/mcdoc/src/parser/index.ts
+++ b/packages/mcdoc/src/parser/index.ts
@@ -1172,6 +1172,7 @@ export const tupleType: Parser<TupleTypeNode> = typeBase(
 export const dispatcherType: Parser<DispatcherTypeNode> = typeBase(
 	'mcdoc:type/dispatcher',
 	syntax([
+		prelim,
 		failOnError(resLoc({ category: 'mcdoc/dispatcher' })),
 		indexBody(),
 	]),

--- a/packages/mcdoc/src/parser/index.ts
+++ b/packages/mcdoc/src/parser/index.ts
@@ -1173,7 +1173,7 @@ export const dispatcherType: Parser<DispatcherTypeNode> = typeBase(
 	'mcdoc:type/dispatcher',
 	syntax([
 		failOnError(resLoc({ category: 'mcdoc/dispatcher' })),
-		indexBody()
+		indexBody(),
 	]),
 )
 
@@ -1206,9 +1206,7 @@ export const unionType: Parser<UnionTypeNode> = typeBase(
 
 export const referenceType: InfallibleParser<ReferenceTypeNode> = typeBase(
 	'mcdoc:type/reference',
-	syntax([
-		path
-	]),
+	syntax([path]),
 )
 
 export const type: InfallibleParser<TypeNode> = any([

--- a/packages/mcdoc/src/parser/index.ts
+++ b/packages/mcdoc/src/parser/index.ts
@@ -679,6 +679,7 @@ export const dispatchStatement: Parser<DispatchStatementNode> = setType(
 			optionalTypeParamBlock,
 			literal('to'),
 			{ get: () => type },
+			// marker(';'),
 		],
 		true,
 	),
@@ -876,6 +877,7 @@ export const typeAliasStatement: Parser<TypeAliasNode> = setType(
 			optionalTypeParamBlock,
 			punctuation('='),
 			{ get: () => type },
+			// marker(';'),
 		],
 		true,
 	),
@@ -1171,11 +1173,7 @@ export const tupleType: Parser<TupleTypeNode> = typeBase(
 
 export const dispatcherType: Parser<DispatcherTypeNode> = typeBase(
 	'mcdoc:type/dispatcher',
-	syntax([
-		prelim,
-		failOnError(resLoc({ category: 'mcdoc/dispatcher' })),
-		indexBody(),
-	]),
+	syntax([failOnError(resLoc({ category: 'mcdoc/dispatcher' })),indexBody()]),
 )
 
 export const unionType: Parser<UnionTypeNode> = typeBase(

--- a/packages/mcdoc/src/parser/index.ts
+++ b/packages/mcdoc/src/parser/index.ts
@@ -649,25 +649,6 @@ const noop: InfallibleParser<undefined> = () => undefined
 const optionalTypeParamBlock: InfallibleParser<TypeParamBlockNode | undefined> =
 	select([{ prefix: '<', parser: typeParamBlock }, { parser: noop }])
 
-export const dispatchStatement: Parser<DispatchStatementNode> = setType(
-	'mcdoc:dispatch_statement',
-	syntax(
-		[
-			attributes,
-			keyword('dispatch'),
-			resLoc({
-				category: 'mcdoc/dispatcher',
-				accessType: SymbolAccessType.Write,
-			}),
-			indexBody({ noDynamic: true }),
-			optionalTypeParamBlock,
-			literal('to'),
-			{ get: () => type },
-		],
-		true,
-	),
-)
-
 export const docComment: Parser<CommentNode> = core.comment({
 	singleLinePrefixes: new Set(['///']),
 	includesEol: true,
@@ -683,6 +664,25 @@ export const docComments: InfallibleParser<DocCommentsNode> = setType(
 
 const prelim: InfallibleParser<SyntaxUtil<DocCommentsNode | AttributeNode>> =
 	syntax([optional(failOnEmpty(docComments)), attributes])
+
+export const dispatchStatement: Parser<DispatchStatementNode> = setType(
+	'mcdoc:dispatch_statement',
+	syntax(
+		[
+			prelim,
+			keyword('dispatch'),
+			resLoc({
+				category: 'mcdoc/dispatcher',
+				accessType: SymbolAccessType.Write,
+			}),
+			indexBody({ noDynamic: true }),
+			optionalTypeParamBlock,
+			literal('to'),
+			{ get: () => type },
+		],
+		true,
+	),
+)
 
 const enumType: InfallibleParser<LiteralNode> = literal(
 	['byte', 'short', 'int', 'long', 'string', 'float', 'double'],
@@ -1171,7 +1171,11 @@ export const tupleType: Parser<TupleTypeNode> = typeBase(
 
 export const dispatcherType: Parser<DispatcherTypeNode> = typeBase(
 	'mcdoc:type/dispatcher',
-	syntax([failOnError(resLoc({ category: 'mcdoc/dispatcher' })), indexBody()]),
+	syntax([
+		prelim,
+		failOnError(resLoc({ category: 'mcdoc/dispatcher' })),
+		indexBody()
+	]),
 )
 
 export const unionType: Parser<UnionTypeNode> = typeBase(
@@ -1203,7 +1207,10 @@ export const unionType: Parser<UnionTypeNode> = typeBase(
 
 export const referenceType: InfallibleParser<ReferenceTypeNode> = typeBase(
 	'mcdoc:type/reference',
-	syntax([path]),
+	syntax([
+		prelim,
+		path
+	]),
 )
 
 export const type: InfallibleParser<TypeNode> = any([

--- a/packages/mcdoc/src/parser/index.ts
+++ b/packages/mcdoc/src/parser/index.ts
@@ -1172,7 +1172,6 @@ export const tupleType: Parser<TupleTypeNode> = typeBase(
 export const dispatcherType: Parser<DispatcherTypeNode> = typeBase(
 	'mcdoc:type/dispatcher',
 	syntax([
-		prelim,
 		failOnError(resLoc({ category: 'mcdoc/dispatcher' })),
 		indexBody()
 	]),
@@ -1208,7 +1207,6 @@ export const unionType: Parser<UnionTypeNode> = typeBase(
 export const referenceType: InfallibleParser<ReferenceTypeNode> = typeBase(
 	'mcdoc:type/reference',
 	syntax([
-		prelim,
 		path
 	]),
 )

--- a/packages/mcdoc/src/parser/index.ts
+++ b/packages/mcdoc/src/parser/index.ts
@@ -665,6 +665,100 @@ export const docComments: InfallibleParser<DocCommentsNode> = setType(
 const prelim: InfallibleParser<SyntaxUtil<DocCommentsNode | AttributeNode>> =
 	syntax([optional(failOnEmpty(docComments)), attributes])
 
+const structMapKey: InfallibleParser<StructMapKeyNode> = setType(
+	'mcdoc:struct/map_key',
+	syntax([punctuation('['), { get: () => type }, punctuation(']')], true),
+)
+
+const structKey: InfallibleParser<StructKeyNode> = select([
+	{ prefix: '"', parser: string },
+	{ prefix: '[', parser: structMapKey },
+	{ parser: identifier },
+])
+
+const structPairField: InfallibleParser<StructPairFieldNode> = (src, ctx) => {
+	let isOptional: boolean | undefined
+	const result0 = syntax([prelim, structKey], true)(src, ctx)
+	if (src.trySkip('?')) {
+		isOptional = true
+	}
+	const result1 = syntax([punctuation(':'), { get: () => type }], true)(
+		src,
+		ctx,
+	)
+	const ans: StructPairFieldNode = {
+		type: 'mcdoc:struct/field/pair',
+		children: [...result0.children, ...result1.children],
+		range: Range.span(result0, result1),
+		isOptional,
+	}
+	return ans
+}
+
+const structSpreadField: Parser<StructSpreadFieldNode> = setType(
+	'mcdoc:struct/field/spread',
+	syntax([attributes, marker('...'), { get: () => type }], true),
+)
+
+const structField: InfallibleParser<
+	StructPairFieldNode | StructSpreadFieldNode
+> = any([structSpreadField, structPairField])
+
+const structBlock: InfallibleParser<StructBlockNode> = setType(
+	'mcdoc:struct/block',
+	syntax(
+		[
+			punctuation('{'),
+			select([
+				{ prefix: '}', parser: punctuation('}') },
+				{
+					parser: syntax(
+						[
+							structField,
+							syntaxRepeat(
+								syntax([marker(','), failOnEmpty(structField)], true),
+								true,
+							),
+							optional(marker(',')),
+							punctuation('}'),
+						],
+						true,
+					),
+				},
+			]),
+		],
+		true,
+	),
+)
+
+export const struct: Parser<StructNode> = setType(
+	'mcdoc:struct',
+	syntax(
+		[
+			prelim,
+			keyword('struct'),
+			optional(failOnEmpty(identifier)),
+			structBlock,
+		],
+		true,
+	),
+)
+
+export const typeAliasStatement: Parser<TypeAliasNode> = setType(
+	'mcdoc:type_alias',
+	syntax(
+		[
+			prelim,
+			keyword('type'),
+			identifier,
+			optionalTypeParamBlock,
+			punctuation('='),
+			{ get: () => type },
+		],
+		true,
+	),
+)
+
 export const dispatchStatement: Parser<DispatchStatementNode> = setType(
 	'mcdoc:dispatch_statement',
 	syntax(
@@ -678,7 +772,7 @@ export const dispatchStatement: Parser<DispatchStatementNode> = setType(
 			indexBody({ noDynamic: true }),
 			optionalTypeParamBlock,
 			literal('to'),
-			{ get: () => type },
+			select([{parser: struct}, {parser: typeAliasStatement}]),
 		],
 		true,
 	),
@@ -759,85 +853,6 @@ export const enum_: Parser<EnumNode> = setType(
 	),
 )
 
-const structMapKey: InfallibleParser<StructMapKeyNode> = setType(
-	'mcdoc:struct/map_key',
-	syntax([punctuation('['), { get: () => type }, punctuation(']')], true),
-)
-
-const structKey: InfallibleParser<StructKeyNode> = select([
-	{ prefix: '"', parser: string },
-	{ prefix: '[', parser: structMapKey },
-	{ parser: identifier },
-])
-
-const structPairField: InfallibleParser<StructPairFieldNode> = (src, ctx) => {
-	let isOptional: boolean | undefined
-	const result0 = syntax([prelim, structKey], true)(src, ctx)
-	if (src.trySkip('?')) {
-		isOptional = true
-	}
-	const result1 = syntax([punctuation(':'), { get: () => type }], true)(
-		src,
-		ctx,
-	)
-	const ans: StructPairFieldNode = {
-		type: 'mcdoc:struct/field/pair',
-		children: [...result0.children, ...result1.children],
-		range: Range.span(result0, result1),
-		isOptional,
-	}
-	return ans
-}
-
-const structSpreadField: Parser<StructSpreadFieldNode> = setType(
-	'mcdoc:struct/field/spread',
-	syntax([attributes, marker('...'), { get: () => type }], true),
-)
-
-const structField: InfallibleParser<
-	StructPairFieldNode | StructSpreadFieldNode
-> = any([structSpreadField, structPairField])
-
-const structBlock: InfallibleParser<StructBlockNode> = setType(
-	'mcdoc:struct/block',
-	syntax(
-		[
-			punctuation('{'),
-			select([
-				{ prefix: '}', parser: punctuation('}') },
-				{
-					parser: syntax(
-						[
-							structField,
-							syntaxRepeat(
-								syntax([marker(','), failOnEmpty(structField)], true),
-								true,
-							),
-							optional(marker(',')),
-							punctuation('}'),
-						],
-						true,
-					),
-				},
-			]),
-		],
-		true,
-	),
-)
-
-export const struct: Parser<StructNode> = setType(
-	'mcdoc:struct',
-	syntax(
-		[
-			prelim,
-			keyword('struct'),
-			optional(failOnEmpty(identifier)),
-			structBlock,
-		],
-		true,
-	),
-)
-
 const enumInjection: InfallibleParser<EnumInjectionNode> = setType(
 	'mcdoc:injection/enum',
 	syntax([
@@ -864,21 +879,6 @@ export const injection: Parser<InjectionNode> = setType(
 			{ parser: structInjection },
 		]),
 	]),
-)
-
-export const typeAliasStatement: Parser<TypeAliasNode> = setType(
-	'mcdoc:type_alias',
-	syntax(
-		[
-			prelim,
-			keyword('type'),
-			identifier,
-			optionalTypeParamBlock,
-			punctuation('='),
-			{ get: () => type },
-		],
-		true,
-	),
 )
 
 export const useStatement: Parser<UseStatementNode> = setType(

--- a/packages/mcdoc/src/type/index.ts
+++ b/packages/mcdoc/src/type/index.ts
@@ -23,6 +23,7 @@ export const StaticIndexKeywords = Object.freeze(
 		'fallback',
 		'none',
 		'unknown',
+		'spawnitem'
 	] as const,
 )
 export type StaticIndexKeyword = (typeof StaticIndexKeywords)[number]

--- a/packages/mcdoc/src/type/index.ts
+++ b/packages/mcdoc/src/type/index.ts
@@ -23,7 +23,7 @@ export const StaticIndexKeywords = Object.freeze(
 		'fallback',
 		'none',
 		'unknown',
-		'spawnitem'
+		'spawnitem',
 	] as const,
 )
 export type StaticIndexKeyword = (typeof StaticIndexKeywords)[number]


### PR DESCRIPTION
Appears to be due to `{ get: () => type }` greedily capturing all nodes after `dispatch` and `type` statements, results in all comments after these to be parsed as dev comments and inserted into the value (`type/dispatcher` or `type/reference`) children.

**Not ready to merge**