### PR TITLE
🦺 Validate command tree patch

### DIFF
--- a/packages/core/src/symbol/Symbol.ts
+++ b/packages/core/src/symbol/Symbol.ts
@@ -141,7 +141,9 @@ export const MiscCategories = Object.freeze(
 	[
 		'attribute_modifier_uuid',
 		'bossbar',
+		'jigsaw_block_name',
 		'objective',
+		'random_sequence',
 		'score_holder',
 		'storage',
 		'tag',
@@ -171,6 +173,8 @@ export type AllCategory = (typeof AllCategories)[number]
 export const ResourceLocationCategories = Object.freeze(
 	[
 		'bossbar',
+		'jigsaw_block_name',
+		'random_sequence',
 		'storage',
 		'mcdoc/dispatcher',
 		...FileCategories,

--- a/packages/java-edition/src/dependency/common.ts
+++ b/packages/java-edition/src/dependency/common.ts
@@ -9,6 +9,18 @@ export namespace ReleaseVersion {
 	export function cmp(a: ReleaseVersion, b: ReleaseVersion): number {
 		return Math.sign(Number(a.slice(2)) - Number(b.slice(2)))
 	}
+
+	/**
+	 * @returns `true` if `version` is newer than `since` (inclusive) and older
+	 * than `until` (exclusive)
+	 */
+	export function isBetween(
+		version: ReleaseVersion,
+		since: ReleaseVersion,
+		until: ReleaseVersion,
+	): boolean {
+		return cmp(version, since) >= 0 && cmp(version, until) < 0
+	}
 }
 
 export interface VersionInfo {

--- a/packages/java-edition/src/mcfunction/tree/argument.ts
+++ b/packages/java-edition/src/mcfunction/tree/argument.ts
@@ -153,28 +153,36 @@ export interface MinecraftMobEffectArgumentTreeNode
 export interface NbtParserProperties extends Record<string, unknown> {
 	/**
 	 * The NBT checker should check this argument by dispatching on `dispatcher`
-	 * with a static index inferred from the argument that is at the index
-	 * `dispatchedBy` relative to the current argument and optionally indexing
-	 * on the dispatched type by indices inferred from the argument that is at the
-	 * index `indexedBy` relative to the current argument.
+	 * with a static index inferred from the argument with the name `dispatchedBy`
+	 * and optionally indexing on the dispatched type by indices inferred from the
+	 * argument named by `indexedBy`.
 	 */
 	dispatcher:
 		| 'minecraft:block_entity'
 		| 'minecraft:entity'
 		| 'minecraft:storage'
 	/**
-	 * Could point to a vec3, an entity, an entity resource location, or a storage
-	 * resource location.
+	 * The name of a vec3, an entity, an entity resource location, or a
+	 * storage resource location argument.
 	 *
 	 * @see {@link NbtParserProperties.dispatcher}
 	 */
-	dispatchedBy: number
+	dispatchedBy: string
 	/**
-	 * Could point to an NBT path.
+	 * The name of an NBT path argument.
 	 *
 	 * @see {@link NbtParserProperties.dispatcher}
 	 */
-	indexedBy?: number
+	indexedBy?: string
+	/**
+	 * @default {@link core.SymbolAccessType.Read}
+	 */
+	accessType?: core.SymbolAccessType
+	/**
+	 * `true` if the NBT checker should check this argument as a predicate. In a
+	 * predicate NBT argument, resource location strings must include the default
+	 * `minecraft:` namespace and numbers must have the exact type match.
+	 */
 	isPredicate?: boolean
 }
 export interface MinecraftNbtCompoundTagArgumentTreeNode

--- a/packages/java-edition/src/mcfunction/tree/argument.ts
+++ b/packages/java-edition/src/mcfunction/tree/argument.ts
@@ -150,16 +150,46 @@ export interface MinecraftMobEffectArgumentTreeNode
 {
 	parser: 'minecraft:mob_effect'
 }
+export interface NbtParserProperties extends Record<string, unknown> {
+	/**
+	 * The NBT checker should check this argument by dispatching on `dispatcher`
+	 * with a static index inferred from the argument that is at the index
+	 * `dispatchedBy` relative to the current argument and optionally indexing
+	 * on the dispatched type by indices inferred from the argument that is at the
+	 * index `indexedBy` relative to the current argument.
+	 */
+	dispatcher:
+		| 'minecraft:block_entity'
+		| 'minecraft:entity'
+		| 'minecraft:storage'
+	/**
+	 * Could point to a vec3, an entity, an entity resource location, or a storage
+	 * resource location.
+	 *
+	 * @see {@link NbtParserProperties.dispatcher}
+	 */
+	dispatchedBy: number
+	/**
+	 * Could point to an NBT path.
+	 *
+	 * @see {@link NbtParserProperties.dispatcher}
+	 */
+	indexedBy?: number
+	isPredicate?: boolean
+}
 export interface MinecraftNbtCompoundTagArgumentTreeNode
 	extends mcf.ArgumentTreeNode
 {
 	parser: 'minecraft:nbt_compound_tag'
+	properties?: NbtParserProperties
 }
 export interface MinecraftNbtPathArgumentTreeNode extends mcf.ArgumentTreeNode {
 	parser: 'minecraft:nbt_path'
+	properties?: NbtParserProperties
 }
 export interface MinecraftNbtTagArgumentTreeNode extends mcf.ArgumentTreeNode {
 	parser: 'minecraft:nbt_tag'
+	properties?: NbtParserProperties
 }
 export interface MinecraftObjectiveArgumentTreeNode
 	extends mcf.ArgumentTreeNode


### PR DESCRIPTION
Resolves #1113.

## Prerequisites

- #1191
- #1192

## Changes

- [x] Patch `minecraft:nbt_compound_tag` parsers
- [x] Patch `minecraft:nbt_path` parsers
- [x] Patch `minecraft:nbt_tag` parsers
- [x] Patch `minecraft:resource_location` parsers
- [x] Patch `minecraft:uuid` parsers
- [x] Add necessary `permission` properties for new commands