### PR TITLE
🐛 Allow single quotes in NBT paths

### DIFF
--- a/__snapshots__/packages/nbt/test-out/parser/path.spec.js
+++ b/__snapshots__/packages/nbt/test-out/parser/path.spec.js
@@ -82,16 +82,7 @@ exports['nbt path() Parse "\'foo\'" 1'] = {
       "end": 5
     }
   },
-  "errors": [
-    {
-      "range": {
-        "start": 0,
-        "end": 0
-      },
-      "message": "Only “\"” can be used to quote strings here",
-      "severity": 3
-    }
-  ]
+  "errors": []
 }
 
 exports['nbt path() Parse "[ ]" 1'] = {

--- a/packages/nbt/src/parser/path.ts
+++ b/packages/nbt/src/parser/path.ts
@@ -87,8 +87,9 @@ const key: PartParser = (children, src, ctx) => {
 	const node = core.string({
 		colorTokenType: 'property',
 		escapable: {},
-		// No single quotes: https://bugs.mojang.com/browse/MC-175504
-		quotes: ['"'],
+		// Single quotes supported since 1.20 Pre-release 2 (roughly pack format 15)
+		// https://bugs.mojang.com/browse/MC-175504
+		quotes: ['"', "'"],
 		unquotable: {
 			blockList: new Set([
 				'\n',


### PR DESCRIPTION
Fixes #1058. This change allows single quotes for
all versions, not just the versions after 1.20 Pre- release 2, as the `nbt` package does not have
access to the `ReleaseVersion.cmp()` function from `java-edition` and it'd take too much effort to
do it properly just to eliminate a tiny little
false negative. We may revisit this if we decide
to use pack formats internally instead since it'd
be an easy
`parseInt(ctx.project['loadedFormat']) < 15` check.