### PR TITLE
♻️ Use LSP to provide inlay hints

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
 			"runtimeExecutable": "${execPath}",
 			"args": ["--extensionDevelopmentPath=${workspaceRoot}/packages/vscode-extension"],
 			"outFiles": ["${workspaceRoot}/packages/vscode-extension/dist/**/*.js"],
-			"preLaunchTask": "npm: watch - packages/vscode-extension"
+			"preLaunchTask": "npm: watch"
 		},
 		{
 			"type": "node",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -34,39 +34,6 @@
 		},
 		{
 			"type": "npm",
-			"script": "watch",
-			"group": "build",
-			"isBackground": true,
-			"path": "packages/vscode-extension/",
-			"dependsOn": "npm: watch",
-			"problemMatcher": {
-				"severity": "error",
-				"fileLocation": "absolute",
-				"source": "esbuild",
-				"background": {
-					"activeOnStart": true,
-					"beginsPattern": "Start building\\.\\.\\.",
-					"endsPattern": "Built successfully\\."
-				},
-				"pattern": [
-					{
-						"regexp": "ERROR in ([^\\(]*)\\((\\d+),(\\d+)\\):",
-						"file": 1,
-						"line": 2,
-						"column": 3
-					},
-					{
-						"regexp": "([A-Za-z0-9-]+):(.*)",
-						"message": 2,
-						"code": 1
-					}
-				]
-			},
-			"label": "npm: watch - packages/vscode-extension",
-			"detail": "Builds the VS Code extension."
-		},
-		{
-			"type": "npm",
 			"script": "test",
 			"group": "test",
 			"problemMatcher": [],

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,12 +42,16 @@
 			}
 		},
 		"node_modules/@babel/code-frame": {
-			"version": "7.12.11",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
-			"integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
+			"version": "7.24.2",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.2.tgz",
+			"integrity": "sha512-y5+tLQyV8pg3fsiln67BVLD1P13Eg4lh5RW9mF0zUuvLrv9uIQ4MCL+CRT+FTsBlBjcIan6PGsLcBN0m3ClUyQ==",
 			"dev": true,
 			"dependencies": {
-				"@babel/highlight": "^7.10.4"
+				"@babel/highlight": "^7.24.2",
+				"picocolors": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/core": {
@@ -78,43 +82,71 @@
 			}
 		},
 		"node_modules/@babel/core/node_modules/semver": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+			"version": "5.7.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+			"integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
 			"dev": true,
 			"bin": {
 				"semver": "bin/semver"
 			}
 		},
 		"node_modules/@babel/generator": {
-			"version": "7.12.5",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.5.tgz",
-			"integrity": "sha512-m16TQQJ8hPt7E+OS/XVQg/7U184MLXtvuGbCdA7na61vha+ImkyyNM/9DDA0unYCVZn3ZOhng+qz48/KBOT96A==",
+			"version": "7.24.5",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.5.tgz",
+			"integrity": "sha512-x32i4hEXvr+iI0NEoEfDKzlemF8AmtOP8CcrRaEcpzysWuoEb1KknpcvMsHKPONoKZiDuItklgWhB18xEhr9PA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/types": "^7.12.5",
-				"jsesc": "^2.5.1",
-				"source-map": "^0.5.0"
+				"@babel/types": "^7.24.5",
+				"@jridgewell/gen-mapping": "^0.3.5",
+				"@jridgewell/trace-mapping": "^0.3.25",
+				"jsesc": "^2.5.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/generator/node_modules/@jridgewell/trace-mapping": {
+			"version": "0.3.25",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+			"integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+			"dev": true,
+			"dependencies": {
+				"@jridgewell/resolve-uri": "^3.1.0",
+				"@jridgewell/sourcemap-codec": "^1.4.14"
+			}
+		},
+		"node_modules/@babel/helper-environment-visitor": {
+			"version": "7.22.20",
+			"resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
+			"integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
+			"dev": true,
+			"engines": {
+				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-function-name": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
-			"integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
+			"version": "7.23.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
+			"integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-get-function-arity": "^7.10.4",
-				"@babel/template": "^7.10.4",
-				"@babel/types": "^7.10.4"
+				"@babel/template": "^7.22.15",
+				"@babel/types": "^7.23.0"
+			},
+			"engines": {
+				"node": ">=6.9.0"
 			}
 		},
-		"node_modules/@babel/helper-get-function-arity": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
-			"integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
+		"node_modules/@babel/helper-hoist-variables": {
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
+			"integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/types": "^7.10.4"
+				"@babel/types": "^7.22.5"
+			},
+			"engines": {
+				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-member-expression-to-functions": {
@@ -183,19 +215,34 @@
 			}
 		},
 		"node_modules/@babel/helper-split-export-declaration": {
-			"version": "7.11.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
-			"integrity": "sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==",
+			"version": "7.24.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.24.5.tgz",
+			"integrity": "sha512-5CHncttXohrHk8GWOFCcCl4oRD9fKosWlIRgWm4ql9VYioKm52Mk2xsmoohvm7f3JoiLSM5ZgJuRaf5QZZYd3Q==",
 			"dev": true,
 			"dependencies": {
-				"@babel/types": "^7.11.0"
+				"@babel/types": "^7.24.5"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-string-parser": {
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.1.tgz",
+			"integrity": "sha512-2ofRCjnnA9y+wk8b9IAREroeUP02KHp431N2mhKniy2yKIDKpbrHv9eXwm8cBeWQYcJmzv5qKCu65P47eCF7CQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-validator-identifier": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
-			"integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
-			"dev": true
+			"version": "7.24.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.5.tgz",
+			"integrity": "sha512-3q93SSKX2TWCG30M2G2kwaKeTYgEUp5Snjuj8qm729SObL6nbtUldAi37qbxkD5gg3xnBio+f9nqpSepGZMvxA==",
+			"dev": true,
+			"engines": {
+				"node": ">=6.9.0"
+			}
 		},
 		"node_modules/@babel/helpers": {
 			"version": "7.12.5",
@@ -209,20 +256,24 @@
 			}
 		},
 		"node_modules/@babel/highlight": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
-			"integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+			"version": "7.24.5",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.5.tgz",
+			"integrity": "sha512-8lLmua6AVh/8SLJRRVD6V8p73Hir9w5mJrhE+IPpILG31KKlI9iz5zmBYKcWPS59qSfgP9RaSBQSHHE81WKuEw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.10.4",
-				"chalk": "^2.0.0",
-				"js-tokens": "^4.0.0"
+				"@babel/helper-validator-identifier": "^7.24.5",
+				"chalk": "^2.4.2",
+				"js-tokens": "^4.0.0",
+				"picocolors": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.12.7",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.7.tgz",
-			"integrity": "sha512-oWR02Ubp4xTLCAqPRiNIuMVgNO5Aif/xpXtabhzW2HWUD47XJsAB4Zd/Rg30+XeQA3juXigV7hlquOTmwqLiwg==",
+			"version": "7.24.5",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.5.tgz",
+			"integrity": "sha512-EOv5IK8arwh3LI47dz1b0tKUb/1uhHAnHJOrjgtQMIpu1uXd9mlFrJg9IUgGUgZ41Ch0K8REPTYpO7B76b4vJg==",
 			"dev": true,
 			"bin": {
 				"parser": "bin/babel-parser.js"
@@ -241,31 +292,38 @@
 			}
 		},
 		"node_modules/@babel/template": {
-			"version": "7.12.7",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.7.tgz",
-			"integrity": "sha512-GkDzmHS6GV7ZeXfJZ0tLRBhZcMcY0/Lnb+eEbXDBfCAcZCjrZKe6p3J4we/D24O9Y8enxWAg1cWwof59yLh2ow==",
+			"version": "7.24.0",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.24.0.tgz",
+			"integrity": "sha512-Bkf2q8lMB0AFpX0NFEqSbx1OkTHf0f+0j82mkw+ZpzBnkk7e9Ql0891vlfgi+kHwOk8tQjiQHpqh4LaSa0fKEA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/code-frame": "^7.10.4",
-				"@babel/parser": "^7.12.7",
-				"@babel/types": "^7.12.7"
+				"@babel/code-frame": "^7.23.5",
+				"@babel/parser": "^7.24.0",
+				"@babel/types": "^7.24.0"
+			},
+			"engines": {
+				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.12.9",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.9.tgz",
-			"integrity": "sha512-iX9ajqnLdoU1s1nHt36JDI9KG4k+vmI8WgjK5d+aDTwQbL2fUnzedNedssA645Ede3PM2ma1n8Q4h2ohwXgMXw==",
+			"version": "7.24.5",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.24.5.tgz",
+			"integrity": "sha512-7aaBLeDQ4zYcUFDUD41lJc1fG8+5IU9DaNSJAgal866FGvmD5EbWQgnEC6kO1gGLsX0esNkfnJSndbTXA3r7UA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/code-frame": "^7.10.4",
-				"@babel/generator": "^7.12.5",
-				"@babel/helper-function-name": "^7.10.4",
-				"@babel/helper-split-export-declaration": "^7.11.0",
-				"@babel/parser": "^7.12.7",
-				"@babel/types": "^7.12.7",
-				"debug": "^4.1.0",
-				"globals": "^11.1.0",
-				"lodash": "^4.17.19"
+				"@babel/code-frame": "^7.24.2",
+				"@babel/generator": "^7.24.5",
+				"@babel/helper-environment-visitor": "^7.22.20",
+				"@babel/helper-function-name": "^7.23.0",
+				"@babel/helper-hoist-variables": "^7.22.5",
+				"@babel/helper-split-export-declaration": "^7.24.5",
+				"@babel/parser": "^7.24.5",
+				"@babel/types": "^7.24.5",
+				"debug": "^4.3.1",
+				"globals": "^11.1.0"
+			},
+			"engines": {
+				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/traverse/node_modules/globals": {
@@ -278,14 +336,17 @@
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.12.7",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.7.tgz",
-			"integrity": "sha512-MNyI92qZq6jrQkXvtIiykvl4WtoRrVV9MPn+ZfsoEENjiWcBQ3ZSHrkxnJWgWtLX3XXqX5hrSQ+X69wkmesXuQ==",
+			"version": "7.24.5",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.5.tgz",
+			"integrity": "sha512-6mQNsaLeXTw0nxYUYu+NSa4Hx4BlF1x1x8/PMFbiR+GBSr+2DkECc69b8hgy2frEodNcvPffeH8YfWd3LI6jhQ==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.10.4",
-				"lodash": "^4.17.19",
+				"@babel/helper-string-parser": "^7.24.1",
+				"@babel/helper-validator-identifier": "^7.24.5",
 				"to-fast-properties": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@bahmutov/data-driven": {
@@ -958,6 +1019,15 @@
 			"integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
 			"dev": true
 		},
+		"node_modules/@inquirer/figures": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.1.tgz",
+			"integrity": "sha512-mtup3wVKia3ZwULPHcbs4Mor8Voi+iIXEWD7wCNbIO6lYR62oPCTQyrddi5OMYVXHzeCSoneZwJuS8sBvlEwDw==",
+			"dev": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/@istanbuljs/load-nyc-config": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -1039,17 +1109,27 @@
 			}
 		},
 		"node_modules/@jridgewell/gen-mapping": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
-			"integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
+			"version": "0.3.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
+			"integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
 			"dev": true,
 			"dependencies": {
-				"@jridgewell/set-array": "^1.0.1",
+				"@jridgewell/set-array": "^1.2.1",
 				"@jridgewell/sourcemap-codec": "^1.4.10",
-				"@jridgewell/trace-mapping": "^0.3.9"
+				"@jridgewell/trace-mapping": "^0.3.24"
 			},
 			"engines": {
 				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@jridgewell/gen-mapping/node_modules/@jridgewell/trace-mapping": {
+			"version": "0.3.25",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+			"integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+			"dev": true,
+			"dependencies": {
+				"@jridgewell/resolve-uri": "^3.1.0",
+				"@jridgewell/sourcemap-codec": "^1.4.14"
 			}
 		},
 		"node_modules/@jridgewell/resolve-uri": {
@@ -1062,9 +1142,9 @@
 			}
 		},
 		"node_modules/@jridgewell/set-array": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
-			"integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+			"integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
 			"dev": true,
 			"engines": {
 				"node": ">=6.0.0"
@@ -1118,6 +1198,18 @@
 			"dev": true,
 			"dependencies": {
 				"@lezer/common": "^0.16.0"
+			}
+		},
+		"node_modules/@ljharb/through": {
+			"version": "2.3.13",
+			"resolved": "https://registry.npmjs.org/@ljharb/through/-/through-2.3.13.tgz",
+			"integrity": "sha512-/gKJun8NNiWGZJkGzI/Ragc53cOdcLNdzjLaIa+GEjguQs0ulsurx8WN0jijdK9yPqDvziX995sMRLyLt1uZMQ==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.7"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			}
 		},
 		"node_modules/@nodelib/fs.scandir": {
@@ -1291,6 +1383,12 @@
 				"node": ">= 6"
 			}
 		},
+		"node_modules/@tootallnate/quickjs-emscripten": {
+			"version": "0.23.0",
+			"resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+			"integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+			"dev": true
+		},
 		"node_modules/@tsconfig/node10": {
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
@@ -1411,12 +1509,6 @@
 			"integrity": "sha512-wbw+IDRw/xY/RGy+BL6f4Eey4jsUgHQrMuA4Qj0CSG3x/7C2Oc57pmRoM2z3M4DkylWRz+G1pfX06sCXQm0J+w==",
 			"dev": true
 		},
-		"node_modules/@types/minimist": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
-			"integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
-			"dev": true
-		},
 		"node_modules/@types/mocha": {
 			"version": "10.0.1",
 			"resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.1.tgz",
@@ -1449,12 +1541,6 @@
 			"engines": {
 				"node": ">= 6"
 			}
-		},
-		"node_modules/@types/normalize-package-data": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
-			"integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
-			"dev": true
 		},
 		"node_modules/@types/pako": {
 			"version": "2.0.0",
@@ -1566,13 +1652,10 @@
 			}
 		},
 		"node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
-			"version": "7.3.7",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-			"integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+			"version": "7.6.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+			"integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
 			"dev": true,
-			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
 			"bin": {
 				"semver": "bin/semver.js"
 			},
@@ -1743,13 +1826,10 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
-			"integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
+			"version": "7.6.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+			"integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
 			"dev": true,
-			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
 			"bin": {
 				"semver": "bin/semver.js"
 			},
@@ -1784,13 +1864,10 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils/node_modules/semver": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
-			"integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
+			"version": "7.6.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+			"integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
 			"dev": true,
-			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
 			"bin": {
 				"semver": "bin/semver.js"
 			},
@@ -2117,15 +2194,15 @@
 			}
 		},
 		"node_modules/ajv-formats/node_modules/ajv": {
-			"version": "8.12.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-			"integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+			"version": "8.13.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.13.0.tgz",
+			"integrity": "sha512-PRA911Blj99jR5RMeTunVbNXMF6Lp4vZXnk5GQjcnUWUTsrXtekg/pnmFFI2u/I36Y/2bITGS30GZCXei6uNkA==",
 			"dev": true,
 			"dependencies": {
-				"fast-deep-equal": "^3.1.1",
+				"fast-deep-equal": "^3.1.3",
 				"json-schema-traverse": "^1.0.0",
 				"require-from-string": "^2.0.2",
-				"uri-js": "^4.2.2"
+				"uri-js": "^4.4.1"
 			},
 			"funding": {
 				"type": "github",
@@ -2490,15 +2567,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/arrify": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-			"integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/ast-types": {
 			"version": "0.13.4",
 			"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
@@ -2512,9 +2580,9 @@
 			}
 		},
 		"node_modules/ast-types/node_modules/tslib": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
 			"dev": true
 		},
 		"node_modules/async": {
@@ -2529,13 +2597,13 @@
 			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
 		},
 		"node_modules/atomically": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/atomically/-/atomically-2.0.1.tgz",
-			"integrity": "sha512-sxBhVZUFBFhqSAsYMM3X2oaUi2NVDJ8U026FsIusM8gYXls9AYs/eXzgGrufs1Qjpkxi9zunds+75QUFz+m7UQ==",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/atomically/-/atomically-2.0.3.tgz",
+			"integrity": "sha512-kU6FmrwZ3Lx7/7y3hPS5QnbJfaohcIul5fGqf7ok+4KklIEk9tJ0C2IQPdacSbVUWv6zVHXEBWoWd6NrVMT7Cw==",
 			"dev": true,
 			"dependencies": {
-				"stubborn-fs": "^1.2.4",
-				"when-exit": "^2.0.0"
+				"stubborn-fs": "^1.2.5",
+				"when-exit": "^2.1.1"
 			}
 		},
 		"node_modules/balanced-match": {
@@ -2570,6 +2638,15 @@
 					"url": "https://feross.org/support"
 				}
 			]
+		},
+		"node_modules/basic-ftp": {
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.5.tgz",
+			"integrity": "sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==",
+			"dev": true,
+			"engines": {
+				"node": ">=10.0.0"
+			}
 		},
 		"node_modules/benchmark": {
 			"version": "2.1.4",
@@ -2935,15 +3012,6 @@
 				"node": ">=0.2.0"
 			}
 		},
-		"node_modules/bytes": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.1.tgz",
-			"integrity": "sha512-dWe4nWO/ruEOY7HkUJ5gFt1DCFV9zPRoJr8pV0/ASQermOZjtq8jMjOprC0Kd10GLN+l7xaUPvxzJFWtxGu8Fg==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
 		"node_modules/cacheable-lookup": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
@@ -2986,6 +3054,25 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/call-bind": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
+			"integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
+			"dev": true,
+			"dependencies": {
+				"es-define-property": "^1.0.0",
+				"es-errors": "^1.3.0",
+				"function-bind": "^1.1.2",
+				"get-intrinsic": "^1.2.4",
+				"set-function-length": "^1.2.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/callsites": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -3002,48 +3089,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=6"
-			}
-		},
-		"node_modules/camelcase-keys": {
-			"version": "8.0.2",
-			"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-8.0.2.tgz",
-			"integrity": "sha512-qMKdlOfsjlezMqxkUGGMaWWs17i2HoL15tM+wtx8ld4nLrUwU58TFdvyGOz/piNP842KeO8yXvggVQSdQ828NA==",
-			"dev": true,
-			"dependencies": {
-				"camelcase": "^7.0.0",
-				"map-obj": "^4.3.0",
-				"quick-lru": "^6.1.1",
-				"type-fest": "^2.13.0"
-			},
-			"engines": {
-				"node": ">=14.16"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/camelcase-keys/node_modules/camelcase": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-7.0.1.tgz",
-			"integrity": "sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw==",
-			"dev": true,
-			"engines": {
-				"node": ">=14.16"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/camelcase-keys/node_modules/type-fest": {
-			"version": "2.19.0",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-			"integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-			"dev": true,
-			"engines": {
-				"node": ">=12.20"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/caniuse-lite": {
@@ -3193,9 +3238,9 @@
 			}
 		},
 		"node_modules/cli-spinners": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.7.0.tgz",
-			"integrity": "sha512-qu3pN8Y3qHNgE2AFweciB1IfMnmZ/fsNTEE+NOFjmGB2F/7rLhnhzppvpCnN4FovtP26k8lHyy9ptEbNwWFLzw==",
+			"version": "2.9.2",
+			"resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+			"integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
 			"dev": true,
 			"engines": {
 				"node": ">=6"
@@ -3280,7 +3325,7 @@
 		"node_modules/color-name": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
 			"dev": true
 		},
 		"node_modules/colorette": {
@@ -3327,9 +3372,9 @@
 			"dev": true
 		},
 		"node_modules/conf": {
-			"version": "11.0.1",
-			"resolved": "https://registry.npmjs.org/conf/-/conf-11.0.1.tgz",
-			"integrity": "sha512-WlLiQboEjKx0bYx2IIRGedBgNjLAxtwPaCSnsjWPST5xR0DB4q8lcsO/bEH9ZRYNcj63Y9vj/JG/5Fg6uWzI0Q==",
+			"version": "11.0.2",
+			"resolved": "https://registry.npmjs.org/conf/-/conf-11.0.2.tgz",
+			"integrity": "sha512-jjyhlQ0ew/iwmtwsS2RaB6s8DBifcE2GYBEaw2SJDUY/slJJbNfY4GlDVzOs/ff8cM/Wua5CikqXgbFl5eu85A==",
 			"dev": true,
 			"dependencies": {
 				"ajv": "^8.12.0",
@@ -3349,15 +3394,15 @@
 			}
 		},
 		"node_modules/conf/node_modules/ajv": {
-			"version": "8.12.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-			"integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+			"version": "8.13.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.13.0.tgz",
+			"integrity": "sha512-PRA911Blj99jR5RMeTunVbNXMF6Lp4vZXnk5GQjcnUWUTsrXtekg/pnmFFI2u/I36Y/2bITGS30GZCXei6uNkA==",
 			"dev": true,
 			"dependencies": {
-				"fast-deep-equal": "^3.1.1",
+				"fast-deep-equal": "^3.1.3",
 				"json-schema-traverse": "^1.0.0",
 				"require-from-string": "^2.0.2",
-				"uri-js": "^4.2.2"
+				"uri-js": "^4.4.1"
 			},
 			"funding": {
 				"type": "github",
@@ -3383,13 +3428,10 @@
 			"dev": true
 		},
 		"node_modules/conf/node_modules/semver": {
-			"version": "7.3.8",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-			"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+			"version": "7.6.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+			"integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
 			"dev": true,
-			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
 			"bin": {
 				"semver": "bin/semver.js"
 			},
@@ -3536,12 +3578,12 @@
 			}
 		},
 		"node_modules/data-uri-to-buffer": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz",
-			"integrity": "sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+			"integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
 			"dev": true,
 			"engines": {
-				"node": ">= 6"
+				"node": ">= 14"
 			}
 		},
 		"node_modules/datapack-language-server": {
@@ -3584,31 +3626,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
 			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/decamelize-keys": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.1.tgz",
-			"integrity": "sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==",
-			"dev": true,
-			"dependencies": {
-				"decamelize": "^1.1.0",
-				"map-obj": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/decamelize-keys/node_modules/map-obj": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-			"integrity": "sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
@@ -3874,19 +3891,35 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/degenerator": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/degenerator/-/degenerator-3.0.1.tgz",
-			"integrity": "sha512-LFsIFEeLPlKvAKXu7j3ssIG6RT0TbI7/GhsqrI0DnHASEQjXQ0LUSYcjJteGgRGmZbl1TnMSxpNQIAiJ7Du5TQ==",
+		"node_modules/define-data-property": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+			"integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
 			"dev": true,
 			"dependencies": {
-				"ast-types": "^0.13.2",
-				"escodegen": "^1.8.1",
-				"esprima": "^4.0.0",
-				"vm2": "^3.9.3"
+				"es-define-property": "^1.0.0",
+				"es-errors": "^1.3.0",
+				"gopd": "^1.0.1"
 			},
 			"engines": {
-				"node": ">= 6"
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/degenerator": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+			"integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+			"dev": true,
+			"dependencies": {
+				"ast-types": "^0.13.4",
+				"escodegen": "^2.1.0",
+				"esprima": "^4.0.1"
+			},
+			"engines": {
+				"node": ">= 14"
 			}
 		},
 		"node_modules/delayed-stream": {
@@ -3895,15 +3928,6 @@
 			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
 			"engines": {
 				"node": ">=0.4.0"
-			}
-		},
-		"node_modules/depd": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-			"integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.6"
 			}
 		},
 		"node_modules/didyoumean": {
@@ -4145,13 +4169,25 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/error-ex": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-			"integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+		"node_modules/es-define-property": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
+			"integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
 			"dev": true,
 			"dependencies": {
-				"is-arrayish": "^0.2.1"
+				"get-intrinsic": "^1.2.4"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-errors": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+			"integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
 			}
 		},
 		"node_modules/es-module-lexer": {
@@ -4242,64 +4278,33 @@
 			}
 		},
 		"node_modules/escodegen": {
-			"version": "1.14.3",
-			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
-			"integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+			"integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
 			"dev": true,
 			"dependencies": {
 				"esprima": "^4.0.1",
-				"estraverse": "^4.2.0",
-				"esutils": "^2.0.2",
-				"optionator": "^0.8.1"
+				"estraverse": "^5.2.0",
+				"esutils": "^2.0.2"
 			},
 			"bin": {
 				"escodegen": "bin/escodegen.js",
 				"esgenerate": "bin/esgenerate.js"
 			},
 			"engines": {
-				"node": ">=4.0"
+				"node": ">=6.0"
 			},
 			"optionalDependencies": {
 				"source-map": "~0.6.1"
 			}
 		},
-		"node_modules/escodegen/node_modules/levn": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-			"dev": true,
-			"dependencies": {
-				"prelude-ls": "~1.1.2",
-				"type-check": "~0.3.2"
-			},
-			"engines": {
-				"node": ">= 0.8.0"
-			}
-		},
-		"node_modules/escodegen/node_modules/optionator": {
-			"version": "0.8.3",
-			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
-			"integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
-			"dev": true,
-			"dependencies": {
-				"deep-is": "~0.1.3",
-				"fast-levenshtein": "~2.0.6",
-				"levn": "~0.3.0",
-				"prelude-ls": "~1.1.2",
-				"type-check": "~0.3.2",
-				"word-wrap": "~1.2.3"
-			},
-			"engines": {
-				"node": ">= 0.8.0"
-			}
-		},
-		"node_modules/escodegen/node_modules/prelude-ls": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+		"node_modules/escodegen/node_modules/estraverse": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
 			"dev": true,
 			"engines": {
-				"node": ">= 0.8.0"
+				"node": ">=4.0"
 			}
 		},
 		"node_modules/escodegen/node_modules/source-map": {
@@ -4310,18 +4315,6 @@
 			"optional": true,
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/escodegen/node_modules/type-check": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-			"dev": true,
-			"dependencies": {
-				"prelude-ls": "~1.1.2"
-			},
-			"engines": {
-				"node": ">= 0.8.0"
 			}
 		},
 		"node_modules/eslint": {
@@ -4763,26 +4756,38 @@
 			}
 		},
 		"node_modules/execa": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/execa/-/execa-7.1.1.tgz",
-			"integrity": "sha512-wH0eMf/UXckdUYnO21+HDztteVv05rq2GXksxT4fCGeHkBhw1DROXh40wcjMcRqDOWE7iPJ4n3M7e2+YFP+76Q==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+			"integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
 			"dev": true,
 			"dependencies": {
 				"cross-spawn": "^7.0.3",
-				"get-stream": "^6.0.1",
-				"human-signals": "^4.3.0",
+				"get-stream": "^8.0.1",
+				"human-signals": "^5.0.0",
 				"is-stream": "^3.0.0",
 				"merge-stream": "^2.0.0",
 				"npm-run-path": "^5.1.0",
 				"onetime": "^6.0.0",
-				"signal-exit": "^3.0.7",
+				"signal-exit": "^4.1.0",
 				"strip-final-newline": "^3.0.0"
 			},
 			"engines": {
-				"node": "^14.18.0 || ^16.14.0 || >=18.0.0"
+				"node": ">=16.17"
 			},
 			"funding": {
 				"url": "https://github.com/sindresorhus/execa?sponsor=1"
+			}
+		},
+		"node_modules/execa/node_modules/get-stream": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+			"integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+			"dev": true,
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/execa/node_modules/is-stream": {
@@ -4810,6 +4815,18 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/execa/node_modules/signal-exit": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+			"dev": true,
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/external-editor": {
@@ -4942,15 +4959,6 @@
 				"node": "^10.12.0 || >=12.0.0"
 			}
 		},
-		"node_modules/file-uri-to-path": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-2.0.0.tgz",
-			"integrity": "sha512-hjPFI8oE/2iQPVe4gbrJ73Pp+Xfub2+WI2LlXDbsaJBwT5wuMh35WNWVYYTpnz895shtwfyutMFLFywpQAFdLg==",
-			"dev": true,
-			"engines": {
-				"node": ">= 6"
-			}
-		},
 		"node_modules/fill-range": {
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -5034,22 +5042,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/find-up": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/find-up/-/find-up-6.3.0.tgz",
-			"integrity": "sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==",
-			"dev": true,
-			"dependencies": {
-				"locate-path": "^7.1.0",
-				"path-exists": "^5.0.0"
-			},
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/flat": {
 			"version": "5.0.2",
 			"resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
@@ -5100,9 +5092,9 @@
 			"dev": true
 		},
 		"node_modules/follow-redirects": {
-			"version": "1.14.8",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.8.tgz",
-			"integrity": "sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA==",
+			"version": "1.15.6",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+			"integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
 			"funding": [
 				{
 					"type": "individual",
@@ -5177,17 +5169,16 @@
 			"integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
 		},
 		"node_modules/fs-extra": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-			"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-			"dev": true,
+			"version": "11.2.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+			"integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
 			"dependencies": {
 				"graceful-fs": "^4.2.0",
-				"jsonfile": "^4.0.0",
-				"universalify": "^0.1.0"
+				"jsonfile": "^6.0.1",
+				"universalify": "^2.0.0"
 			},
 			"engines": {
-				"node": ">=6 <7 || >=8"
+				"node": ">=14.14"
 			}
 		},
 		"node_modules/fs.realpath": {
@@ -5224,48 +5215,14 @@
 				"node": ">=0.6"
 			}
 		},
-		"node_modules/ftp": {
-			"version": "0.3.10",
-			"resolved": "https://registry.npmjs.org/ftp/-/ftp-0.3.10.tgz",
-			"integrity": "sha1-kZfYYa2BQvPmPVqDv+TFn3MwiF0=",
-			"dev": true,
-			"dependencies": {
-				"readable-stream": "1.1.x",
-				"xregexp": "2.0.0"
-			},
-			"engines": {
-				"node": ">=0.8.0"
-			}
-		},
-		"node_modules/ftp/node_modules/isarray": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-			"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-			"dev": true
-		},
-		"node_modules/ftp/node_modules/readable-stream": {
-			"version": "1.1.14",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-			"integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-			"dev": true,
-			"dependencies": {
-				"core-util-is": "~1.0.0",
-				"inherits": "~2.0.1",
-				"isarray": "0.0.1",
-				"string_decoder": "~0.10.x"
-			}
-		},
-		"node_modules/ftp/node_modules/string_decoder": {
-			"version": "0.10.31",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-			"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-			"dev": true
-		},
 		"node_modules/function-bind": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-			"dev": true
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+			"dev": true,
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
 		"node_modules/fuse.js": {
 			"version": "6.6.2",
@@ -5293,6 +5250,25 @@
 				"node": "6.* || 8.* || >= 10.*"
 			}
 		},
+		"node_modules/get-intrinsic": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
+			"integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
+			"dev": true,
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"function-bind": "^1.1.2",
+				"has-proto": "^1.0.1",
+				"has-symbols": "^1.0.3",
+				"hasown": "^2.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/get-package-type": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
@@ -5315,26 +5291,41 @@
 			}
 		},
 		"node_modules/get-uri": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/get-uri/-/get-uri-3.0.2.tgz",
-			"integrity": "sha512-+5s0SJbGoyiJTZZ2JTpFPLMPSch72KEqGOTvQsBqg0RBWvwhWUSYZFAtz3TPW0GXJuLBJPts1E241iHg+VRfhg==",
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.3.tgz",
+			"integrity": "sha512-BzUrJBS9EcUb4cFol8r4W3v1cPsSyajLSthNkz5BxbpDcHN5tIrM10E2eNvfnvBn3DaT3DUgx0OpsBKkaOpanw==",
 			"dev": true,
 			"dependencies": {
-				"@tootallnate/once": "1",
-				"data-uri-to-buffer": "3",
-				"debug": "4",
-				"file-uri-to-path": "2",
-				"fs-extra": "^8.1.0",
-				"ftp": "^0.3.10"
+				"basic-ftp": "^5.0.2",
+				"data-uri-to-buffer": "^6.0.2",
+				"debug": "^4.3.4",
+				"fs-extra": "^11.2.0"
 			},
 			"engines": {
-				"node": ">= 6"
+				"node": ">= 14"
+			}
+		},
+		"node_modules/get-uri/node_modules/debug": {
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+			"dev": true,
+			"dependencies": {
+				"ms": "2.1.2"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/gitmoji-cli": {
-			"version": "8.1.1",
-			"resolved": "https://registry.npmjs.org/gitmoji-cli/-/gitmoji-cli-8.1.1.tgz",
-			"integrity": "sha512-lEt1/o151KUZ3E73ipQCQPqNXfJvK2Krm8X3poQqxQH5Xw/20gt8MME/VIf8WKG9ylYEs3EKOp30gdRoUI1vbg==",
+			"version": "8.5.0",
+			"resolved": "https://registry.npmjs.org/gitmoji-cli/-/gitmoji-cli-8.5.0.tgz",
+			"integrity": "sha512-ZSplvgm8UiAjsWBOxYAfbLj8JTMFj5TjB6yM7RFlqEfsFMgP0fhIPpgnHU5aMiyVyvX6jBRVf1hzjrmP3/cgiA==",
 			"dev": true,
 			"funding": [
 				{
@@ -5347,19 +5338,19 @@
 				}
 			],
 			"dependencies": {
-				"chalk": "^5.0.1",
-				"conf": "11.0.1",
-				"execa": "^7.1.1",
+				"chalk": "^5.3.0",
+				"conf": "11.0.2",
+				"execa": "^8.0.1",
 				"fuse.js": "6.6.2",
-				"inquirer": "^9.1.5",
+				"inquirer": "^9.2.10",
 				"inquirer-autocomplete-prompt": "^3.0.0",
-				"meow": "^11.0.0",
-				"node-fetch": "^3.3.1",
-				"ora": "^6.3.0",
+				"meow": "^12.1.1",
+				"node-fetch": "^3.3.2",
+				"ora": "^7.0.1",
 				"path-exists": "^5.0.0",
-				"proxy-agent": "5.0.0",
+				"proxy-agent": "^6.3.1",
 				"update-notifier": "^6.0.2",
-				"validator": "^13.9.0"
+				"validator": "^13.11.0"
 			},
 			"bin": {
 				"gitmoji": "lib/cli.js"
@@ -5384,33 +5375,44 @@
 			}
 		},
 		"node_modules/gitmoji-cli/node_modules/ansi-regex": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-			"integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
 			"dev": true,
 			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+				"node": ">=8"
 			}
 		},
 		"node_modules/gitmoji-cli/node_modules/ansi-styles": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-			"integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 			"dev": true,
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=8"
 			},
 			"funding": {
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
+		"node_modules/gitmoji-cli/node_modules/bl": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+			"integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+			"dev": true,
+			"dependencies": {
+				"buffer": "^5.5.0",
+				"inherits": "^2.0.4",
+				"readable-stream": "^3.4.0"
+			}
+		},
 		"node_modules/gitmoji-cli/node_modules/chalk": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.2.0.tgz",
-			"integrity": "sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA==",
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+			"integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
 			"dev": true,
 			"engines": {
 				"node": "^12.17.0 || ^14.13 || >=16.0.0"
@@ -5419,29 +5421,32 @@
 				"url": "https://github.com/chalk/chalk?sponsor=1"
 			}
 		},
-		"node_modules/gitmoji-cli/node_modules/cli-cursor": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
-			"integrity": "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==",
-			"dev": true,
-			"dependencies": {
-				"restore-cursor": "^4.0.0"
-			},
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/gitmoji-cli/node_modules/cli-width": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.0.0.tgz",
-			"integrity": "sha512-ZksGS2xpa/bYkNzN3BAw1wEjsLV/ZKOf/CCrJ/QOBsxx6fOARIkwTutxp1XIOIohi6HKmOFjMoK/XaqDVUpEEw==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+			"integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
 			"dev": true,
 			"engines": {
 				"node": ">= 12"
 			}
+		},
+		"node_modules/gitmoji-cli/node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/gitmoji-cli/node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true
 		},
 		"node_modules/gitmoji-cli/node_modules/data-uri-to-buffer": {
 			"version": "4.0.1",
@@ -5451,12 +5456,6 @@
 			"engines": {
 				"node": ">= 12"
 			}
-		},
-		"node_modules/gitmoji-cli/node_modules/emoji-regex": {
-			"version": "9.2.2",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-			"integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-			"dev": true
 		},
 		"node_modules/gitmoji-cli/node_modules/escape-string-regexp": {
 			"version": "5.0.0",
@@ -5486,30 +5485,39 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/gitmoji-cli/node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/gitmoji-cli/node_modules/inquirer": {
-			"version": "9.2.0",
-			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-9.2.0.tgz",
-			"integrity": "sha512-WWERbVqjsTXjXub1ZW0ZHDit1dyHqy0T9XIkky9TnmKAPrjU9Jkd59nZPK0dUuM3s73GZAZu2Jo4iFU3XSPVLA==",
+			"version": "9.2.21",
+			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-9.2.21.tgz",
+			"integrity": "sha512-c/dwDruM1FtzeISV+xMHm+JZTmhpmgWPEZI2bU3+Fwu5MhbAX0zMHHxj5warNfttE5NUID3aijrFUpDc2yBvcA==",
 			"dev": true,
 			"dependencies": {
-				"ansi-escapes": "^6.0.0",
-				"chalk": "^5.2.0",
-				"cli-cursor": "^4.0.0",
-				"cli-width": "^4.0.0",
-				"external-editor": "^3.0.3",
-				"figures": "^5.0.0",
+				"@inquirer/figures": "^1.0.1",
+				"@ljharb/through": "^2.3.13",
+				"ansi-escapes": "^4.3.2",
+				"chalk": "^5.3.0",
+				"cli-cursor": "^3.1.0",
+				"cli-width": "^4.1.0",
+				"external-editor": "^3.1.0",
 				"lodash": "^4.17.21",
 				"mute-stream": "1.0.0",
-				"ora": "^6.1.2",
-				"run-async": "^2.4.0",
-				"rxjs": "^7.8.0",
-				"string-width": "^5.1.2",
-				"strip-ansi": "^7.0.1",
-				"through": "^2.3.6",
-				"wrap-ansi": "^8.1.0"
+				"ora": "^5.4.1",
+				"run-async": "^3.0.0",
+				"rxjs": "^7.8.1",
+				"string-width": "^4.2.3",
+				"strip-ansi": "^6.0.1",
+				"wrap-ansi": "^6.2.0"
 			},
 			"engines": {
-				"node": ">=14.18.0"
+				"node": ">=18"
 			}
 		},
 		"node_modules/gitmoji-cli/node_modules/inquirer-autocomplete-prompt": {
@@ -5529,6 +5537,102 @@
 			},
 			"peerDependencies": {
 				"inquirer": "^9.1.0"
+			}
+		},
+		"node_modules/gitmoji-cli/node_modules/inquirer/node_modules/ansi-escapes": {
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+			"integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+			"dev": true,
+			"dependencies": {
+				"type-fest": "^0.21.3"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/gitmoji-cli/node_modules/inquirer/node_modules/is-unicode-supported": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+			"integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/gitmoji-cli/node_modules/inquirer/node_modules/ora": {
+			"version": "5.4.1",
+			"resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+			"integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+			"dev": true,
+			"dependencies": {
+				"bl": "^4.1.0",
+				"chalk": "^4.1.0",
+				"cli-cursor": "^3.1.0",
+				"cli-spinners": "^2.5.0",
+				"is-interactive": "^1.0.0",
+				"is-unicode-supported": "^0.1.0",
+				"log-symbols": "^4.1.0",
+				"strip-ansi": "^6.0.0",
+				"wcwidth": "^1.0.1"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/gitmoji-cli/node_modules/inquirer/node_modules/ora/node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/gitmoji-cli/node_modules/inquirer/node_modules/run-async": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/run-async/-/run-async-3.0.0.tgz",
+			"integrity": "sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.12.0"
+			}
+		},
+		"node_modules/gitmoji-cli/node_modules/inquirer/node_modules/type-fest": {
+			"version": "0.21.3",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+			"integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/gitmoji-cli/node_modules/is-interactive": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+			"integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/gitmoji-cli/node_modules/is-unicode-supported": {
@@ -5553,9 +5657,9 @@
 			}
 		},
 		"node_modules/gitmoji-cli/node_modules/node-fetch": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.1.tgz",
-			"integrity": "sha512-cRVc/kyto/7E5shrWca1Wsea4y6tL9iYJE5FBCius3JQfb/4P4I295PfhgbJQBLTx6lATE4z+wK0rPM4VS2uow==",
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+			"integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
 			"dev": true,
 			"dependencies": {
 				"data-uri-to-buffer": "^4.0.0",
@@ -5570,61 +5674,51 @@
 				"url": "https://opencollective.com/node-fetch"
 			}
 		},
-		"node_modules/gitmoji-cli/node_modules/restore-cursor": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
-			"integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
+		"node_modules/gitmoji-cli/node_modules/readable-stream": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
 			"dev": true,
 			"dependencies": {
-				"onetime": "^5.1.0",
-				"signal-exit": "^3.0.2"
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
 			},
 			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
+				"node": ">= 6"
 			}
 		},
 		"node_modules/gitmoji-cli/node_modules/rxjs": {
-			"version": "7.8.0",
-			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.0.tgz",
-			"integrity": "sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==",
+			"version": "7.8.1",
+			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+			"integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
 			"dev": true,
 			"dependencies": {
 				"tslib": "^2.1.0"
 			}
 		},
-		"node_modules/gitmoji-cli/node_modules/string-width": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-			"integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+		"node_modules/gitmoji-cli/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
 			"dev": true,
 			"dependencies": {
-				"eastasianwidth": "^0.2.0",
-				"emoji-regex": "^9.2.2",
-				"strip-ansi": "^7.0.1"
+				"ansi-regex": "^5.0.1"
 			},
 			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
+				"node": ">=8"
 			}
 		},
-		"node_modules/gitmoji-cli/node_modules/strip-ansi": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
-			"integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
+		"node_modules/gitmoji-cli/node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 			"dev": true,
 			"dependencies": {
-				"ansi-regex": "^6.0.1"
+				"has-flag": "^4.0.0"
 			},
 			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+				"node": ">=8"
 			}
 		},
 		"node_modules/gitmoji-cli/node_modules/tslib": {
@@ -5646,20 +5740,17 @@
 			}
 		},
 		"node_modules/gitmoji-cli/node_modules/wrap-ansi": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-			"integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+			"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
 			"dev": true,
 			"dependencies": {
-				"ansi-styles": "^6.1.0",
-				"string-width": "^5.0.1",
-				"strip-ansi": "^7.0.1"
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
 			},
 			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+				"node": ">=8"
 			}
 		},
 		"node_modules/glob": {
@@ -5760,6 +5851,18 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/gopd": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+			"integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+			"dev": true,
+			"dependencies": {
+				"get-intrinsic": "^1.1.3"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/got": {
 			"version": "12.6.0",
 			"resolved": "https://registry.npmjs.org/got/-/got-12.6.0.tgz",
@@ -5796,15 +5899,6 @@
 			"integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
 			"dev": true
 		},
-		"node_modules/hard-rejection": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
-			"integrity": "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==",
-			"dev": true,
-			"engines": {
-				"node": ">=6"
-			}
-		},
 		"node_modules/has": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -5832,7 +5926,7 @@
 		"node_modules/has-flag": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+			"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
 			"dev": true,
 			"engines": {
 				"node": ">=4"
@@ -5845,6 +5939,42 @@
 			"dev": true,
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/has-property-descriptors": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+			"integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+			"dev": true,
+			"dependencies": {
+				"es-define-property": "^1.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/has-proto": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
+			"integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/has-symbols": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+			"integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/has-yarn": {
@@ -5872,6 +6002,18 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/hasown": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+			"integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+			"dev": true,
+			"dependencies": {
+				"function-bind": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/he": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
@@ -5879,27 +6021,6 @@
 			"dev": true,
 			"bin": {
 				"he": "bin/he"
-			}
-		},
-		"node_modules/hosted-git-info": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-5.2.1.tgz",
-			"integrity": "sha512-xIcQYMnhcx2Nr4JTjsFmwwnr9vldugPy9uVm0o87bjqqWMv9GaqsTeT+i99wTl0mk1uLxJtHxLb8kymqTENQsw==",
-			"dev": true,
-			"dependencies": {
-				"lru-cache": "^7.5.1"
-			},
-			"engines": {
-				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-			}
-		},
-		"node_modules/hosted-git-info/node_modules/lru-cache": {
-			"version": "7.18.3",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-			"integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
-			"dev": true,
-			"engines": {
-				"node": ">=12"
 			}
 		},
 		"node_modules/html-escaper": {
@@ -5913,22 +6034,6 @@
 			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
 			"integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
 			"dev": true
-		},
-		"node_modules/http-errors": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
-			"integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
-			"dev": true,
-			"dependencies": {
-				"depd": "~1.1.2",
-				"inherits": "2.0.4",
-				"setprototypeof": "1.2.0",
-				"statuses": ">= 1.5.0 < 2",
-				"toidentifier": "1.0.1"
-			},
-			"engines": {
-				"node": ">= 0.6"
-			}
 		},
 		"node_modules/http-proxy-agent": {
 			"version": "4.0.1",
@@ -5983,12 +6088,12 @@
 			}
 		},
 		"node_modules/human-signals": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-4.3.1.tgz",
-			"integrity": "sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+			"integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
 			"dev": true,
 			"engines": {
-				"node": ">=14.18.0"
+				"node": ">=16.17.0"
 			}
 		},
 		"node_modules/iconv-lite": {
@@ -6221,16 +6326,23 @@
 				"node": ">=10.13.0"
 			}
 		},
-		"node_modules/ip": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
-			"integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
-			"dev": true
+		"node_modules/ip-address": {
+			"version": "9.0.5",
+			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
+			"integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+			"dev": true,
+			"dependencies": {
+				"jsbn": "1.1.0",
+				"sprintf-js": "^1.1.3"
+			},
+			"engines": {
+				"node": ">= 12"
+			}
 		},
-		"node_modules/is-arrayish": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-			"integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+		"node_modules/ip-address/node_modules/sprintf-js": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+			"integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
 			"dev": true
 		},
 		"node_modules/is-binary-path": {
@@ -6364,15 +6476,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/is-plain-obj": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-			"integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/is-plain-object": {
@@ -6677,6 +6780,12 @@
 				"js-yaml": "bin/js-yaml.js"
 			}
 		},
+		"node_modules/jsbn": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+			"integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
+			"dev": true
+		},
 		"node_modules/jsesc": {
 			"version": "2.5.2",
 			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -6816,10 +6925,12 @@
 			"dev": true
 		},
 		"node_modules/jsonfile": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-			"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-			"dev": true,
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+			"integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+			"dependencies": {
+				"universalify": "^2.0.0"
+			},
 			"optionalDependencies": {
 				"graceful-fs": "^4.1.6"
 			}
@@ -6907,12 +7018,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/lines-and-columns": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-			"integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-			"dev": true
-		},
 		"node_modules/listenercount": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
@@ -6940,21 +7045,6 @@
 			},
 			"engines": {
 				"node": ">=8.9.0"
-			}
-		},
-		"node_modules/locate-path": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.2.0.tgz",
-			"integrity": "sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==",
-			"dev": true,
-			"dependencies": {
-				"p-locate": "^6.0.0"
-			},
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/lodash": {
@@ -7067,18 +7157,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/lru-cache": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-			"dev": true,
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/make-dir": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -7100,75 +7178,16 @@
 			"integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
 			"dev": true
 		},
-		"node_modules/map-obj": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
-			"integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/meow": {
-			"version": "11.0.0",
-			"resolved": "https://registry.npmjs.org/meow/-/meow-11.0.0.tgz",
-			"integrity": "sha512-Cl0yeeIrko6d94KpUo1M+0X1sB14ikoaqlIGuTH1fW4I+E3+YljL54/hb/BWmVfrV9tTV9zU04+xjw08Fh2WkA==",
+			"version": "12.1.1",
+			"resolved": "https://registry.npmjs.org/meow/-/meow-12.1.1.tgz",
+			"integrity": "sha512-BhXM0Au22RwUneMPwSCnyhTOizdWoIEPU9sp0Aqa1PnDMR5Wv2FGXYDjuzJEIX+Eo2Rb8xuYe5jrnm5QowQFkw==",
 			"dev": true,
-			"dependencies": {
-				"@types/minimist": "^1.2.2",
-				"camelcase-keys": "^8.0.2",
-				"decamelize": "^6.0.0",
-				"decamelize-keys": "^1.1.0",
-				"hard-rejection": "^2.1.0",
-				"minimist-options": "4.1.0",
-				"normalize-package-data": "^4.0.1",
-				"read-pkg-up": "^9.1.0",
-				"redent": "^4.0.0",
-				"trim-newlines": "^4.0.2",
-				"type-fest": "^3.1.0",
-				"yargs-parser": "^21.1.1"
-			},
 			"engines": {
-				"node": ">=14.16"
+				"node": ">=16.10"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/meow/node_modules/decamelize": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-6.0.0.tgz",
-			"integrity": "sha512-Fv96DCsdOgB6mdGl67MT5JaTNKRzrzill5OH5s8bjYJXVlcXyPYGyPsUkWyGV5p1TXI5esYIYMMeDJL0hEIwaA==",
-			"dev": true,
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/meow/node_modules/type-fest": {
-			"version": "3.6.1",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.6.1.tgz",
-			"integrity": "sha512-htXWckxlT6U4+ilVgweNliPqlsVSSucbxVexRYllyMVJDtf5rTjv6kF/s+qAd4QSL1BZcnJPEJavYBPQiWuZDA==",
-			"dev": true,
-			"engines": {
-				"node": ">=14.16"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/meow/node_modules/yargs-parser": {
-			"version": "21.1.1",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-			"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-			"dev": true,
-			"engines": {
-				"node": ">=12"
 			}
 		},
 		"node_modules/merge-stream": {
@@ -7240,15 +7259,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/min-indent": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
-			"integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
-			"dev": true,
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/minimatch": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -7266,20 +7276,6 @@
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
 			"integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
 			"dev": true
-		},
-		"node_modules/minimist-options": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.1.0.tgz",
-			"integrity": "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==",
-			"dev": true,
-			"dependencies": {
-				"arrify": "^1.0.1",
-				"is-plain-obj": "^1.1.0",
-				"kind-of": "^6.0.3"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
 		},
 		"node_modules/mkdirp": {
 			"version": "0.5.5",
@@ -7627,36 +7623,6 @@
 			"integrity": "sha512-LLUo+PpH3dU6XizX3iVoubUNheF/owjXCZZ5yACDxNnPtgFuludV1ZL3ayK1kVep42Rmm0+R9/Y60NQbZ2bifw==",
 			"dev": true
 		},
-		"node_modules/normalize-package-data": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-4.0.1.tgz",
-			"integrity": "sha512-EBk5QKKuocMJhB3BILuKhmaPjI8vNRSpIfO9woLC6NyHVkKKdVEdAO1mrT0ZfxNR1lKwCcTkuZfmGIFdizZ8Pg==",
-			"dev": true,
-			"dependencies": {
-				"hosted-git-info": "^5.0.0",
-				"is-core-module": "^2.8.1",
-				"semver": "^7.3.5",
-				"validate-npm-package-license": "^3.0.4"
-			},
-			"engines": {
-				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-			}
-		},
-		"node_modules/normalize-package-data/node_modules/semver": {
-			"version": "7.3.8",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-			"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-			"dev": true,
-			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/normalize-path": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -7678,9 +7644,9 @@
 			}
 		},
 		"node_modules/npm-run-path": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz",
-			"integrity": "sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==",
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+			"integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
 			"dev": true,
 			"dependencies": {
 				"path-key": "^4.0.0"
@@ -7993,23 +7959,23 @@
 			}
 		},
 		"node_modules/ora": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/ora/-/ora-6.3.0.tgz",
-			"integrity": "sha512-1/D8uRFY0ay2kgBpmAwmSA404w4OoPVhHMqRqtjvrcK/dnzcEZxMJ+V4DUbyICu8IIVRclHcOf5wlD1tMY4GUQ==",
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/ora/-/ora-7.0.1.tgz",
+			"integrity": "sha512-0TUxTiFJWv+JnjWm4o9yvuskpEJLXTcng8MJuKd+SzAzp2o+OP3HWqNhB4OdJRt1Vsd9/mR0oyaEYlOnL7XIRw==",
 			"dev": true,
 			"dependencies": {
-				"chalk": "^5.0.0",
+				"chalk": "^5.3.0",
 				"cli-cursor": "^4.0.0",
-				"cli-spinners": "^2.6.1",
+				"cli-spinners": "^2.9.0",
 				"is-interactive": "^2.0.0",
-				"is-unicode-supported": "^1.1.0",
+				"is-unicode-supported": "^1.3.0",
 				"log-symbols": "^5.1.0",
 				"stdin-discarder": "^0.1.0",
-				"strip-ansi": "^7.0.1",
-				"wcwidth": "^1.0.1"
+				"string-width": "^6.1.0",
+				"strip-ansi": "^7.1.0"
 			},
 			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+				"node": ">=16"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -8028,9 +7994,9 @@
 			}
 		},
 		"node_modules/ora/node_modules/chalk": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.2.0.tgz",
-			"integrity": "sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA==",
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+			"integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
 			"dev": true,
 			"engines": {
 				"node": "^12.17.0 || ^14.13 || >=16.0.0"
@@ -8053,6 +8019,12 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
+		},
+		"node_modules/ora/node_modules/emoji-regex": {
+			"version": "10.3.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.3.0.tgz",
+			"integrity": "sha512-QpLs9D9v9kArv4lfDEgg1X/gN5XLnf/A6l9cs8SPZLRZR3ZkY9+kwIQTxm+fsSej5UMYGE8fdoaZVIBlqG0XTw==",
+			"dev": true
 		},
 		"node_modules/ora/node_modules/is-unicode-supported": {
 			"version": "1.3.0",
@@ -8098,10 +8070,27 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/ora/node_modules/string-width": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-6.1.0.tgz",
+			"integrity": "sha512-k01swCJAgQmuADB0YIc+7TuatfNvTBVOoaUWJjTB9R4VJzR5vNWzf5t42ESVZFPS8xTySF7CAdV4t/aaIm3UnQ==",
+			"dev": true,
+			"dependencies": {
+				"eastasianwidth": "^0.2.0",
+				"emoji-regex": "^10.2.1",
+				"strip-ansi": "^7.0.1"
+			},
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/ora/node_modules/strip-ansi": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
-			"integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+			"integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
 			"dev": true,
 			"dependencies": {
 				"ansi-regex": "^6.0.1"
@@ -8143,48 +8132,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/p-locate": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-6.0.0.tgz",
-			"integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
-			"dev": true,
-			"dependencies": {
-				"p-limit": "^4.0.0"
-			},
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/p-locate/node_modules/p-limit": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
-			"integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
-			"dev": true,
-			"dependencies": {
-				"yocto-queue": "^1.0.0"
-			},
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/p-locate/node_modules/yocto-queue": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
-			"integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==",
-			"dev": true,
-			"engines": {
-				"node": ">=12.20"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/p-try": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
@@ -8195,37 +8142,90 @@
 			}
 		},
 		"node_modules/pac-proxy-agent": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-5.0.0.tgz",
-			"integrity": "sha512-CcFG3ZtnxO8McDigozwE3AqAw15zDvGH+OjXO4kzf7IkEKkQ4gxQ+3sdF50WmhQ4P/bVusXcqNE2S3XrNURwzQ==",
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.0.1.tgz",
+			"integrity": "sha512-ASV8yU4LLKBAjqIPMbrgtaKIvxQri/yh2OpI+S6hVa9JRkUI3Y3NPFbfngDtY7oFtSMD3w31Xns89mDa3Feo5A==",
 			"dev": true,
 			"dependencies": {
-				"@tootallnate/once": "1",
-				"agent-base": "6",
-				"debug": "4",
-				"get-uri": "3",
-				"http-proxy-agent": "^4.0.1",
-				"https-proxy-agent": "5",
-				"pac-resolver": "^5.0.0",
-				"raw-body": "^2.2.0",
-				"socks-proxy-agent": "5"
+				"@tootallnate/quickjs-emscripten": "^0.23.0",
+				"agent-base": "^7.0.2",
+				"debug": "^4.3.4",
+				"get-uri": "^6.0.1",
+				"http-proxy-agent": "^7.0.0",
+				"https-proxy-agent": "^7.0.2",
+				"pac-resolver": "^7.0.0",
+				"socks-proxy-agent": "^8.0.2"
 			},
 			"engines": {
-				"node": ">= 8"
+				"node": ">= 14"
+			}
+		},
+		"node_modules/pac-proxy-agent/node_modules/agent-base": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
+			"integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
+			"dev": true,
+			"dependencies": {
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/pac-proxy-agent/node_modules/debug": {
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+			"dev": true,
+			"dependencies": {
+				"ms": "2.1.2"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/pac-proxy-agent/node_modules/http-proxy-agent": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+			"integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+			"dev": true,
+			"dependencies": {
+				"agent-base": "^7.1.0",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/pac-proxy-agent/node_modules/https-proxy-agent": {
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz",
+			"integrity": "sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==",
+			"dev": true,
+			"dependencies": {
+				"agent-base": "^7.0.2",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 14"
 			}
 		},
 		"node_modules/pac-resolver": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-5.0.0.tgz",
-			"integrity": "sha512-H+/A6KitiHNNW+bxBKREk2MCGSxljfqRX76NjummWEYIat7ldVXRU3dhRIE3iXZ0nvGBk6smv3nntxKkzRL8NA==",
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+			"integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
 			"dev": true,
 			"dependencies": {
-				"degenerator": "^3.0.1",
-				"ip": "^1.1.5",
-				"netmask": "^2.0.1"
+				"degenerator": "^5.0.0",
+				"netmask": "^2.0.2"
 			},
 			"engines": {
-				"node": ">= 8"
+				"node": ">= 14"
 			}
 		},
 		"node_modules/package-hash": {
@@ -8262,13 +8262,10 @@
 			}
 		},
 		"node_modules/package-json/node_modules/semver": {
-			"version": "7.3.8",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-			"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+			"version": "7.6.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+			"integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
 			"dev": true,
-			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
 			"bin": {
 				"semver": "bin/semver.js"
 			},
@@ -8291,24 +8288,6 @@
 			},
 			"engines": {
 				"node": ">=6"
-			}
-		},
-		"node_modules/parse-json": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
-			"integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-			"dev": true,
-			"dependencies": {
-				"@babel/code-frame": "^7.0.0",
-				"error-ex": "^1.3.1",
-				"json-parse-even-better-errors": "^2.3.0",
-				"lines-and-columns": "^1.1.6"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/path-exists": {
@@ -8464,38 +8443,87 @@
 			"dev": true
 		},
 		"node_modules/proxy-agent": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-5.0.0.tgz",
-			"integrity": "sha512-gkH7BkvLVkSfX9Dk27W6TyNOWWZWRilRfk1XxGNWOYJ2TuedAv1yFpCaU9QSBmBe716XOTNpYNOzhysyw8xn7g==",
+			"version": "6.4.0",
+			"resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.4.0.tgz",
+			"integrity": "sha512-u0piLU+nCOHMgGjRbimiXmA9kM/L9EHh3zL81xCdp7m+Y2pHIsnmbdDoEDoAz5geaonNR6q6+yOPQs6n4T6sBQ==",
 			"dev": true,
 			"dependencies": {
-				"agent-base": "^6.0.0",
-				"debug": "4",
-				"http-proxy-agent": "^4.0.0",
-				"https-proxy-agent": "^5.0.0",
-				"lru-cache": "^5.1.1",
-				"pac-proxy-agent": "^5.0.0",
-				"proxy-from-env": "^1.0.0",
-				"socks-proxy-agent": "^5.0.0"
+				"agent-base": "^7.0.2",
+				"debug": "^4.3.4",
+				"http-proxy-agent": "^7.0.1",
+				"https-proxy-agent": "^7.0.3",
+				"lru-cache": "^7.14.1",
+				"pac-proxy-agent": "^7.0.1",
+				"proxy-from-env": "^1.1.0",
+				"socks-proxy-agent": "^8.0.2"
 			},
 			"engines": {
-				"node": ">= 8"
+				"node": ">= 14"
+			}
+		},
+		"node_modules/proxy-agent/node_modules/agent-base": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
+			"integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
+			"dev": true,
+			"dependencies": {
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/proxy-agent/node_modules/debug": {
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+			"dev": true,
+			"dependencies": {
+				"ms": "2.1.2"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/proxy-agent/node_modules/http-proxy-agent": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+			"integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+			"dev": true,
+			"dependencies": {
+				"agent-base": "^7.1.0",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/proxy-agent/node_modules/https-proxy-agent": {
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz",
+			"integrity": "sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==",
+			"dev": true,
+			"dependencies": {
+				"agent-base": "^7.0.2",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 14"
 			}
 		},
 		"node_modules/proxy-agent/node_modules/lru-cache": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-			"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+			"version": "7.18.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+			"integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
 			"dev": true,
-			"dependencies": {
-				"yallist": "^3.0.2"
+			"engines": {
+				"node": ">=12"
 			}
-		},
-		"node_modules/proxy-agent/node_modules/yallist": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-			"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-			"dev": true
 		},
 		"node_modules/proxy-from-env": {
 			"version": "1.1.0",
@@ -8546,18 +8574,6 @@
 				}
 			]
 		},
-		"node_modules/quick-lru": {
-			"version": "6.1.1",
-			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-6.1.1.tgz",
-			"integrity": "sha512-S27GBT+F0NTRiehtbrgaSE1idUAJ5bX8dPAQTdylEyNlrdcH5X4Lz7Edz3DYzecbsCluD5zO8ZNEe04z3D3u6Q==",
-			"dev": true,
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/quote": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/quote/-/quote-0.4.0.tgz",
@@ -8577,33 +8593,6 @@
 			"dev": true,
 			"dependencies": {
 				"safe-buffer": "^5.1.0"
-			}
-		},
-		"node_modules/raw-body": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.2.tgz",
-			"integrity": "sha512-RPMAFUJP19WIet/99ngh6Iv8fzAbqum4Li7AD6DtGaW2RpMB/11xDoalPiJMTbu6I3hkbMVkATvZrqb9EEqeeQ==",
-			"dev": true,
-			"dependencies": {
-				"bytes": "3.1.1",
-				"http-errors": "1.8.1",
-				"iconv-lite": "0.4.24",
-				"unpipe": "1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
-		"node_modules/raw-body/node_modules/iconv-lite": {
-			"version": "0.4.24",
-			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-			"dev": true,
-			"dependencies": {
-				"safer-buffer": ">= 2.1.2 < 3"
-			},
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/rc": {
@@ -8634,107 +8623,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/read-pkg": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-7.1.0.tgz",
-			"integrity": "sha512-5iOehe+WF75IccPc30bWTbpdDQLOCc3Uu8bi3Dte3Eueij81yx1Mrufk8qBx/YAbR4uL1FdUr+7BKXDwEtisXg==",
-			"dev": true,
-			"dependencies": {
-				"@types/normalize-package-data": "^2.4.1",
-				"normalize-package-data": "^3.0.2",
-				"parse-json": "^5.2.0",
-				"type-fest": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=12.20"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/read-pkg-up": {
-			"version": "9.1.0",
-			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-9.1.0.tgz",
-			"integrity": "sha512-vaMRR1AC1nrd5CQM0PhlRsO5oc2AAigqr7cCrZ/MW/Rsaflz4RlgzkpL4qoU/z1F6wrbd85iFv1OQj/y5RdGvg==",
-			"dev": true,
-			"dependencies": {
-				"find-up": "^6.3.0",
-				"read-pkg": "^7.1.0",
-				"type-fest": "^2.5.0"
-			},
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/read-pkg-up/node_modules/type-fest": {
-			"version": "2.19.0",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-			"integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-			"dev": true,
-			"engines": {
-				"node": ">=12.20"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/read-pkg/node_modules/hosted-git-info": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
-			"integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
-			"dev": true,
-			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/read-pkg/node_modules/normalize-package-data": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
-			"integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
-			"dev": true,
-			"dependencies": {
-				"hosted-git-info": "^4.0.1",
-				"is-core-module": "^2.5.0",
-				"semver": "^7.3.4",
-				"validate-npm-package-license": "^3.0.1"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/read-pkg/node_modules/semver": {
-			"version": "7.3.8",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-			"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-			"dev": true,
-			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/read-pkg/node_modules/type-fest": {
-			"version": "2.19.0",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-			"integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-			"dev": true,
-			"engines": {
-				"node": ">=12.20"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/readable-stream": {
@@ -8777,34 +8665,6 @@
 			},
 			"engines": {
 				"node": ">= 10.13.0"
-			}
-		},
-		"node_modules/redent": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/redent/-/redent-4.0.0.tgz",
-			"integrity": "sha512-tYkDkVVtYkSVhuQ4zBgfvciymHaeuel+zFKXShfDnFP5SyVEP7qo70Rf1jTOTCx3vGNAbnEi/xFkcfQVMIBWag==",
-			"dev": true,
-			"dependencies": {
-				"indent-string": "^5.0.0",
-				"strip-indent": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/redent/node_modules/indent-string": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
-			"integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
-			"dev": true,
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/regenerator-runtime": {
@@ -9051,9 +8911,9 @@
 			}
 		},
 		"node_modules/semver": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
 			"dev": true,
 			"bin": {
 				"semver": "bin/semver.js"
@@ -9075,13 +8935,10 @@
 			}
 		},
 		"node_modules/semver-diff/node_modules/semver": {
-			"version": "7.3.8",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-			"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+			"version": "7.6.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+			"integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
 			"dev": true,
-			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
 			"bin": {
 				"semver": "bin/semver.js"
 			},
@@ -9104,16 +8961,27 @@
 			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
 			"dev": true
 		},
+		"node_modules/set-function-length": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+			"integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+			"dev": true,
+			"dependencies": {
+				"define-data-property": "^1.1.4",
+				"es-errors": "^1.3.0",
+				"function-bind": "^1.1.2",
+				"get-intrinsic": "^1.2.4",
+				"gopd": "^1.0.1",
+				"has-property-descriptors": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/setimmediate": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
 			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
-			"dev": true
-		},
-		"node_modules/setprototypeof": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
-			"integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
 			"dev": true
 		},
 		"node_modules/shallow-clone": {
@@ -9319,31 +9187,60 @@
 			}
 		},
 		"node_modules/socks": {
-			"version": "2.6.1",
-			"resolved": "https://registry.npmjs.org/socks/-/socks-2.6.1.tgz",
-			"integrity": "sha512-kLQ9N5ucj8uIcxrDwjm0Jsqk06xdpBjGNQtpXy4Q8/QY2k+fY7nZH8CARy+hkbG+SGAovmzzuauCpBlb8FrnBA==",
+			"version": "2.8.3",
+			"resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
+			"integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
 			"dev": true,
 			"dependencies": {
-				"ip": "^1.1.5",
-				"smart-buffer": "^4.1.0"
+				"ip-address": "^9.0.5",
+				"smart-buffer": "^4.2.0"
 			},
 			"engines": {
-				"node": ">= 10.13.0",
+				"node": ">= 10.0.0",
 				"npm": ">= 3.0.0"
 			}
 		},
 		"node_modules/socks-proxy-agent": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-5.0.1.tgz",
-			"integrity": "sha512-vZdmnjb9a2Tz6WEQVIurybSwElwPxMZaIc7PzqbJTrezcKNznv6giT7J7tZDZ1BojVaa1jvO/UiUdhDVB0ACoQ==",
+			"version": "8.0.3",
+			"resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.3.tgz",
+			"integrity": "sha512-VNegTZKhuGq5vSD6XNKlbqWhyt/40CgoEw8XxD6dhnm8Jq9IEa3nIa4HwnM8XOqU0CdB0BwWVXusqiFXfHB3+A==",
 			"dev": true,
 			"dependencies": {
-				"agent-base": "^6.0.2",
-				"debug": "4",
-				"socks": "^2.3.3"
+				"agent-base": "^7.1.1",
+				"debug": "^4.3.4",
+				"socks": "^2.7.1"
 			},
 			"engines": {
-				"node": ">= 6"
+				"node": ">= 14"
+			}
+		},
+		"node_modules/socks-proxy-agent/node_modules/agent-base": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
+			"integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
+			"dev": true,
+			"dependencies": {
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/socks-proxy-agent/node_modules/debug": {
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+			"dev": true,
+			"dependencies": {
+				"ms": "2.1.2"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/source-map": {
@@ -9448,52 +9345,11 @@
 				"node": ">= 8"
 			}
 		},
-		"node_modules/spdx-correct": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
-			"integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
-			"dev": true,
-			"dependencies": {
-				"spdx-expression-parse": "^3.0.0",
-				"spdx-license-ids": "^3.0.0"
-			}
-		},
-		"node_modules/spdx-exceptions": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
-			"integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
-			"dev": true
-		},
-		"node_modules/spdx-expression-parse": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
-			"integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
-			"dev": true,
-			"dependencies": {
-				"spdx-exceptions": "^2.1.0",
-				"spdx-license-ids": "^3.0.0"
-			}
-		},
-		"node_modules/spdx-license-ids": {
-			"version": "3.0.12",
-			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.12.tgz",
-			"integrity": "sha512-rr+VVSXtRhO4OHbXUiAF7xW3Bo9DuuF6C5jH+q/x15j2jniycgKbxU09Hr0WqlSLUs4i4ltHGXqTe7VHclYWyA==",
-			"dev": true
-		},
 		"node_modules/sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
 			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
 			"dev": true
-		},
-		"node_modules/statuses": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-			"integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.6"
-			}
 		},
 		"node_modules/stdin-discarder": {
 			"version": "0.1.0",
@@ -9587,21 +9443,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/strip-indent": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-4.0.0.tgz",
-			"integrity": "sha512-mnVSV2l+Zv6BLpSD/8V87CW/y9EmmbYzGCIavsnsI6/nwn26DwffM/yztm30Z/I2DY9wdS3vXVCMnHDgZaVNoA==",
-			"dev": true,
-			"dependencies": {
-				"min-indent": "^1.0.1"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/strip-json-comments": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -9612,9 +9453,9 @@
 			}
 		},
 		"node_modules/stubborn-fs": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/stubborn-fs/-/stubborn-fs-1.2.4.tgz",
-			"integrity": "sha512-KRa4nIRJ8q6uApQbPwYZVhOof8979fw4xbajBWa5kPJFa4nyY3aFaMWVyIVCDnkNCCG/3HLipUZ4QaNlYsmX1w==",
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/stubborn-fs/-/stubborn-fs-1.2.5.tgz",
+			"integrity": "sha512-H2N9c26eXjzL/S/K+i/RHHcFanE74dptvvjM8iwzwbVcWY/zjBbgRqF3K0DY4+OD+uTTASTBvDoxPDaPN02D7g==",
 			"dev": true
 		},
 		"node_modules/style-mod": {
@@ -9803,31 +9644,10 @@
 				"node": ">=8.0"
 			}
 		},
-		"node_modules/toidentifier": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
-			"integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.6"
-			}
-		},
 		"node_modules/tr46": {
 			"version": "0.0.3",
 			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
 			"integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
-		},
-		"node_modules/trim-newlines": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-4.0.2.tgz",
-			"integrity": "sha512-GJtWyq9InR/2HRiLZgpIKv+ufIKrVrvjQWEj7PxAXNc5dwbNJkqhAUoAGgzRmULAnoOM5EIpveYd3J2VeSAIew==",
-			"dev": true,
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
 		},
 		"node_modules/ts-loader": {
 			"version": "9.4.2",
@@ -9907,13 +9727,10 @@
 			}
 		},
 		"node_modules/ts-loader/node_modules/semver": {
-			"version": "7.3.5",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-			"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+			"version": "7.6.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+			"integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
 			"dev": true,
-			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
 			"bin": {
 				"semver": "bin/semver.js"
 			},
@@ -10070,21 +9887,11 @@
 			}
 		},
 		"node_modules/universalify": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-			"dev": true,
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
 			"engines": {
-				"node": ">= 4.0.0"
-			}
-		},
-		"node_modules/unpipe": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-			"integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.8"
+				"node": ">= 10.0.0"
 			}
 		},
 		"node_modules/unzipper": {
@@ -10179,13 +9986,10 @@
 			}
 		},
 		"node_modules/update-notifier/node_modules/semver": {
-			"version": "7.3.8",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-			"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+			"version": "7.6.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+			"integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
 			"dev": true,
-			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
 			"bin": {
 				"semver": "bin/semver.js"
 			},
@@ -10194,9 +9998,9 @@
 			}
 		},
 		"node_modules/uri-js": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
-			"integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
 			"dev": true,
 			"dependencies": {
 				"punycode": "^2.1.0"
@@ -10222,20 +10026,10 @@
 			"integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
 			"dev": true
 		},
-		"node_modules/validate-npm-package-license": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
-			"integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
-			"dev": true,
-			"dependencies": {
-				"spdx-correct": "^3.0.0",
-				"spdx-expression-parse": "^3.0.0"
-			}
-		},
 		"node_modules/validator": {
-			"version": "13.9.0",
-			"resolved": "https://registry.npmjs.org/validator/-/validator-13.9.0.tgz",
-			"integrity": "sha512-B+dGG8U3fdtM0/aNK4/X8CXq/EcxU2WPrPEkJGslb47qyHsxmbggTWK0yEA4qnYVNF+nxNlN88o14hIcPmSIEA==",
+			"version": "13.12.0",
+			"resolved": "https://registry.npmjs.org/validator/-/validator-13.12.0.tgz",
+			"integrity": "sha512-c1Q0mCiPlgdTVVVIJIrBuxNicYE+t/7oKeI9MWLj3fh/uq2Pxh/3eeWbVZ4OcGW1TUf53At0njHw5SMdA3tmMg==",
 			"dev": true,
 			"engines": {
 				"node": ">= 0.10"
@@ -10292,52 +10086,54 @@
 				"node": ">=0.8.0"
 			}
 		},
-		"node_modules/vm2": {
-			"version": "3.9.19",
-			"resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.19.tgz",
-			"integrity": "sha512-J637XF0DHDMV57R6JyVsTak7nIL8gy5KH4r1HiwWLf/4GBbb5MKL5y7LpmF4A8E2nR6XmzpmMFQ7V7ppPTmUQg==",
-			"dev": true,
-			"dependencies": {
-				"acorn": "^8.7.0",
-				"acorn-walk": "^8.2.0"
-			},
-			"bin": {
-				"vm2": "bin/vm2"
-			},
-			"engines": {
-				"node": ">=6.0"
-			}
-		},
 		"node_modules/vscode-jsonrpc": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz",
-			"integrity": "sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg==",
+			"version": "8.2.0",
+			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+			"integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
 			"engines": {
-				"node": ">=8.0.0 || >=10.0.0"
+				"node": ">=14.0.0"
 			}
 		},
 		"node_modules/vscode-languageclient": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-8.0.1.tgz",
-			"integrity": "sha512-9XoE+HJfaWvu7Y75H3VmLo5WLCtsbxEgEhrLPqwt7eyoR49lUIyyrjb98Yfa50JCMqF2cePJAEVI6oe2o1sIhw==",
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-9.0.1.tgz",
+			"integrity": "sha512-JZiimVdvimEuHh5olxhxkht09m3JzUGwggb5eRUkzzJhZ2KjCN0nh55VfiED9oez9DyF8/fz1g1iBV3h+0Z2EA==",
 			"dev": true,
 			"dependencies": {
-				"minimatch": "^3.0.4",
-				"semver": "^7.3.5",
-				"vscode-languageserver-protocol": "3.17.1"
+				"minimatch": "^5.1.0",
+				"semver": "^7.3.7",
+				"vscode-languageserver-protocol": "3.17.5"
 			},
 			"engines": {
-				"vscode": "^1.67.0"
+				"vscode": "^1.82.0"
+			}
+		},
+		"node_modules/vscode-languageclient/node_modules/brace-expansion": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+			"dev": true,
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/vscode-languageclient/node_modules/minimatch": {
+			"version": "5.1.6",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+			"integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+			"dev": true,
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/vscode-languageclient/node_modules/semver": {
-			"version": "7.3.7",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-			"integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+			"version": "7.6.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+			"integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
 			"dev": true,
-			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
 			"bin": {
 				"semver": "bin/semver.js"
 			},
@@ -10345,60 +10141,35 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/vscode-languageclient/node_modules/vscode-jsonrpc": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.0.1.tgz",
-			"integrity": "sha512-N/WKvghIajmEvXpatSzvTvOIz61ZSmOSa4BRA4pTLi+1+jozquQKP/MkaylP9iB68k73Oua1feLQvH3xQuigiQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/vscode-languageclient/node_modules/vscode-languageserver-protocol": {
-			"version": "3.17.1",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.1.tgz",
-			"integrity": "sha512-BNlAYgQoYwlSgDLJhSG+DeA8G1JyECqRzM2YO6tMmMji3Ad9Mw6AW7vnZMti90qlAKb0LqAlJfSVGEdqMMNzKg==",
-			"dev": true,
-			"dependencies": {
-				"vscode-jsonrpc": "8.0.1",
-				"vscode-languageserver-types": "3.17.1"
-			}
-		},
-		"node_modules/vscode-languageclient/node_modules/vscode-languageserver-types": {
-			"version": "3.17.1",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.1.tgz",
-			"integrity": "sha512-K3HqVRPElLZVVPtMeKlsyL9aK0GxGQpvtAUTfX4k7+iJ4mc1M+JM+zQwkgGy2LzY0f0IAafe8MKqIkJrxfGGjQ==",
-			"dev": true
-		},
 		"node_modules/vscode-languageserver": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-7.0.0.tgz",
-			"integrity": "sha512-60HTx5ID+fLRcgdHfmz0LDZAXYEV68fzwG0JWwEPBode9NuMYTIxuYXPg4ngO8i8+Ou0lM7y6GzaYWbiDL0drw==",
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
+			"integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
 			"dependencies": {
-				"vscode-languageserver-protocol": "3.16.0"
+				"vscode-languageserver-protocol": "3.17.5"
 			},
 			"bin": {
 				"installServerIntoExtension": "bin/installServerIntoExtension"
 			}
 		},
 		"node_modules/vscode-languageserver-protocol": {
-			"version": "3.16.0",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz",
-			"integrity": "sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==",
+			"version": "3.17.5",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+			"integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
 			"dependencies": {
-				"vscode-jsonrpc": "6.0.0",
-				"vscode-languageserver-types": "3.16.0"
+				"vscode-jsonrpc": "8.2.0",
+				"vscode-languageserver-types": "3.17.5"
 			}
 		},
 		"node_modules/vscode-languageserver-textdocument": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.4.tgz",
-			"integrity": "sha512-/xhqXP/2A2RSs+J8JNXpiiNVvvNM0oTosNVmQnunlKvq9o4mupHOBAnnzH0lwIPKazXKvAKsVp1kr+H/K4lgoQ=="
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.11.tgz",
+			"integrity": "sha512-X+8T3GoiwTVlJbicx/sIAF+yuJAqz8VvwJyoMVhwEMoEKE/fkDmrqUgDMyBECcM2A2frVZIUj5HI/ErRXCfOeA=="
 		},
 		"node_modules/vscode-languageserver-types": {
-			"version": "3.16.0",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
-			"integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
+			"version": "3.17.5",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+			"integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg=="
 		},
 		"node_modules/vscode-test": {
 			"version": "1.5.2",
@@ -10456,9 +10227,9 @@
 			}
 		},
 		"node_modules/web-streams-polyfill": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
-			"integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+			"integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
 			"dev": true,
 			"engines": {
 				"node": ">= 8"
@@ -10703,9 +10474,9 @@
 			}
 		},
 		"node_modules/when-exit": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/when-exit/-/when-exit-2.1.0.tgz",
-			"integrity": "sha512-H85ulNwUBU1e6PGxkWUDgxnbohSXD++ah6Xw1VHAN7CtypcbZaC4aYjQ+C2PMVaDkURDuOinNAT+Lnz3utWXxQ==",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/when-exit/-/when-exit-2.1.2.tgz",
+			"integrity": "sha512-u9J+toaf3CCxCAzM/484qNAxQE75rFdVgiFEEV8Xps2gzYhf0tx73s1WXDQhkwV17E3MxRMz40m7Ekd2/121Lg==",
 			"dev": true
 		},
 		"node_modules/which-module": {
@@ -10805,9 +10576,9 @@
 			}
 		},
 		"node_modules/word-wrap": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-			"integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+			"integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
@@ -10933,15 +10704,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/xregexp": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/xregexp/-/xregexp-2.0.0.tgz",
-			"integrity": "sha1-UqY+VsoLhKfzpfPWGHLxJq16WUM=",
-			"dev": true,
-			"engines": {
-				"node": "*"
-			}
-		},
 		"node_modules/xtend": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -10954,12 +10716,6 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
 			"integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
-			"dev": true
-		},
-		"node_modules/yallist": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 			"dev": true
 		},
 		"node_modules/yargs": {
@@ -11159,8 +10915,8 @@
 			"license": "MIT",
 			"dependencies": {
 				"env-paths": "^2.2.1",
-				"vscode-languageserver": "^7.0.0",
-				"vscode-languageserver-textdocument": "^1.0.1"
+				"vscode-languageserver": "^9.0.1",
+				"vscode-languageserver-textdocument": "^1.0.11"
 			},
 			"bin": {
 				"spyglassmc-language-server": "bin/server.js"
@@ -11202,38 +10958,6 @@
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.17.tgz",
 			"integrity": "sha512-HJSUJmni4BeDHhfzn6nF0sVmd1SMezP7/4F0Lq+aXzmp2xm9O7WXrUtHW/CHlYVtZUbByEvWidHqRtcJXGF2Ng==",
 			"dev": true
-		},
-		"packages/mcdoc-cli/node_modules/fs-extra": {
-			"version": "11.1.1",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
-			"integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
-			"dependencies": {
-				"graceful-fs": "^4.2.0",
-				"jsonfile": "^6.0.1",
-				"universalify": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=14.14"
-			}
-		},
-		"packages/mcdoc-cli/node_modules/jsonfile": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-			"integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-			"dependencies": {
-				"universalify": "^2.0.0"
-			},
-			"optionalDependencies": {
-				"graceful-fs": "^4.1.6"
-			}
-		},
-		"packages/mcdoc-cli/node_modules/universalify": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-			"integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-			"engines": {
-				"node": ">= 10.0.0"
-			}
 		},
 		"packages/mcdoc-cli/node_modules/y18n": {
 			"version": "5.0.8",
@@ -11298,7 +11022,7 @@
 			"devDependencies": {
 				"@types/vscode": "1.67.0",
 				"esbuild": "^0.17.18",
-				"vscode-languageclient": "^8.0.1",
+				"vscode-languageclient": "^9.0.1",
 				"vscode-test": "^1.5.2"
 			},
 			"engines": {
@@ -11308,12 +11032,13 @@
 	},
 	"dependencies": {
 		"@babel/code-frame": {
-			"version": "7.12.11",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
-			"integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
+			"version": "7.24.2",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.2.tgz",
+			"integrity": "sha512-y5+tLQyV8pg3fsiln67BVLD1P13Eg4lh5RW9mF0zUuvLrv9uIQ4MCL+CRT+FTsBlBjcIan6PGsLcBN0m3ClUyQ==",
 			"dev": true,
 			"requires": {
-				"@babel/highlight": "^7.10.4"
+				"@babel/highlight": "^7.24.2",
+				"picocolors": "^1.0.0"
 			}
 		},
 		"@babel/core": {
@@ -11341,42 +11066,60 @@
 			},
 			"dependencies": {
 				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+					"version": "5.7.2",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+					"integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
 					"dev": true
 				}
 			}
 		},
 		"@babel/generator": {
-			"version": "7.12.5",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.5.tgz",
-			"integrity": "sha512-m16TQQJ8hPt7E+OS/XVQg/7U184MLXtvuGbCdA7na61vha+ImkyyNM/9DDA0unYCVZn3ZOhng+qz48/KBOT96A==",
+			"version": "7.24.5",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.5.tgz",
+			"integrity": "sha512-x32i4hEXvr+iI0NEoEfDKzlemF8AmtOP8CcrRaEcpzysWuoEb1KknpcvMsHKPONoKZiDuItklgWhB18xEhr9PA==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.12.5",
-				"jsesc": "^2.5.1",
-				"source-map": "^0.5.0"
+				"@babel/types": "^7.24.5",
+				"@jridgewell/gen-mapping": "^0.3.5",
+				"@jridgewell/trace-mapping": "^0.3.25",
+				"jsesc": "^2.5.1"
+			},
+			"dependencies": {
+				"@jridgewell/trace-mapping": {
+					"version": "0.3.25",
+					"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+					"integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+					"dev": true,
+					"requires": {
+						"@jridgewell/resolve-uri": "^3.1.0",
+						"@jridgewell/sourcemap-codec": "^1.4.14"
+					}
+				}
 			}
+		},
+		"@babel/helper-environment-visitor": {
+			"version": "7.22.20",
+			"resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
+			"integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
+			"dev": true
 		},
 		"@babel/helper-function-name": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
-			"integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
+			"version": "7.23.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
+			"integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-get-function-arity": "^7.10.4",
-				"@babel/template": "^7.10.4",
-				"@babel/types": "^7.10.4"
+				"@babel/template": "^7.22.15",
+				"@babel/types": "^7.23.0"
 			}
 		},
-		"@babel/helper-get-function-arity": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
-			"integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
+		"@babel/helper-hoist-variables": {
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
+			"integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.10.4"
+				"@babel/types": "^7.22.5"
 			}
 		},
 		"@babel/helper-member-expression-to-functions": {
@@ -11445,18 +11188,24 @@
 			}
 		},
 		"@babel/helper-split-export-declaration": {
-			"version": "7.11.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
-			"integrity": "sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==",
+			"version": "7.24.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.24.5.tgz",
+			"integrity": "sha512-5CHncttXohrHk8GWOFCcCl4oRD9fKosWlIRgWm4ql9VYioKm52Mk2xsmoohvm7f3JoiLSM5ZgJuRaf5QZZYd3Q==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.11.0"
+				"@babel/types": "^7.24.5"
 			}
 		},
+		"@babel/helper-string-parser": {
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.1.tgz",
+			"integrity": "sha512-2ofRCjnnA9y+wk8b9IAREroeUP02KHp431N2mhKniy2yKIDKpbrHv9eXwm8cBeWQYcJmzv5qKCu65P47eCF7CQ==",
+			"dev": true
+		},
 		"@babel/helper-validator-identifier": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
-			"integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
+			"version": "7.24.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.5.tgz",
+			"integrity": "sha512-3q93SSKX2TWCG30M2G2kwaKeTYgEUp5Snjuj8qm729SObL6nbtUldAi37qbxkD5gg3xnBio+f9nqpSepGZMvxA==",
 			"dev": true
 		},
 		"@babel/helpers": {
@@ -11471,20 +11220,21 @@
 			}
 		},
 		"@babel/highlight": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
-			"integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+			"version": "7.24.5",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.5.tgz",
+			"integrity": "sha512-8lLmua6AVh/8SLJRRVD6V8p73Hir9w5mJrhE+IPpILG31KKlI9iz5zmBYKcWPS59qSfgP9RaSBQSHHE81WKuEw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-validator-identifier": "^7.10.4",
-				"chalk": "^2.0.0",
-				"js-tokens": "^4.0.0"
+				"@babel/helper-validator-identifier": "^7.24.5",
+				"chalk": "^2.4.2",
+				"js-tokens": "^4.0.0",
+				"picocolors": "^1.0.0"
 			}
 		},
 		"@babel/parser": {
-			"version": "7.12.7",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.7.tgz",
-			"integrity": "sha512-oWR02Ubp4xTLCAqPRiNIuMVgNO5Aif/xpXtabhzW2HWUD47XJsAB4Zd/Rg30+XeQA3juXigV7hlquOTmwqLiwg==",
+			"version": "7.24.5",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.5.tgz",
+			"integrity": "sha512-EOv5IK8arwh3LI47dz1b0tKUb/1uhHAnHJOrjgtQMIpu1uXd9mlFrJg9IUgGUgZ41Ch0K8REPTYpO7B76b4vJg==",
 			"dev": true
 		},
 		"@babel/runtime": {
@@ -11497,31 +11247,32 @@
 			}
 		},
 		"@babel/template": {
-			"version": "7.12.7",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.7.tgz",
-			"integrity": "sha512-GkDzmHS6GV7ZeXfJZ0tLRBhZcMcY0/Lnb+eEbXDBfCAcZCjrZKe6p3J4we/D24O9Y8enxWAg1cWwof59yLh2ow==",
+			"version": "7.24.0",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.24.0.tgz",
+			"integrity": "sha512-Bkf2q8lMB0AFpX0NFEqSbx1OkTHf0f+0j82mkw+ZpzBnkk7e9Ql0891vlfgi+kHwOk8tQjiQHpqh4LaSa0fKEA==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.10.4",
-				"@babel/parser": "^7.12.7",
-				"@babel/types": "^7.12.7"
+				"@babel/code-frame": "^7.23.5",
+				"@babel/parser": "^7.24.0",
+				"@babel/types": "^7.24.0"
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.12.9",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.9.tgz",
-			"integrity": "sha512-iX9ajqnLdoU1s1nHt36JDI9KG4k+vmI8WgjK5d+aDTwQbL2fUnzedNedssA645Ede3PM2ma1n8Q4h2ohwXgMXw==",
+			"version": "7.24.5",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.24.5.tgz",
+			"integrity": "sha512-7aaBLeDQ4zYcUFDUD41lJc1fG8+5IU9DaNSJAgal866FGvmD5EbWQgnEC6kO1gGLsX0esNkfnJSndbTXA3r7UA==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.10.4",
-				"@babel/generator": "^7.12.5",
-				"@babel/helper-function-name": "^7.10.4",
-				"@babel/helper-split-export-declaration": "^7.11.0",
-				"@babel/parser": "^7.12.7",
-				"@babel/types": "^7.12.7",
-				"debug": "^4.1.0",
-				"globals": "^11.1.0",
-				"lodash": "^4.17.19"
+				"@babel/code-frame": "^7.24.2",
+				"@babel/generator": "^7.24.5",
+				"@babel/helper-environment-visitor": "^7.22.20",
+				"@babel/helper-function-name": "^7.23.0",
+				"@babel/helper-hoist-variables": "^7.22.5",
+				"@babel/helper-split-export-declaration": "^7.24.5",
+				"@babel/parser": "^7.24.5",
+				"@babel/types": "^7.24.5",
+				"debug": "^4.3.1",
+				"globals": "^11.1.0"
 			},
 			"dependencies": {
 				"globals": {
@@ -11533,13 +11284,13 @@
 			}
 		},
 		"@babel/types": {
-			"version": "7.12.7",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.7.tgz",
-			"integrity": "sha512-MNyI92qZq6jrQkXvtIiykvl4WtoRrVV9MPn+ZfsoEENjiWcBQ3ZSHrkxnJWgWtLX3XXqX5hrSQ+X69wkmesXuQ==",
+			"version": "7.24.5",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.5.tgz",
+			"integrity": "sha512-6mQNsaLeXTw0nxYUYu+NSa4Hx4BlF1x1x8/PMFbiR+GBSr+2DkECc69b8hgy2frEodNcvPffeH8YfWd3LI6jhQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-validator-identifier": "^7.10.4",
-				"lodash": "^4.17.19",
+				"@babel/helper-string-parser": "^7.24.1",
+				"@babel/helper-validator-identifier": "^7.24.5",
 				"to-fast-properties": "^2.0.0"
 			}
 		},
@@ -11958,6 +11709,12 @@
 			"integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
 			"dev": true
 		},
+		"@inquirer/figures": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.1.tgz",
+			"integrity": "sha512-mtup3wVKia3ZwULPHcbs4Mor8Voi+iIXEWD7wCNbIO6lYR62oPCTQyrddi5OMYVXHzeCSoneZwJuS8sBvlEwDw==",
+			"dev": true
+		},
 		"@istanbuljs/load-nyc-config": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -12020,14 +11777,26 @@
 			"dev": true
 		},
 		"@jridgewell/gen-mapping": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
-			"integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
+			"version": "0.3.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
+			"integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
 			"dev": true,
 			"requires": {
-				"@jridgewell/set-array": "^1.0.1",
+				"@jridgewell/set-array": "^1.2.1",
 				"@jridgewell/sourcemap-codec": "^1.4.10",
-				"@jridgewell/trace-mapping": "^0.3.9"
+				"@jridgewell/trace-mapping": "^0.3.24"
+			},
+			"dependencies": {
+				"@jridgewell/trace-mapping": {
+					"version": "0.3.25",
+					"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+					"integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+					"dev": true,
+					"requires": {
+						"@jridgewell/resolve-uri": "^3.1.0",
+						"@jridgewell/sourcemap-codec": "^1.4.14"
+					}
+				}
 			}
 		},
 		"@jridgewell/resolve-uri": {
@@ -12037,9 +11806,9 @@
 			"dev": true
 		},
 		"@jridgewell/set-array": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
-			"integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+			"integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
 			"dev": true
 		},
 		"@jridgewell/source-map": {
@@ -12090,6 +11859,15 @@
 			"dev": true,
 			"requires": {
 				"@lezer/common": "^0.16.0"
+			}
+		},
+		"@ljharb/through": {
+			"version": "2.3.13",
+			"resolved": "https://registry.npmjs.org/@ljharb/through/-/through-2.3.13.tgz",
+			"integrity": "sha512-/gKJun8NNiWGZJkGzI/Ragc53cOdcLNdzjLaIa+GEjguQs0ulsurx8WN0jijdK9yPqDvziX995sMRLyLt1uZMQ==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.7"
 			}
 		},
 		"@nodelib/fs.scandir": {
@@ -12208,8 +11986,8 @@
 			"version": "file:packages/language-server",
 			"requires": {
 				"env-paths": "^2.2.1",
-				"vscode-languageserver": "^7.0.0",
-				"vscode-languageserver-textdocument": "^1.0.1"
+				"vscode-languageserver": "^9.0.1",
+				"vscode-languageserver-textdocument": "^1.0.11"
 			}
 		},
 		"@spyglassmc/locales": {
@@ -12237,30 +12015,6 @@
 					"resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.17.tgz",
 					"integrity": "sha512-HJSUJmni4BeDHhfzn6nF0sVmd1SMezP7/4F0Lq+aXzmp2xm9O7WXrUtHW/CHlYVtZUbByEvWidHqRtcJXGF2Ng==",
 					"dev": true
-				},
-				"fs-extra": {
-					"version": "11.1.1",
-					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
-					"integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
-					"requires": {
-						"graceful-fs": "^4.2.0",
-						"jsonfile": "^6.0.1",
-						"universalify": "^2.0.0"
-					}
-				},
-				"jsonfile": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-					"integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-					"requires": {
-						"graceful-fs": "^4.1.6",
-						"universalify": "^2.0.0"
-					}
-				},
-				"universalify": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-					"integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
 				},
 				"y18n": {
 					"version": "5.0.8",
@@ -12318,6 +12072,12 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
 			"integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+			"dev": true
+		},
+		"@tootallnate/quickjs-emscripten": {
+			"version": "0.23.0",
+			"resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+			"integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
 			"dev": true
 		},
 		"@tsconfig/node10": {
@@ -12440,12 +12200,6 @@
 			"integrity": "sha512-wbw+IDRw/xY/RGy+BL6f4Eey4jsUgHQrMuA4Qj0CSG3x/7C2Oc57pmRoM2z3M4DkylWRz+G1pfX06sCXQm0J+w==",
 			"dev": true
 		},
-		"@types/minimist": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
-			"integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
-			"dev": true
-		},
 		"@types/mocha": {
 			"version": "10.0.1",
 			"resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.1.tgz",
@@ -12477,12 +12231,6 @@
 					}
 				}
 			}
-		},
-		"@types/normalize-package-data": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
-			"integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
-			"dev": true
 		},
 		"@types/pako": {
 			"version": "2.0.0",
@@ -12570,13 +12318,10 @@
 					}
 				},
 				"semver": {
-					"version": "7.3.7",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-					"integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-					"dev": true,
-					"requires": {
-						"lru-cache": "^6.0.0"
-					}
+					"version": "7.6.2",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+					"integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+					"dev": true
 				}
 			}
 		},
@@ -12667,13 +12412,10 @@
 					}
 				},
 				"semver": {
-					"version": "7.5.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
-					"integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
-					"dev": true,
-					"requires": {
-						"lru-cache": "^6.0.0"
-					}
+					"version": "7.6.2",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+					"integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+					"dev": true
 				}
 			}
 		},
@@ -12694,13 +12436,10 @@
 			},
 			"dependencies": {
 				"semver": {
-					"version": "7.5.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
-					"integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
-					"dev": true,
-					"requires": {
-						"lru-cache": "^6.0.0"
-					}
+					"version": "7.6.2",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+					"integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+					"dev": true
 				}
 			}
 		},
@@ -12966,15 +12705,15 @@
 			},
 			"dependencies": {
 				"ajv": {
-					"version": "8.12.0",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-					"integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+					"version": "8.13.0",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.13.0.tgz",
+					"integrity": "sha512-PRA911Blj99jR5RMeTunVbNXMF6Lp4vZXnk5GQjcnUWUTsrXtekg/pnmFFI2u/I36Y/2bITGS30GZCXei6uNkA==",
 					"dev": true,
 					"requires": {
-						"fast-deep-equal": "^3.1.1",
+						"fast-deep-equal": "^3.1.3",
 						"json-schema-traverse": "^1.0.0",
 						"require-from-string": "^2.0.2",
-						"uri-js": "^4.2.2"
+						"uri-js": "^4.4.1"
 					}
 				},
 				"json-schema-traverse": {
@@ -13258,12 +12997,6 @@
 			"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
 			"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="
 		},
-		"arrify": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-			"integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
-			"dev": true
-		},
 		"ast-types": {
 			"version": "0.13.4",
 			"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
@@ -13274,9 +13007,9 @@
 			},
 			"dependencies": {
 				"tslib": {
-					"version": "2.3.1",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-					"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
 					"dev": true
 				}
 			}
@@ -13293,13 +13026,13 @@
 			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
 		},
 		"atomically": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/atomically/-/atomically-2.0.1.tgz",
-			"integrity": "sha512-sxBhVZUFBFhqSAsYMM3X2oaUi2NVDJ8U026FsIusM8gYXls9AYs/eXzgGrufs1Qjpkxi9zunds+75QUFz+m7UQ==",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/atomically/-/atomically-2.0.3.tgz",
+			"integrity": "sha512-kU6FmrwZ3Lx7/7y3hPS5QnbJfaohcIul5fGqf7ok+4KklIEk9tJ0C2IQPdacSbVUWv6zVHXEBWoWd6NrVMT7Cw==",
 			"dev": true,
 			"requires": {
-				"stubborn-fs": "^1.2.4",
-				"when-exit": "^2.0.0"
+				"stubborn-fs": "^1.2.5",
+				"when-exit": "^2.1.1"
 			}
 		},
 		"balanced-match": {
@@ -13317,6 +13050,12 @@
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
 			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+		},
+		"basic-ftp": {
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.5.tgz",
+			"integrity": "sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==",
+			"dev": true
 		},
 		"benchmark": {
 			"version": "2.1.4",
@@ -13567,12 +13306,6 @@
 			"integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s=",
 			"dev": true
 		},
-		"bytes": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.1.tgz",
-			"integrity": "sha512-dWe4nWO/ruEOY7HkUJ5gFt1DCFV9zPRoJr8pV0/ASQermOZjtq8jMjOprC0Kd10GLN+l7xaUPvxzJFWtxGu8Fg==",
-			"dev": true
-		},
 		"cacheable-lookup": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
@@ -13606,6 +13339,19 @@
 				"write-file-atomic": "^3.0.0"
 			}
 		},
+		"call-bind": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
+			"integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
+			"dev": true,
+			"requires": {
+				"es-define-property": "^1.0.0",
+				"es-errors": "^1.3.0",
+				"function-bind": "^1.1.2",
+				"get-intrinsic": "^1.2.4",
+				"set-function-length": "^1.2.1"
+			}
+		},
 		"callsites": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -13617,32 +13363,6 @@
 			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
 			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
 			"dev": true
-		},
-		"camelcase-keys": {
-			"version": "8.0.2",
-			"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-8.0.2.tgz",
-			"integrity": "sha512-qMKdlOfsjlezMqxkUGGMaWWs17i2HoL15tM+wtx8ld4nLrUwU58TFdvyGOz/piNP842KeO8yXvggVQSdQ828NA==",
-			"dev": true,
-			"requires": {
-				"camelcase": "^7.0.0",
-				"map-obj": "^4.3.0",
-				"quick-lru": "^6.1.1",
-				"type-fest": "^2.13.0"
-			},
-			"dependencies": {
-				"camelcase": {
-					"version": "7.0.1",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-7.0.1.tgz",
-					"integrity": "sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw==",
-					"dev": true
-				},
-				"type-fest": {
-					"version": "2.19.0",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-					"integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-					"dev": true
-				}
-			}
 		},
 		"caniuse-lite": {
 			"version": "1.0.30001228",
@@ -13748,9 +13468,9 @@
 			}
 		},
 		"cli-spinners": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.7.0.tgz",
-			"integrity": "sha512-qu3pN8Y3qHNgE2AFweciB1IfMnmZ/fsNTEE+NOFjmGB2F/7rLhnhzppvpCnN4FovtP26k8lHyy9ptEbNwWFLzw==",
+			"version": "2.9.2",
+			"resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+			"integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
 			"dev": true
 		},
 		"cli-width": {
@@ -13813,7 +13533,7 @@
 		"color-name": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
 			"dev": true
 		},
 		"colorette": {
@@ -13854,9 +13574,9 @@
 			"dev": true
 		},
 		"conf": {
-			"version": "11.0.1",
-			"resolved": "https://registry.npmjs.org/conf/-/conf-11.0.1.tgz",
-			"integrity": "sha512-WlLiQboEjKx0bYx2IIRGedBgNjLAxtwPaCSnsjWPST5xR0DB4q8lcsO/bEH9ZRYNcj63Y9vj/JG/5Fg6uWzI0Q==",
+			"version": "11.0.2",
+			"resolved": "https://registry.npmjs.org/conf/-/conf-11.0.2.tgz",
+			"integrity": "sha512-jjyhlQ0ew/iwmtwsS2RaB6s8DBifcE2GYBEaw2SJDUY/slJJbNfY4GlDVzOs/ff8cM/Wua5CikqXgbFl5eu85A==",
 			"dev": true,
 			"requires": {
 				"ajv": "^8.12.0",
@@ -13870,15 +13590,15 @@
 			},
 			"dependencies": {
 				"ajv": {
-					"version": "8.12.0",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-					"integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+					"version": "8.13.0",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.13.0.tgz",
+					"integrity": "sha512-PRA911Blj99jR5RMeTunVbNXMF6Lp4vZXnk5GQjcnUWUTsrXtekg/pnmFFI2u/I36Y/2bITGS30GZCXei6uNkA==",
 					"dev": true,
 					"requires": {
-						"fast-deep-equal": "^3.1.1",
+						"fast-deep-equal": "^3.1.3",
 						"json-schema-traverse": "^1.0.0",
 						"require-from-string": "^2.0.2",
-						"uri-js": "^4.2.2"
+						"uri-js": "^4.4.1"
 					}
 				},
 				"env-paths": {
@@ -13894,13 +13614,10 @@
 					"dev": true
 				},
 				"semver": {
-					"version": "7.3.8",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-					"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-					"dev": true,
-					"requires": {
-						"lru-cache": "^6.0.0"
-					}
+					"version": "7.6.2",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+					"integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+					"dev": true
 				}
 			}
 		},
@@ -14020,9 +13737,9 @@
 			}
 		},
 		"data-uri-to-buffer": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz",
-			"integrity": "sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+			"integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
 			"dev": true
 		},
 		"datapack-language-server": {
@@ -14030,7 +13747,7 @@
 			"requires": {
 				"@types/vscode": "1.67.0",
 				"esbuild": "^0.17.18",
-				"vscode-languageclient": "^8.0.1",
+				"vscode-languageclient": "^9.0.1",
 				"vscode-test": "^1.5.2"
 			}
 		},
@@ -14057,24 +13774,6 @@
 			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
 			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
 			"dev": true
-		},
-		"decamelize-keys": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.1.tgz",
-			"integrity": "sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==",
-			"dev": true,
-			"requires": {
-				"decamelize": "^1.1.0",
-				"map-obj": "^1.0.0"
-			},
-			"dependencies": {
-				"map-obj": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-					"integrity": "sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==",
-					"dev": true
-				}
-			}
 		},
 		"decompress": {
 			"version": "4.2.1",
@@ -14274,28 +13973,32 @@
 			"integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
 			"dev": true
 		},
-		"degenerator": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/degenerator/-/degenerator-3.0.1.tgz",
-			"integrity": "sha512-LFsIFEeLPlKvAKXu7j3ssIG6RT0TbI7/GhsqrI0DnHASEQjXQ0LUSYcjJteGgRGmZbl1TnMSxpNQIAiJ7Du5TQ==",
+		"define-data-property": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+			"integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
 			"dev": true,
 			"requires": {
-				"ast-types": "^0.13.2",
-				"escodegen": "^1.8.1",
-				"esprima": "^4.0.0",
-				"vm2": "^3.9.3"
+				"es-define-property": "^1.0.0",
+				"es-errors": "^1.3.0",
+				"gopd": "^1.0.1"
+			}
+		},
+		"degenerator": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+			"integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+			"dev": true,
+			"requires": {
+				"ast-types": "^0.13.4",
+				"escodegen": "^2.1.0",
+				"esprima": "^4.0.1"
 			}
 		},
 		"delayed-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
 			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
-		},
-		"depd": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-			"integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
-			"dev": true
 		},
 		"didyoumean": {
 			"version": "1.2.1",
@@ -14483,14 +14186,20 @@
 			"integrity": "sha512-/o+BXHmB7ocbHEAs6F2EnG0ogybVVUdkRunTT2glZU9XAaGmhqskrvKwqXuDfNjEO0LZKWdejEEpnq8aM0tOaw==",
 			"dev": true
 		},
-		"error-ex": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-			"integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+		"es-define-property": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
+			"integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
 			"dev": true,
 			"requires": {
-				"is-arrayish": "^0.2.1"
+				"get-intrinsic": "^1.2.4"
 			}
+		},
+		"es-errors": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+			"integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+			"dev": true
 		},
 		"es-module-lexer": {
 			"version": "1.2.1",
@@ -14561,46 +14270,21 @@
 			"dev": true
 		},
 		"escodegen": {
-			"version": "1.14.3",
-			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
-			"integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+			"integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
 			"dev": true,
 			"requires": {
 				"esprima": "^4.0.1",
-				"estraverse": "^4.2.0",
+				"estraverse": "^5.2.0",
 				"esutils": "^2.0.2",
-				"optionator": "^0.8.1",
 				"source-map": "~0.6.1"
 			},
 			"dependencies": {
-				"levn": {
-					"version": "0.3.0",
-					"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-					"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-					"dev": true,
-					"requires": {
-						"prelude-ls": "~1.1.2",
-						"type-check": "~0.3.2"
-					}
-				},
-				"optionator": {
-					"version": "0.8.3",
-					"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
-					"integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
-					"dev": true,
-					"requires": {
-						"deep-is": "~0.1.3",
-						"fast-levenshtein": "~2.0.6",
-						"levn": "~0.3.0",
-						"prelude-ls": "~1.1.2",
-						"type-check": "~0.3.2",
-						"word-wrap": "~1.2.3"
-					}
-				},
-				"prelude-ls": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-					"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+				"estraverse": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+					"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
 					"dev": true
 				},
 				"source-map": {
@@ -14609,15 +14293,6 @@
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 					"dev": true,
 					"optional": true
-				},
-				"type-check": {
-					"version": "0.3.2",
-					"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-					"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-					"dev": true,
-					"requires": {
-						"prelude-ls": "~1.1.2"
-					}
 				}
 			}
 		},
@@ -14926,22 +14601,28 @@
 			"dev": true
 		},
 		"execa": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/execa/-/execa-7.1.1.tgz",
-			"integrity": "sha512-wH0eMf/UXckdUYnO21+HDztteVv05rq2GXksxT4fCGeHkBhw1DROXh40wcjMcRqDOWE7iPJ4n3M7e2+YFP+76Q==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+			"integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
 			"dev": true,
 			"requires": {
 				"cross-spawn": "^7.0.3",
-				"get-stream": "^6.0.1",
-				"human-signals": "^4.3.0",
+				"get-stream": "^8.0.1",
+				"human-signals": "^5.0.0",
 				"is-stream": "^3.0.0",
 				"merge-stream": "^2.0.0",
 				"npm-run-path": "^5.1.0",
 				"onetime": "^6.0.0",
-				"signal-exit": "^3.0.7",
+				"signal-exit": "^4.1.0",
 				"strip-final-newline": "^3.0.0"
 			},
 			"dependencies": {
+				"get-stream": {
+					"version": "8.0.1",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+					"integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+					"dev": true
+				},
 				"is-stream": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
@@ -14956,6 +14637,12 @@
 					"requires": {
 						"mimic-fn": "^4.0.0"
 					}
+				},
+				"signal-exit": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+					"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+					"dev": true
 				}
 			}
 		},
@@ -15060,12 +14747,6 @@
 				"flat-cache": "^3.0.4"
 			}
 		},
-		"file-uri-to-path": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-2.0.0.tgz",
-			"integrity": "sha512-hjPFI8oE/2iQPVe4gbrJ73Pp+Xfub2+WI2LlXDbsaJBwT5wuMh35WNWVYYTpnz895shtwfyutMFLFywpQAFdLg==",
-			"dev": true
-		},
 		"fill-range": {
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -15130,16 +14811,6 @@
 				}
 			}
 		},
-		"find-up": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/find-up/-/find-up-6.3.0.tgz",
-			"integrity": "sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==",
-			"dev": true,
-			"requires": {
-				"locate-path": "^7.1.0",
-				"path-exists": "^5.0.0"
-			}
-		},
 		"flat": {
 			"version": "5.0.2",
 			"resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
@@ -15180,9 +14851,9 @@
 			"dev": true
 		},
 		"follow-redirects": {
-			"version": "1.14.8",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.8.tgz",
-			"integrity": "sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA=="
+			"version": "1.15.6",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+			"integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA=="
 		},
 		"foreground-child": {
 			"version": "2.0.0",
@@ -15231,14 +14902,13 @@
 			"integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
 		},
 		"fs-extra": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-			"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-			"dev": true,
+			"version": "11.2.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+			"integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
 			"requires": {
 				"graceful-fs": "^4.2.0",
-				"jsonfile": "^4.0.0",
-				"universalify": "^0.1.0"
+				"jsonfile": "^6.0.1",
+				"universalify": "^2.0.0"
 			}
 		},
 		"fs.realpath": {
@@ -15265,46 +14935,10 @@
 				"rimraf": "2"
 			}
 		},
-		"ftp": {
-			"version": "0.3.10",
-			"resolved": "https://registry.npmjs.org/ftp/-/ftp-0.3.10.tgz",
-			"integrity": "sha1-kZfYYa2BQvPmPVqDv+TFn3MwiF0=",
-			"dev": true,
-			"requires": {
-				"readable-stream": "1.1.x",
-				"xregexp": "2.0.0"
-			},
-			"dependencies": {
-				"isarray": {
-					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-					"dev": true
-				},
-				"readable-stream": {
-					"version": "1.1.14",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-					"integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-					"dev": true,
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.1",
-						"isarray": "0.0.1",
-						"string_decoder": "~0.10.x"
-					}
-				},
-				"string_decoder": {
-					"version": "0.10.31",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-					"dev": true
-				}
-			}
-		},
 		"function-bind": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
 			"dev": true
 		},
 		"fuse.js": {
@@ -15324,6 +14958,19 @@
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
 			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
 		},
+		"get-intrinsic": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
+			"integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
+			"dev": true,
+			"requires": {
+				"es-errors": "^1.3.0",
+				"function-bind": "^1.1.2",
+				"has-proto": "^1.0.1",
+				"has-symbols": "^1.0.3",
+				"hasown": "^2.0.0"
+			}
+		},
 		"get-package-type": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
@@ -15337,38 +14984,47 @@
 			"dev": true
 		},
 		"get-uri": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/get-uri/-/get-uri-3.0.2.tgz",
-			"integrity": "sha512-+5s0SJbGoyiJTZZ2JTpFPLMPSch72KEqGOTvQsBqg0RBWvwhWUSYZFAtz3TPW0GXJuLBJPts1E241iHg+VRfhg==",
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.3.tgz",
+			"integrity": "sha512-BzUrJBS9EcUb4cFol8r4W3v1cPsSyajLSthNkz5BxbpDcHN5tIrM10E2eNvfnvBn3DaT3DUgx0OpsBKkaOpanw==",
 			"dev": true,
 			"requires": {
-				"@tootallnate/once": "1",
-				"data-uri-to-buffer": "3",
-				"debug": "4",
-				"file-uri-to-path": "2",
-				"fs-extra": "^8.1.0",
-				"ftp": "^0.3.10"
+				"basic-ftp": "^5.0.2",
+				"data-uri-to-buffer": "^6.0.2",
+				"debug": "^4.3.4",
+				"fs-extra": "^11.2.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.3.4",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+					"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+					"dev": true,
+					"requires": {
+						"ms": "2.1.2"
+					}
+				}
 			}
 		},
 		"gitmoji-cli": {
-			"version": "8.1.1",
-			"resolved": "https://registry.npmjs.org/gitmoji-cli/-/gitmoji-cli-8.1.1.tgz",
-			"integrity": "sha512-lEt1/o151KUZ3E73ipQCQPqNXfJvK2Krm8X3poQqxQH5Xw/20gt8MME/VIf8WKG9ylYEs3EKOp30gdRoUI1vbg==",
+			"version": "8.5.0",
+			"resolved": "https://registry.npmjs.org/gitmoji-cli/-/gitmoji-cli-8.5.0.tgz",
+			"integrity": "sha512-ZSplvgm8UiAjsWBOxYAfbLj8JTMFj5TjB6yM7RFlqEfsFMgP0fhIPpgnHU5aMiyVyvX6jBRVf1hzjrmP3/cgiA==",
 			"dev": true,
 			"requires": {
-				"chalk": "^5.0.1",
-				"conf": "11.0.1",
-				"execa": "^7.1.1",
+				"chalk": "^5.3.0",
+				"conf": "11.0.2",
+				"execa": "^8.0.1",
 				"fuse.js": "6.6.2",
-				"inquirer": "^9.1.5",
+				"inquirer": "^9.2.10",
 				"inquirer-autocomplete-prompt": "^3.0.0",
-				"meow": "^11.0.0",
-				"node-fetch": "^3.3.1",
-				"ora": "^6.3.0",
+				"meow": "^12.1.1",
+				"node-fetch": "^3.3.2",
+				"ora": "^7.0.1",
 				"path-exists": "^5.0.0",
-				"proxy-agent": "5.0.0",
+				"proxy-agent": "^6.3.1",
 				"update-notifier": "^6.0.2",
-				"validator": "^13.9.0"
+				"validator": "^13.11.0"
 			},
 			"dependencies": {
 				"ansi-escapes": {
@@ -15381,48 +15037,62 @@
 					}
 				},
 				"ansi-regex": {
-					"version": "6.0.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-					"integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+					"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
 					"dev": true
 				},
 				"ansi-styles": {
-					"version": "6.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-					"integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
-					"dev": true
-				},
-				"chalk": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.2.0.tgz",
-					"integrity": "sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA==",
-					"dev": true
-				},
-				"cli-cursor": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
-					"integrity": "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 					"dev": true,
 					"requires": {
-						"restore-cursor": "^4.0.0"
+						"color-convert": "^2.0.1"
 					}
 				},
+				"bl": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+					"integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+					"dev": true,
+					"requires": {
+						"buffer": "^5.5.0",
+						"inherits": "^2.0.4",
+						"readable-stream": "^3.4.0"
+					}
+				},
+				"chalk": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+					"integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+					"dev": true
+				},
 				"cli-width": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.0.0.tgz",
-					"integrity": "sha512-ZksGS2xpa/bYkNzN3BAw1wEjsLV/ZKOf/CCrJ/QOBsxx6fOARIkwTutxp1XIOIohi6HKmOFjMoK/XaqDVUpEEw==",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+					"integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+					"dev": true
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 					"dev": true
 				},
 				"data-uri-to-buffer": {
 					"version": "4.0.1",
 					"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
 					"integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-					"dev": true
-				},
-				"emoji-regex": {
-					"version": "9.2.2",
-					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-					"integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
 					"dev": true
 				},
 				"escape-string-regexp": {
@@ -15441,27 +15111,91 @@
 						"is-unicode-supported": "^1.2.0"
 					}
 				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
 				"inquirer": {
-					"version": "9.2.0",
-					"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-9.2.0.tgz",
-					"integrity": "sha512-WWERbVqjsTXjXub1ZW0ZHDit1dyHqy0T9XIkky9TnmKAPrjU9Jkd59nZPK0dUuM3s73GZAZu2Jo4iFU3XSPVLA==",
+					"version": "9.2.21",
+					"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-9.2.21.tgz",
+					"integrity": "sha512-c/dwDruM1FtzeISV+xMHm+JZTmhpmgWPEZI2bU3+Fwu5MhbAX0zMHHxj5warNfttE5NUID3aijrFUpDc2yBvcA==",
 					"dev": true,
 					"requires": {
-						"ansi-escapes": "^6.0.0",
-						"chalk": "^5.2.0",
-						"cli-cursor": "^4.0.0",
-						"cli-width": "^4.0.0",
-						"external-editor": "^3.0.3",
-						"figures": "^5.0.0",
+						"@inquirer/figures": "^1.0.1",
+						"@ljharb/through": "^2.3.13",
+						"ansi-escapes": "^4.3.2",
+						"chalk": "^5.3.0",
+						"cli-cursor": "^3.1.0",
+						"cli-width": "^4.1.0",
+						"external-editor": "^3.1.0",
 						"lodash": "^4.17.21",
 						"mute-stream": "1.0.0",
-						"ora": "^6.1.2",
-						"run-async": "^2.4.0",
-						"rxjs": "^7.8.0",
-						"string-width": "^5.1.2",
-						"strip-ansi": "^7.0.1",
-						"through": "^2.3.6",
-						"wrap-ansi": "^8.1.0"
+						"ora": "^5.4.1",
+						"run-async": "^3.0.0",
+						"rxjs": "^7.8.1",
+						"string-width": "^4.2.3",
+						"strip-ansi": "^6.0.1",
+						"wrap-ansi": "^6.2.0"
+					},
+					"dependencies": {
+						"ansi-escapes": {
+							"version": "4.3.2",
+							"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+							"integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+							"dev": true,
+							"requires": {
+								"type-fest": "^0.21.3"
+							}
+						},
+						"is-unicode-supported": {
+							"version": "0.1.0",
+							"resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+							"integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+							"dev": true
+						},
+						"ora": {
+							"version": "5.4.1",
+							"resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+							"integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+							"dev": true,
+							"requires": {
+								"bl": "^4.1.0",
+								"chalk": "^4.1.0",
+								"cli-cursor": "^3.1.0",
+								"cli-spinners": "^2.5.0",
+								"is-interactive": "^1.0.0",
+								"is-unicode-supported": "^0.1.0",
+								"log-symbols": "^4.1.0",
+								"strip-ansi": "^6.0.0",
+								"wcwidth": "^1.0.1"
+							},
+							"dependencies": {
+								"chalk": {
+									"version": "4.1.2",
+									"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+									"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+									"dev": true,
+									"requires": {
+										"ansi-styles": "^4.1.0",
+										"supports-color": "^7.1.0"
+									}
+								}
+							}
+						},
+						"run-async": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/run-async/-/run-async-3.0.0.tgz",
+							"integrity": "sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q==",
+							"dev": true
+						},
+						"type-fest": {
+							"version": "0.21.3",
+							"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+							"integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+							"dev": true
+						}
 					}
 				},
 				"inquirer-autocomplete-prompt": {
@@ -15477,6 +15211,12 @@
 						"rxjs": "^7.5.6"
 					}
 				},
+				"is-interactive": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+					"integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+					"dev": true
+				},
 				"is-unicode-supported": {
 					"version": "1.3.0",
 					"resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
@@ -15490,9 +15230,9 @@
 					"dev": true
 				},
 				"node-fetch": {
-					"version": "3.3.1",
-					"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.1.tgz",
-					"integrity": "sha512-cRVc/kyto/7E5shrWca1Wsea4y6tL9iYJE5FBCius3JQfb/4P4I295PfhgbJQBLTx6lATE4z+wK0rPM4VS2uow==",
+					"version": "3.3.2",
+					"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+					"integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
 					"dev": true,
 					"requires": {
 						"data-uri-to-buffer": "^4.0.0",
@@ -15500,43 +15240,42 @@
 						"formdata-polyfill": "^4.0.10"
 					}
 				},
-				"restore-cursor": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
-					"integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
+				"readable-stream": {
+					"version": "3.6.2",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+					"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
 					"dev": true,
 					"requires": {
-						"onetime": "^5.1.0",
-						"signal-exit": "^3.0.2"
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
 					}
 				},
 				"rxjs": {
-					"version": "7.8.0",
-					"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.0.tgz",
-					"integrity": "sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==",
+					"version": "7.8.1",
+					"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+					"integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
 					"dev": true,
 					"requires": {
 						"tslib": "^2.1.0"
 					}
 				},
-				"string-width": {
-					"version": "5.1.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-					"integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+				"strip-ansi": {
+					"version": "6.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+					"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
 					"dev": true,
 					"requires": {
-						"eastasianwidth": "^0.2.0",
-						"emoji-regex": "^9.2.2",
-						"strip-ansi": "^7.0.1"
+						"ansi-regex": "^5.0.1"
 					}
 				},
-				"strip-ansi": {
-					"version": "7.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
-					"integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^6.0.1"
+						"has-flag": "^4.0.0"
 					}
 				},
 				"tslib": {
@@ -15552,14 +15291,14 @@
 					"dev": true
 				},
 				"wrap-ansi": {
-					"version": "8.1.0",
-					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-					"integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+					"version": "6.2.0",
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+					"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^6.1.0",
-						"string-width": "^5.0.1",
-						"strip-ansi": "^7.0.1"
+						"ansi-styles": "^4.0.0",
+						"string-width": "^4.1.0",
+						"strip-ansi": "^6.0.0"
 					}
 				}
 			}
@@ -15631,6 +15370,15 @@
 				"slash": "^3.0.0"
 			}
 		},
+		"gopd": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+			"integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+			"dev": true,
+			"requires": {
+				"get-intrinsic": "^1.1.3"
+			}
+		},
 		"got": {
 			"version": "12.6.0",
 			"resolved": "https://registry.npmjs.org/got/-/got-12.6.0.tgz",
@@ -15661,12 +15409,6 @@
 			"integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
 			"dev": true
 		},
-		"hard-rejection": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
-			"integrity": "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==",
-			"dev": true
-		},
 		"has": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -15688,13 +15430,34 @@
 		"has-flag": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+			"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
 			"dev": true
 		},
 		"has-only": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/has-only/-/has-only-1.1.1.tgz",
 			"integrity": "sha512-3GuFy9rDw0xvovCHb4SOKiRImbZ+a8boFBUyGNRPVd2mRyQOzYdau5G9nodUXC1ZKYN59hrHFkW1lgBQscYfTg==",
+			"dev": true
+		},
+		"has-property-descriptors": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+			"integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+			"dev": true,
+			"requires": {
+				"es-define-property": "^1.0.0"
+			}
+		},
+		"has-proto": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
+			"integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
+			"dev": true
+		},
+		"has-symbols": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+			"integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
 			"dev": true
 		},
 		"has-yarn": {
@@ -15713,28 +15476,20 @@
 				"type-fest": "^0.8.0"
 			}
 		},
+		"hasown": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+			"integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+			"dev": true,
+			"requires": {
+				"function-bind": "^1.1.2"
+			}
+		},
 		"he": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
 			"integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
 			"dev": true
-		},
-		"hosted-git-info": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-5.2.1.tgz",
-			"integrity": "sha512-xIcQYMnhcx2Nr4JTjsFmwwnr9vldugPy9uVm0o87bjqqWMv9GaqsTeT+i99wTl0mk1uLxJtHxLb8kymqTENQsw==",
-			"dev": true,
-			"requires": {
-				"lru-cache": "^7.5.1"
-			},
-			"dependencies": {
-				"lru-cache": {
-					"version": "7.18.3",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-					"integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
-					"dev": true
-				}
-			}
 		},
 		"html-escaper": {
 			"version": "2.0.2",
@@ -15747,19 +15502,6 @@
 			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
 			"integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
 			"dev": true
-		},
-		"http-errors": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
-			"integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
-			"dev": true,
-			"requires": {
-				"depd": "~1.1.2",
-				"inherits": "2.0.4",
-				"setprototypeof": "1.2.0",
-				"statuses": ">= 1.5.0 < 2",
-				"toidentifier": "1.0.1"
-			}
 		},
 		"http-proxy-agent": {
 			"version": "4.0.1",
@@ -15801,9 +15543,9 @@
 			}
 		},
 		"human-signals": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-4.3.1.tgz",
-			"integrity": "sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+			"integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
 			"dev": true
 		},
 		"iconv-lite": {
@@ -15967,17 +15709,23 @@
 			"integrity": "sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==",
 			"dev": true
 		},
-		"ip": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
-			"integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
-			"dev": true
-		},
-		"is-arrayish": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-			"integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-			"dev": true
+		"ip-address": {
+			"version": "9.0.5",
+			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
+			"integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+			"dev": true,
+			"requires": {
+				"jsbn": "1.1.0",
+				"sprintf-js": "^1.1.3"
+			},
+			"dependencies": {
+				"sprintf-js": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+					"integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+					"dev": true
+				}
+			}
 		},
 		"is-binary-path": {
 			"version": "2.1.0",
@@ -16065,12 +15813,6 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
 			"integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
-			"dev": true
-		},
-		"is-plain-obj": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-			"integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
 			"dev": true
 		},
 		"is-plain-object": {
@@ -16304,6 +16046,12 @@
 				"esprima": "^4.0.0"
 			}
 		},
+		"jsbn": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+			"integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
+			"dev": true
+		},
 		"jsesc": {
 			"version": "2.5.2",
 			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -16415,12 +16163,12 @@
 			"dev": true
 		},
 		"jsonfile": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-			"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-			"dev": true,
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+			"integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
 			"requires": {
-				"graceful-fs": "^4.1.6"
+				"graceful-fs": "^4.1.6",
+				"universalify": "^2.0.0"
 			}
 		},
 		"keyv": {
@@ -16487,12 +16235,6 @@
 				}
 			}
 		},
-		"lines-and-columns": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-			"integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-			"dev": true
-		},
 		"listenercount": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
@@ -16514,15 +16256,6 @@
 				"big.js": "^5.2.2",
 				"emojis-list": "^3.0.0",
 				"json5": "^2.1.2"
-			}
-		},
-		"locate-path": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.2.0.tgz",
-			"integrity": "sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==",
-			"dev": true,
-			"requires": {
-				"p-locate": "^6.0.0"
 			}
 		},
 		"lodash": {
@@ -16610,15 +16343,6 @@
 			"integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==",
 			"dev": true
 		},
-		"lru-cache": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-			"dev": true,
-			"requires": {
-				"yallist": "^4.0.0"
-			}
-		},
 		"make-dir": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -16634,51 +16358,11 @@
 			"integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
 			"dev": true
 		},
-		"map-obj": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
-			"integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
-			"dev": true
-		},
 		"meow": {
-			"version": "11.0.0",
-			"resolved": "https://registry.npmjs.org/meow/-/meow-11.0.0.tgz",
-			"integrity": "sha512-Cl0yeeIrko6d94KpUo1M+0X1sB14ikoaqlIGuTH1fW4I+E3+YljL54/hb/BWmVfrV9tTV9zU04+xjw08Fh2WkA==",
-			"dev": true,
-			"requires": {
-				"@types/minimist": "^1.2.2",
-				"camelcase-keys": "^8.0.2",
-				"decamelize": "^6.0.0",
-				"decamelize-keys": "^1.1.0",
-				"hard-rejection": "^2.1.0",
-				"minimist-options": "4.1.0",
-				"normalize-package-data": "^4.0.1",
-				"read-pkg-up": "^9.1.0",
-				"redent": "^4.0.0",
-				"trim-newlines": "^4.0.2",
-				"type-fest": "^3.1.0",
-				"yargs-parser": "^21.1.1"
-			},
-			"dependencies": {
-				"decamelize": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-6.0.0.tgz",
-					"integrity": "sha512-Fv96DCsdOgB6mdGl67MT5JaTNKRzrzill5OH5s8bjYJXVlcXyPYGyPsUkWyGV5p1TXI5esYIYMMeDJL0hEIwaA==",
-					"dev": true
-				},
-				"type-fest": {
-					"version": "3.6.1",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.6.1.tgz",
-					"integrity": "sha512-htXWckxlT6U4+ilVgweNliPqlsVSSucbxVexRYllyMVJDtf5rTjv6kF/s+qAd4QSL1BZcnJPEJavYBPQiWuZDA==",
-					"dev": true
-				},
-				"yargs-parser": {
-					"version": "21.1.1",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-					"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-					"dev": true
-				}
-			}
+			"version": "12.1.1",
+			"resolved": "https://registry.npmjs.org/meow/-/meow-12.1.1.tgz",
+			"integrity": "sha512-BhXM0Au22RwUneMPwSCnyhTOizdWoIEPU9sp0Aqa1PnDMR5Wv2FGXYDjuzJEIX+Eo2Rb8xuYe5jrnm5QowQFkw==",
+			"dev": true
 		},
 		"merge-stream": {
 			"version": "2.0.0",
@@ -16725,12 +16409,6 @@
 			"integrity": "sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==",
 			"dev": true
 		},
-		"min-indent": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
-			"integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
-			"dev": true
-		},
 		"minimatch": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -16745,17 +16423,6 @@
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
 			"integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
 			"dev": true
-		},
-		"minimist-options": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.1.0.tgz",
-			"integrity": "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==",
-			"dev": true,
-			"requires": {
-				"arrify": "^1.0.1",
-				"is-plain-obj": "^1.1.0",
-				"kind-of": "^6.0.3"
-			}
 		},
 		"mkdirp": {
 			"version": "0.5.5",
@@ -17003,29 +16670,6 @@
 			"integrity": "sha512-LLUo+PpH3dU6XizX3iVoubUNheF/owjXCZZ5yACDxNnPtgFuludV1ZL3ayK1kVep42Rmm0+R9/Y60NQbZ2bifw==",
 			"dev": true
 		},
-		"normalize-package-data": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-4.0.1.tgz",
-			"integrity": "sha512-EBk5QKKuocMJhB3BILuKhmaPjI8vNRSpIfO9woLC6NyHVkKKdVEdAO1mrT0ZfxNR1lKwCcTkuZfmGIFdizZ8Pg==",
-			"dev": true,
-			"requires": {
-				"hosted-git-info": "^5.0.0",
-				"is-core-module": "^2.8.1",
-				"semver": "^7.3.5",
-				"validate-npm-package-license": "^3.0.4"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "7.3.8",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-					"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-					"dev": true,
-					"requires": {
-						"lru-cache": "^6.0.0"
-					}
-				}
-			}
-		},
 		"normalize-path": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -17038,9 +16682,9 @@
 			"dev": true
 		},
 		"npm-run-path": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz",
-			"integrity": "sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==",
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+			"integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
 			"dev": true,
 			"requires": {
 				"path-key": "^4.0.0"
@@ -17284,20 +16928,20 @@
 			}
 		},
 		"ora": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/ora/-/ora-6.3.0.tgz",
-			"integrity": "sha512-1/D8uRFY0ay2kgBpmAwmSA404w4OoPVhHMqRqtjvrcK/dnzcEZxMJ+V4DUbyICu8IIVRclHcOf5wlD1tMY4GUQ==",
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/ora/-/ora-7.0.1.tgz",
+			"integrity": "sha512-0TUxTiFJWv+JnjWm4o9yvuskpEJLXTcng8MJuKd+SzAzp2o+OP3HWqNhB4OdJRt1Vsd9/mR0oyaEYlOnL7XIRw==",
 			"dev": true,
 			"requires": {
-				"chalk": "^5.0.0",
+				"chalk": "^5.3.0",
 				"cli-cursor": "^4.0.0",
-				"cli-spinners": "^2.6.1",
+				"cli-spinners": "^2.9.0",
 				"is-interactive": "^2.0.0",
-				"is-unicode-supported": "^1.1.0",
+				"is-unicode-supported": "^1.3.0",
 				"log-symbols": "^5.1.0",
 				"stdin-discarder": "^0.1.0",
-				"strip-ansi": "^7.0.1",
-				"wcwidth": "^1.0.1"
+				"string-width": "^6.1.0",
+				"strip-ansi": "^7.1.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -17307,9 +16951,9 @@
 					"dev": true
 				},
 				"chalk": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.2.0.tgz",
-					"integrity": "sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA==",
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+					"integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
 					"dev": true
 				},
 				"cli-cursor": {
@@ -17320,6 +16964,12 @@
 					"requires": {
 						"restore-cursor": "^4.0.0"
 					}
+				},
+				"emoji-regex": {
+					"version": "10.3.0",
+					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.3.0.tgz",
+					"integrity": "sha512-QpLs9D9v9kArv4lfDEgg1X/gN5XLnf/A6l9cs8SPZLRZR3ZkY9+kwIQTxm+fsSej5UMYGE8fdoaZVIBlqG0XTw==",
+					"dev": true
 				},
 				"is-unicode-supported": {
 					"version": "1.3.0",
@@ -17347,10 +16997,21 @@
 						"signal-exit": "^3.0.2"
 					}
 				},
+				"string-width": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-6.1.0.tgz",
+					"integrity": "sha512-k01swCJAgQmuADB0YIc+7TuatfNvTBVOoaUWJjTB9R4VJzR5vNWzf5t42ESVZFPS8xTySF7CAdV4t/aaIm3UnQ==",
+					"dev": true,
+					"requires": {
+						"eastasianwidth": "^0.2.0",
+						"emoji-regex": "^10.2.1",
+						"strip-ansi": "^7.0.1"
+					}
+				},
 				"strip-ansi": {
-					"version": "7.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
-					"integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+					"integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
 					"dev": true,
 					"requires": {
 						"ansi-regex": "^6.0.1"
@@ -17379,32 +17040,6 @@
 				"p-try": "^2.0.0"
 			}
 		},
-		"p-locate": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-6.0.0.tgz",
-			"integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
-			"dev": true,
-			"requires": {
-				"p-limit": "^4.0.0"
-			},
-			"dependencies": {
-				"p-limit": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
-					"integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
-					"dev": true,
-					"requires": {
-						"yocto-queue": "^1.0.0"
-					}
-				},
-				"yocto-queue": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
-					"integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==",
-					"dev": true
-				}
-			}
-		},
 		"p-try": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
@@ -17412,31 +17047,69 @@
 			"dev": true
 		},
 		"pac-proxy-agent": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-5.0.0.tgz",
-			"integrity": "sha512-CcFG3ZtnxO8McDigozwE3AqAw15zDvGH+OjXO4kzf7IkEKkQ4gxQ+3sdF50WmhQ4P/bVusXcqNE2S3XrNURwzQ==",
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.0.1.tgz",
+			"integrity": "sha512-ASV8yU4LLKBAjqIPMbrgtaKIvxQri/yh2OpI+S6hVa9JRkUI3Y3NPFbfngDtY7oFtSMD3w31Xns89mDa3Feo5A==",
 			"dev": true,
 			"requires": {
-				"@tootallnate/once": "1",
-				"agent-base": "6",
-				"debug": "4",
-				"get-uri": "3",
-				"http-proxy-agent": "^4.0.1",
-				"https-proxy-agent": "5",
-				"pac-resolver": "^5.0.0",
-				"raw-body": "^2.2.0",
-				"socks-proxy-agent": "5"
+				"@tootallnate/quickjs-emscripten": "^0.23.0",
+				"agent-base": "^7.0.2",
+				"debug": "^4.3.4",
+				"get-uri": "^6.0.1",
+				"http-proxy-agent": "^7.0.0",
+				"https-proxy-agent": "^7.0.2",
+				"pac-resolver": "^7.0.0",
+				"socks-proxy-agent": "^8.0.2"
+			},
+			"dependencies": {
+				"agent-base": {
+					"version": "7.1.1",
+					"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
+					"integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
+					"dev": true,
+					"requires": {
+						"debug": "^4.3.4"
+					}
+				},
+				"debug": {
+					"version": "4.3.4",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+					"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+					"dev": true,
+					"requires": {
+						"ms": "2.1.2"
+					}
+				},
+				"http-proxy-agent": {
+					"version": "7.0.2",
+					"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+					"integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+					"dev": true,
+					"requires": {
+						"agent-base": "^7.1.0",
+						"debug": "^4.3.4"
+					}
+				},
+				"https-proxy-agent": {
+					"version": "7.0.4",
+					"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz",
+					"integrity": "sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==",
+					"dev": true,
+					"requires": {
+						"agent-base": "^7.0.2",
+						"debug": "4"
+					}
+				}
 			}
 		},
 		"pac-resolver": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-5.0.0.tgz",
-			"integrity": "sha512-H+/A6KitiHNNW+bxBKREk2MCGSxljfqRX76NjummWEYIat7ldVXRU3dhRIE3iXZ0nvGBk6smv3nntxKkzRL8NA==",
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+			"integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
 			"dev": true,
 			"requires": {
-				"degenerator": "^3.0.1",
-				"ip": "^1.1.5",
-				"netmask": "^2.0.1"
+				"degenerator": "^5.0.0",
+				"netmask": "^2.0.2"
 			}
 		},
 		"package-hash": {
@@ -17464,13 +17137,10 @@
 			},
 			"dependencies": {
 				"semver": {
-					"version": "7.3.8",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-					"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-					"dev": true,
-					"requires": {
-						"lru-cache": "^6.0.0"
-					}
+					"version": "7.6.2",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+					"integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+					"dev": true
 				}
 			}
 		},
@@ -17486,18 +17156,6 @@
 			"dev": true,
 			"requires": {
 				"callsites": "^3.0.0"
-			}
-		},
-		"parse-json": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
-			"integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-			"dev": true,
-			"requires": {
-				"@babel/code-frame": "^7.0.0",
-				"error-ex": "^1.3.1",
-				"json-parse-even-better-errors": "^2.3.0",
-				"lines-and-columns": "^1.1.6"
 			}
 		},
 		"path-exists": {
@@ -17614,34 +17272,63 @@
 			"dev": true
 		},
 		"proxy-agent": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-5.0.0.tgz",
-			"integrity": "sha512-gkH7BkvLVkSfX9Dk27W6TyNOWWZWRilRfk1XxGNWOYJ2TuedAv1yFpCaU9QSBmBe716XOTNpYNOzhysyw8xn7g==",
+			"version": "6.4.0",
+			"resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.4.0.tgz",
+			"integrity": "sha512-u0piLU+nCOHMgGjRbimiXmA9kM/L9EHh3zL81xCdp7m+Y2pHIsnmbdDoEDoAz5geaonNR6q6+yOPQs6n4T6sBQ==",
 			"dev": true,
 			"requires": {
-				"agent-base": "^6.0.0",
-				"debug": "4",
-				"http-proxy-agent": "^4.0.0",
-				"https-proxy-agent": "^5.0.0",
-				"lru-cache": "^5.1.1",
-				"pac-proxy-agent": "^5.0.0",
-				"proxy-from-env": "^1.0.0",
-				"socks-proxy-agent": "^5.0.0"
+				"agent-base": "^7.0.2",
+				"debug": "^4.3.4",
+				"http-proxy-agent": "^7.0.1",
+				"https-proxy-agent": "^7.0.3",
+				"lru-cache": "^7.14.1",
+				"pac-proxy-agent": "^7.0.1",
+				"proxy-from-env": "^1.1.0",
+				"socks-proxy-agent": "^8.0.2"
 			},
 			"dependencies": {
-				"lru-cache": {
-					"version": "5.1.1",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-					"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+				"agent-base": {
+					"version": "7.1.1",
+					"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
+					"integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
 					"dev": true,
 					"requires": {
-						"yallist": "^3.0.2"
+						"debug": "^4.3.4"
 					}
 				},
-				"yallist": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-					"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+				"debug": {
+					"version": "4.3.4",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+					"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+					"dev": true,
+					"requires": {
+						"ms": "2.1.2"
+					}
+				},
+				"http-proxy-agent": {
+					"version": "7.0.2",
+					"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+					"integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+					"dev": true,
+					"requires": {
+						"agent-base": "^7.1.0",
+						"debug": "^4.3.4"
+					}
+				},
+				"https-proxy-agent": {
+					"version": "7.0.4",
+					"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz",
+					"integrity": "sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==",
+					"dev": true,
+					"requires": {
+						"agent-base": "^7.0.2",
+						"debug": "4"
+					}
+				},
+				"lru-cache": {
+					"version": "7.18.3",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+					"integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
 					"dev": true
 				}
 			}
@@ -17672,12 +17359,6 @@
 			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
 			"integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
 		},
-		"quick-lru": {
-			"version": "6.1.1",
-			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-6.1.1.tgz",
-			"integrity": "sha512-S27GBT+F0NTRiehtbrgaSE1idUAJ5bX8dPAQTdylEyNlrdcH5X4Lz7Edz3DYzecbsCluD5zO8ZNEe04z3D3u6Q==",
-			"dev": true
-		},
 		"quote": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/quote/-/quote-0.4.0.tgz",
@@ -17697,29 +17378,6 @@
 			"dev": true,
 			"requires": {
 				"safe-buffer": "^5.1.0"
-			}
-		},
-		"raw-body": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.2.tgz",
-			"integrity": "sha512-RPMAFUJP19WIet/99ngh6Iv8fzAbqum4Li7AD6DtGaW2RpMB/11xDoalPiJMTbu6I3hkbMVkATvZrqb9EEqeeQ==",
-			"dev": true,
-			"requires": {
-				"bytes": "3.1.1",
-				"http-errors": "1.8.1",
-				"iconv-lite": "0.4.24",
-				"unpipe": "1.0.0"
-			},
-			"dependencies": {
-				"iconv-lite": {
-					"version": "0.4.24",
-					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-					"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-					"dev": true,
-					"requires": {
-						"safer-buffer": ">= 2.1.2 < 3"
-					}
-				}
 			}
 		},
 		"rc": {
@@ -17744,75 +17402,6 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
 					"integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
-					"dev": true
-				}
-			}
-		},
-		"read-pkg": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-7.1.0.tgz",
-			"integrity": "sha512-5iOehe+WF75IccPc30bWTbpdDQLOCc3Uu8bi3Dte3Eueij81yx1Mrufk8qBx/YAbR4uL1FdUr+7BKXDwEtisXg==",
-			"dev": true,
-			"requires": {
-				"@types/normalize-package-data": "^2.4.1",
-				"normalize-package-data": "^3.0.2",
-				"parse-json": "^5.2.0",
-				"type-fest": "^2.0.0"
-			},
-			"dependencies": {
-				"hosted-git-info": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
-					"integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
-					"dev": true,
-					"requires": {
-						"lru-cache": "^6.0.0"
-					}
-				},
-				"normalize-package-data": {
-					"version": "3.0.3",
-					"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
-					"integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
-					"dev": true,
-					"requires": {
-						"hosted-git-info": "^4.0.1",
-						"is-core-module": "^2.5.0",
-						"semver": "^7.3.4",
-						"validate-npm-package-license": "^3.0.1"
-					}
-				},
-				"semver": {
-					"version": "7.3.8",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-					"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-					"dev": true,
-					"requires": {
-						"lru-cache": "^6.0.0"
-					}
-				},
-				"type-fest": {
-					"version": "2.19.0",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-					"integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-					"dev": true
-				}
-			}
-		},
-		"read-pkg-up": {
-			"version": "9.1.0",
-			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-9.1.0.tgz",
-			"integrity": "sha512-vaMRR1AC1nrd5CQM0PhlRsO5oc2AAigqr7cCrZ/MW/Rsaflz4RlgzkpL4qoU/z1F6wrbd85iFv1OQj/y5RdGvg==",
-			"dev": true,
-			"requires": {
-				"find-up": "^6.3.0",
-				"read-pkg": "^7.1.0",
-				"type-fest": "^2.5.0"
-			},
-			"dependencies": {
-				"type-fest": {
-					"version": "2.19.0",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-					"integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
 					"dev": true
 				}
 			}
@@ -17853,24 +17442,6 @@
 			"dev": true,
 			"requires": {
 				"resolve": "^1.20.0"
-			}
-		},
-		"redent": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/redent/-/redent-4.0.0.tgz",
-			"integrity": "sha512-tYkDkVVtYkSVhuQ4zBgfvciymHaeuel+zFKXShfDnFP5SyVEP7qo70Rf1jTOTCx3vGNAbnEi/xFkcfQVMIBWag==",
-			"dev": true,
-			"requires": {
-				"indent-string": "^5.0.0",
-				"strip-indent": "^4.0.0"
-			},
-			"dependencies": {
-				"indent-string": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
-					"integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
-					"dev": true
-				}
 			}
 		},
 		"regenerator-runtime": {
@@ -18043,9 +17614,9 @@
 			}
 		},
 		"semver": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
 			"dev": true
 		},
 		"semver-diff": {
@@ -18058,13 +17629,10 @@
 			},
 			"dependencies": {
 				"semver": {
-					"version": "7.3.8",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-					"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-					"dev": true,
-					"requires": {
-						"lru-cache": "^6.0.0"
-					}
+					"version": "7.6.2",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+					"integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+					"dev": true
 				}
 			}
 		},
@@ -18083,16 +17651,24 @@
 			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
 			"dev": true
 		},
+		"set-function-length": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+			"integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+			"dev": true,
+			"requires": {
+				"define-data-property": "^1.1.4",
+				"es-errors": "^1.3.0",
+				"function-bind": "^1.1.2",
+				"get-intrinsic": "^1.2.4",
+				"gopd": "^1.0.1",
+				"has-property-descriptors": "^1.0.2"
+			}
+		},
 		"setimmediate": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
 			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
-			"dev": true
-		},
-		"setprototypeof": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
-			"integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
 			"dev": true
 		},
 		"shallow-clone": {
@@ -18249,24 +17825,44 @@
 			}
 		},
 		"socks": {
-			"version": "2.6.1",
-			"resolved": "https://registry.npmjs.org/socks/-/socks-2.6.1.tgz",
-			"integrity": "sha512-kLQ9N5ucj8uIcxrDwjm0Jsqk06xdpBjGNQtpXy4Q8/QY2k+fY7nZH8CARy+hkbG+SGAovmzzuauCpBlb8FrnBA==",
+			"version": "2.8.3",
+			"resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
+			"integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
 			"dev": true,
 			"requires": {
-				"ip": "^1.1.5",
-				"smart-buffer": "^4.1.0"
+				"ip-address": "^9.0.5",
+				"smart-buffer": "^4.2.0"
 			}
 		},
 		"socks-proxy-agent": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-5.0.1.tgz",
-			"integrity": "sha512-vZdmnjb9a2Tz6WEQVIurybSwElwPxMZaIc7PzqbJTrezcKNznv6giT7J7tZDZ1BojVaa1jvO/UiUdhDVB0ACoQ==",
+			"version": "8.0.3",
+			"resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.3.tgz",
+			"integrity": "sha512-VNegTZKhuGq5vSD6XNKlbqWhyt/40CgoEw8XxD6dhnm8Jq9IEa3nIa4HwnM8XOqU0CdB0BwWVXusqiFXfHB3+A==",
 			"dev": true,
 			"requires": {
-				"agent-base": "^6.0.2",
-				"debug": "4",
-				"socks": "^2.3.3"
+				"agent-base": "^7.1.1",
+				"debug": "^4.3.4",
+				"socks": "^2.7.1"
+			},
+			"dependencies": {
+				"agent-base": {
+					"version": "7.1.1",
+					"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
+					"integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
+					"dev": true,
+					"requires": {
+						"debug": "^4.3.4"
+					}
+				},
+				"debug": {
+					"version": "4.3.4",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+					"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+					"dev": true,
+					"requires": {
+						"ms": "2.1.2"
+					}
+				}
 			}
 		},
 		"source-map": {
@@ -18344,48 +17940,10 @@
 				}
 			}
 		},
-		"spdx-correct": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
-			"integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
-			"dev": true,
-			"requires": {
-				"spdx-expression-parse": "^3.0.0",
-				"spdx-license-ids": "^3.0.0"
-			}
-		},
-		"spdx-exceptions": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
-			"integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
-			"dev": true
-		},
-		"spdx-expression-parse": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
-			"integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
-			"dev": true,
-			"requires": {
-				"spdx-exceptions": "^2.1.0",
-				"spdx-license-ids": "^3.0.0"
-			}
-		},
-		"spdx-license-ids": {
-			"version": "3.0.12",
-			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.12.tgz",
-			"integrity": "sha512-rr+VVSXtRhO4OHbXUiAF7xW3Bo9DuuF6C5jH+q/x15j2jniycgKbxU09Hr0WqlSLUs4i4ltHGXqTe7VHclYWyA==",
-			"dev": true
-		},
 		"sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
 			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-			"dev": true
-		},
-		"statuses": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-			"integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
 			"dev": true
 		},
 		"stdin-discarder": {
@@ -18460,15 +18018,6 @@
 			"integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
 			"dev": true
 		},
-		"strip-indent": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-4.0.0.tgz",
-			"integrity": "sha512-mnVSV2l+Zv6BLpSD/8V87CW/y9EmmbYzGCIavsnsI6/nwn26DwffM/yztm30Z/I2DY9wdS3vXVCMnHDgZaVNoA==",
-			"dev": true,
-			"requires": {
-				"min-indent": "^1.0.1"
-			}
-		},
 		"strip-json-comments": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -18476,9 +18025,9 @@
 			"dev": true
 		},
 		"stubborn-fs": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/stubborn-fs/-/stubborn-fs-1.2.4.tgz",
-			"integrity": "sha512-KRa4nIRJ8q6uApQbPwYZVhOof8979fw4xbajBWa5kPJFa4nyY3aFaMWVyIVCDnkNCCG/3HLipUZ4QaNlYsmX1w==",
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/stubborn-fs/-/stubborn-fs-1.2.5.tgz",
+			"integrity": "sha512-H2N9c26eXjzL/S/K+i/RHHcFanE74dptvvjM8iwzwbVcWY/zjBbgRqF3K0DY4+OD+uTTASTBvDoxPDaPN02D7g==",
 			"dev": true
 		},
 		"style-mod": {
@@ -18623,22 +18172,10 @@
 				"is-number": "^7.0.0"
 			}
 		},
-		"toidentifier": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
-			"integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
-			"dev": true
-		},
 		"tr46": {
 			"version": "0.0.3",
 			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
 			"integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
-		},
-		"trim-newlines": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-4.0.2.tgz",
-			"integrity": "sha512-GJtWyq9InR/2HRiLZgpIKv+ufIKrVrvjQWEj7PxAXNc5dwbNJkqhAUoAGgzRmULAnoOM5EIpveYd3J2VeSAIew==",
-			"dev": true
 		},
 		"ts-loader": {
 			"version": "9.4.2",
@@ -18693,13 +18230,10 @@
 					"dev": true
 				},
 				"semver": {
-					"version": "7.3.5",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-					"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-					"dev": true,
-					"requires": {
-						"lru-cache": "^6.0.0"
-					}
+					"version": "7.6.2",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+					"integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+					"dev": true
 				},
 				"supports-color": {
 					"version": "7.2.0",
@@ -18802,16 +18336,9 @@
 			}
 		},
 		"universalify": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-			"dev": true
-		},
-		"unpipe": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-			"integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
-			"dev": true
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="
 		},
 		"unzipper": {
 			"version": "0.10.11",
@@ -18883,20 +18410,17 @@
 					}
 				},
 				"semver": {
-					"version": "7.3.8",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-					"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-					"dev": true,
-					"requires": {
-						"lru-cache": "^6.0.0"
-					}
+					"version": "7.6.2",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+					"integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+					"dev": true
 				}
 			}
 		},
 		"uri-js": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
-			"integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
 			"dev": true,
 			"requires": {
 				"punycode": "^2.1.0"
@@ -18919,20 +18443,10 @@
 			"integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
 			"dev": true
 		},
-		"validate-npm-package-license": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
-			"integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
-			"dev": true,
-			"requires": {
-				"spdx-correct": "^3.0.0",
-				"spdx-expression-parse": "^3.0.0"
-			}
-		},
 		"validator": {
-			"version": "13.9.0",
-			"resolved": "https://registry.npmjs.org/validator/-/validator-13.9.0.tgz",
-			"integrity": "sha512-B+dGG8U3fdtM0/aNK4/X8CXq/EcxU2WPrPEkJGslb47qyHsxmbggTWK0yEA4qnYVNF+nxNlN88o14hIcPmSIEA==",
+			"version": "13.12.0",
+			"resolved": "https://registry.npmjs.org/validator/-/validator-13.12.0.tgz",
+			"integrity": "sha512-c1Q0mCiPlgdTVVVIJIrBuxNicYE+t/7oKeI9MWLj3fh/uq2Pxh/3eeWbVZ4OcGW1TUf53At0njHw5SMdA3tmMg==",
 			"dev": true
 		},
 		"vanilla-datapack-data": {
@@ -18978,91 +18492,74 @@
 				}
 			}
 		},
-		"vm2": {
-			"version": "3.9.19",
-			"resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.19.tgz",
-			"integrity": "sha512-J637XF0DHDMV57R6JyVsTak7nIL8gy5KH4r1HiwWLf/4GBbb5MKL5y7LpmF4A8E2nR6XmzpmMFQ7V7ppPTmUQg==",
-			"dev": true,
-			"requires": {
-				"acorn": "^8.7.0",
-				"acorn-walk": "^8.2.0"
-			}
-		},
 		"vscode-jsonrpc": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz",
-			"integrity": "sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg=="
+			"version": "8.2.0",
+			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+			"integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA=="
 		},
 		"vscode-languageclient": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-8.0.1.tgz",
-			"integrity": "sha512-9XoE+HJfaWvu7Y75H3VmLo5WLCtsbxEgEhrLPqwt7eyoR49lUIyyrjb98Yfa50JCMqF2cePJAEVI6oe2o1sIhw==",
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-9.0.1.tgz",
+			"integrity": "sha512-JZiimVdvimEuHh5olxhxkht09m3JzUGwggb5eRUkzzJhZ2KjCN0nh55VfiED9oez9DyF8/fz1g1iBV3h+0Z2EA==",
 			"dev": true,
 			"requires": {
-				"minimatch": "^3.0.4",
-				"semver": "^7.3.5",
-				"vscode-languageserver-protocol": "3.17.1"
+				"minimatch": "^5.1.0",
+				"semver": "^7.3.7",
+				"vscode-languageserver-protocol": "3.17.5"
 			},
 			"dependencies": {
+				"brace-expansion": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+					"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+					"dev": true,
+					"requires": {
+						"balanced-match": "^1.0.0"
+					}
+				},
+				"minimatch": {
+					"version": "5.1.6",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+					"integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+					"dev": true,
+					"requires": {
+						"brace-expansion": "^2.0.1"
+					}
+				},
 				"semver": {
-					"version": "7.3.7",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-					"integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-					"dev": true,
-					"requires": {
-						"lru-cache": "^6.0.0"
-					}
-				},
-				"vscode-jsonrpc": {
-					"version": "8.0.1",
-					"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.0.1.tgz",
-					"integrity": "sha512-N/WKvghIajmEvXpatSzvTvOIz61ZSmOSa4BRA4pTLi+1+jozquQKP/MkaylP9iB68k73Oua1feLQvH3xQuigiQ==",
-					"dev": true
-				},
-				"vscode-languageserver-protocol": {
-					"version": "3.17.1",
-					"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.1.tgz",
-					"integrity": "sha512-BNlAYgQoYwlSgDLJhSG+DeA8G1JyECqRzM2YO6tMmMji3Ad9Mw6AW7vnZMti90qlAKb0LqAlJfSVGEdqMMNzKg==",
-					"dev": true,
-					"requires": {
-						"vscode-jsonrpc": "8.0.1",
-						"vscode-languageserver-types": "3.17.1"
-					}
-				},
-				"vscode-languageserver-types": {
-					"version": "3.17.1",
-					"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.1.tgz",
-					"integrity": "sha512-K3HqVRPElLZVVPtMeKlsyL9aK0GxGQpvtAUTfX4k7+iJ4mc1M+JM+zQwkgGy2LzY0f0IAafe8MKqIkJrxfGGjQ==",
+					"version": "7.6.2",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+					"integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
 					"dev": true
 				}
 			}
 		},
 		"vscode-languageserver": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-7.0.0.tgz",
-			"integrity": "sha512-60HTx5ID+fLRcgdHfmz0LDZAXYEV68fzwG0JWwEPBode9NuMYTIxuYXPg4ngO8i8+Ou0lM7y6GzaYWbiDL0drw==",
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
+			"integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
 			"requires": {
-				"vscode-languageserver-protocol": "3.16.0"
+				"vscode-languageserver-protocol": "3.17.5"
 			}
 		},
 		"vscode-languageserver-protocol": {
-			"version": "3.16.0",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz",
-			"integrity": "sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==",
+			"version": "3.17.5",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+			"integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
 			"requires": {
-				"vscode-jsonrpc": "6.0.0",
-				"vscode-languageserver-types": "3.16.0"
+				"vscode-jsonrpc": "8.2.0",
+				"vscode-languageserver-types": "3.17.5"
 			}
 		},
 		"vscode-languageserver-textdocument": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.4.tgz",
-			"integrity": "sha512-/xhqXP/2A2RSs+J8JNXpiiNVvvNM0oTosNVmQnunlKvq9o4mupHOBAnnzH0lwIPKazXKvAKsVp1kr+H/K4lgoQ=="
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.11.tgz",
+			"integrity": "sha512-X+8T3GoiwTVlJbicx/sIAF+yuJAqz8VvwJyoMVhwEMoEKE/fkDmrqUgDMyBECcM2A2frVZIUj5HI/ErRXCfOeA=="
 		},
 		"vscode-languageserver-types": {
-			"version": "3.16.0",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
-			"integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
+			"version": "3.17.5",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+			"integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg=="
 		},
 		"vscode-test": {
 			"version": "1.5.2",
@@ -19113,9 +18610,9 @@
 			}
 		},
 		"web-streams-polyfill": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
-			"integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+			"integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
 			"dev": true
 		},
 		"webidl-conversions": {
@@ -19284,9 +18781,9 @@
 			}
 		},
 		"when-exit": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/when-exit/-/when-exit-2.1.0.tgz",
-			"integrity": "sha512-H85ulNwUBU1e6PGxkWUDgxnbohSXD++ah6Xw1VHAN7CtypcbZaC4aYjQ+C2PMVaDkURDuOinNAT+Lnz3utWXxQ==",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/when-exit/-/when-exit-2.1.2.tgz",
+			"integrity": "sha512-u9J+toaf3CCxCAzM/484qNAxQE75rFdVgiFEEV8Xps2gzYhf0tx73s1WXDQhkwV17E3MxRMz40m7Ekd2/121Lg==",
 			"dev": true
 		},
 		"which-module": {
@@ -19358,9 +18855,9 @@
 			}
 		},
 		"word-wrap": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-			"integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+			"integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
 			"dev": true
 		},
 		"workerpool": {
@@ -19444,12 +18941,6 @@
 			"integrity": "sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ==",
 			"dev": true
 		},
-		"xregexp": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/xregexp/-/xregexp-2.0.0.tgz",
-			"integrity": "sha1-UqY+VsoLhKfzpfPWGHLxJq16WUM=",
-			"dev": true
-		},
 		"xtend": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -19459,12 +18950,6 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
 			"integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
-			"dev": true
-		},
-		"yallist": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 			"dev": true
 		},
 		"yargs": {

--- a/packages/core/src/processor/InlayHintProvider.ts
+++ b/packages/core/src/processor/InlayHintProvider.ts
@@ -3,8 +3,10 @@ import type { AstNode } from '../node/index.js'
 import type { ProcessorContext } from '../service/index.js'
 
 export interface InlayHint {
+	label: string
 	offset: number
-	text: string
+	paddingLeft?: boolean
+	paddingRight?: boolean
 }
 
 export type InlayHintProvider<N extends AstNode = AstNode> = (

--- a/packages/core/src/service/Config.ts
+++ b/packages/core/src/service/Config.ts
@@ -332,7 +332,16 @@ export const VanillaConfig: Config = {
 			formatting: true,
 			hover: true,
 			inlayHint: {
-				enabledNodes: ['mcfunction:command_child/unknown'],
+				enabledNodes: [
+					'boolean',
+					'double',
+					'float',
+					'integer',
+					'long',
+					'mcfunction:coordinate',
+					'mcfunction:vector',
+					'mcfunction:command_child/unknown',
+				],
 			},
 			semanticColoring: true,
 			selectionRanges: true,

--- a/packages/java-edition/src/mcfunction/inlayHintProvider.ts
+++ b/packages/java-edition/src/mcfunction/inlayHintProvider.ts
@@ -22,7 +22,8 @@ export const inlayHintProvider: core.InlayHintProvider<
 			) {
 				ans.push({
 					offset: node.range.start,
-					text: `${node.path[node.path.length - 1]}:`,
+					label: `${node.path[node.path.length - 1]}:`,
+					paddingRight: true,
 				})
 			}
 		},

--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -19,8 +19,8 @@
   },
   "dependencies": {
     "env-paths": "^2.2.1",
-    "vscode-languageserver": "^7.0.0",
-    "vscode-languageserver-textdocument": "^1.0.1"
+    "vscode-languageserver": "^9.0.1",
+    "vscode-languageserver-textdocument": "^1.0.11"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -12,8 +12,6 @@ import type {
 	CustomInitializationOptions,
 	CustomServerCapabilities,
 	MyLspDataHackPubifyRequestParams,
-	MyLspInlayHint,
-	MyLspInlayHintRequestParams,
 } from './util/index.js'
 import { toCore, toLS } from './util/index.js'
 
@@ -112,12 +110,16 @@ connection.onInitialize(async (params) => {
 			},
 		})
 		service.project
-			.on('documentErrored', ({ errors, uri, version }) => {
-				connection.sendDiagnostics({
-					diagnostics: toLS.diagnostics(errors),
-					uri: uri,
-					version: version,
-				})
+			.on('documentErrored', async ({ errors, uri, version }) => {
+				try {
+					await connection.sendDiagnostics({
+						diagnostics: toLS.diagnostics(errors),
+						uri: uri,
+						version: version,
+					})
+				} catch (e) {
+					console.error('[sendDiagnostics]', e)
+				}
 			})
 			.on('ready', () => {
 				progressReporter?.done()
@@ -129,7 +131,6 @@ connection.onInitialize(async (params) => {
 
 	const customCapabilities: CustomServerCapabilities = {
 		dataHackPubify: true,
-		inlayHints: true,
 		resetProjectCache: true,
 		showCacheRoot: true,
 	}
@@ -154,6 +155,7 @@ connection.onInitialize(async (params) => {
 				label: 'Spyglass',
 			},
 			hoverProvider: {},
+			inlayHintProvider: {},
 			semanticTokensProvider: {
 				documentSelector: toLS.documentSelector(service.project.meta),
 				legend: toLS.semanticTokensLegend(),
@@ -405,21 +407,15 @@ connection.onHover(async ({ textDocument: { uri }, position }) => {
 	return ans ? toLS.hover(ans, doc) : undefined
 })
 
-connection.onRequest(
-	'spyglassmc/inlayHints',
-	async ({
-		textDocument: { uri },
-		range,
-	}: MyLspInlayHintRequestParams): Promise<MyLspInlayHint[]> => {
-		const docAndNode = await service.project.ensureClientManagedChecked(uri)
-		if (!docAndNode) {
-			return []
-		}
-		const { doc, node } = docAndNode
-		const hints = service.getInlayHints(node, doc, toCore.range(range, doc))
-		return toLS.inlayHints(hints, doc)
-	},
-)
+connection.languages.inlayHint.on(async ({ textDocument: { uri }, range }) => {
+	const docAndNode = await service.project.ensureClientManagedChecked(uri)
+	if (!docAndNode) {
+		return []
+	}
+	const { doc, node } = docAndNode
+	const hints = service.getInlayHints(node, doc, toCore.range(range, doc))
+	return toLS.inlayHints(hints, doc)
+})
 
 connection.onRequest(
 	'spyglassmc/resetProjectCache',

--- a/packages/language-server/src/util/toLS.ts
+++ b/packages/language-server/src/util/toLS.ts
@@ -8,7 +8,6 @@ import * as core from '@spyglassmc/core'
 import type { TextDocument } from 'vscode-languageserver-textdocument'
 import * as ls from 'vscode-languageserver/node.js'
 import { InsertTextFormat } from 'vscode-languageserver/node.js'
-import type { MyLspInlayHint } from './types.js'
 
 const ZeroPosition: ls.Position = { line: 0, character: 0 }
 const ZeroRange: ls.Range = { start: ZeroPosition, end: ZeroPosition }
@@ -196,17 +195,19 @@ export function hover(hover: core.Hover, doc: TextDocument): ls.Hover {
 export function inlayHint(
 	hint: core.InlayHint,
 	doc: TextDocument,
-): MyLspInlayHint {
+): ls.InlayHint {
 	return {
 		position: doc.positionAt(hint.offset),
-		text: hint.text,
+		label: hint.label,
+		...hint.paddingLeft ? { paddingLeft: hint.paddingLeft } : {},
+		...hint.paddingRight ? { paddingRight: hint.paddingRight } : {},
 	}
 }
 
 export function inlayHints(
 	hints: core.InlayHint[],
 	doc: TextDocument,
-): MyLspInlayHint[] {
+): ls.InlayHint[] {
 	return hints.map((h) => inlayHint(h, doc))
 }
 

--- a/packages/language-server/src/util/types.ts
+++ b/packages/language-server/src/util/types.ts
@@ -1,28 +1,13 @@
-import type * as ls from 'vscode-languageserver/node.js'
-
 export interface CustomInitializationOptions {
 	inDevelopmentMode?: boolean
 }
 
 export interface CustomServerCapabilities {
 	dataHackPubify?: boolean
-	inlayHints?: boolean
 	resetProjectCache?: boolean
 	showCacheRoot?: boolean
 }
 
 export interface MyLspDataHackPubifyRequestParams {
 	initialism: string
-}
-
-export interface MyLspInlayHint {
-	position: ls.Position
-	text: string
-}
-
-export interface MyLspInlayHintRequestParams {
-	textDocument: {
-		uri: string
-	}
-	range: ls.Range
 }

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@types/vscode": "1.67.0",
     "esbuild": "^0.17.18",
-    "vscode-languageclient": "^8.0.1",
+    "vscode-languageclient": "^9.0.1",
     "vscode-test": "^1.5.2"
   },
   "repository": {

--- a/packages/vscode-extension/src/extension.mts
+++ b/packages/vscode-extension/src/extension.mts
@@ -66,46 +66,6 @@ export function activate(context: vsc.ExtensionContext) {
 		() => {
 			const customCapabilities: server.CustomServerCapabilities | undefined =
 				client.initializeResult?.capabilities.experimental?.spyglassmc
-			if (
-				customCapabilities?.inlayHints &&
-				vsc.languages.registerInlayHintsProvider
-			) {
-				vsc.languages.registerInlayHintsProvider(documentSelector, {
-					async provideInlayHints(model, range): Promise<vsc.InlayHint[]> {
-						try {
-							const params: server.MyLspInlayHintRequestParams = {
-								textDocument: { uri: model.uri.toString() },
-								range: {
-									start: {
-										line: range.start.line,
-										character: range.start.character,
-									},
-									end: {
-										line: range.end.line,
-										character: range.end.character,
-									},
-								},
-							}
-							const response: server.MyLspInlayHint[] = await client
-								.sendRequest('spyglassmc/inlayHints', params)
-							return response.map(
-								(v) =>
-									new vsc.InlayHint(
-										new vsc.Position(
-											v.position.line,
-											v.position.character,
-										),
-										v.text,
-										vsc.InlayHintKind.Parameter,
-									),
-							)
-						} catch (e) {
-							console.error('[client#provideInlayHints]', e)
-						}
-						return []
-					},
-				})
-			}
 
 			if (customCapabilities?.dataHackPubify) {
 				context.subscriptions.push(


### PR DESCRIPTION
Resolves #1137.

* Updates dependencies on `vscode-languageserver` and `vscode-languageclient`.
* Uses LSP to provide inlay hints instead of our own protocol.
* Enables inlay hints on more command nodes by default:
  * 'boolean',
  * 'double',
  * 'float',
  * 'integer',
  * 'long',
  * 'mcfunction:coordinate',
  * 'mcfunction:vector',
  * 'mcfunction:command_child/unknown'
  * The rationale behind these nodes is that they're fairly "simple" (subjectively) that it may not be immediately clear to an inexperienced command user what the argument is for. e.g. the boolean argument in `effect give`, the various vectors in `clone`, `tp`, etc, while a more "complicated" node like a block ID is more obvious that it represents a type of block.
    ![inlay hints](https://github.com/SpyglassMC/Spyglass/assets/15277496/e86847ea-b357-43e8-9747-96cbe2db9071)
