### PR TITLE
🔧 Add launch configuration to run tests with VSCode debugger

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,4 @@
 * text=auto eol=lf
 /__snapshots__/** linguist-generated=true
 /contributors/* linguist-generated=true
-/README.md linguist-generated=true
 /**/*.generated.* linguist-generated=true

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -20,6 +20,14 @@
 			"restart": true,
 			"timeout": 180000,
 			"outFiles": ["${workspaceRoot}/packages/vscode-extension/dist/**/*.js"]
+		},
+		{
+			"type": "node",
+			"request": "launch",
+			"name": "Run Unit Tests",
+			"program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
+			"console": "integratedTerminal",
+			"internalConsoleOptions": "neverOpen"
 		}
 	],
 	"compounds": [

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ If you're using VS Code to develop Spyglass:
 
 - Install the recommended [ESLint extension][eslint-extension]. Make a copy of `.vscode/settings.template.json` and rename it to `.vscode/settings.json`.
   Now your VS Code should automatically fix all linting errors every time you save the file.
-- Press F5 to run the VS Code extension in development environment. VS Code will automatically compile all packages and build the extension file in watch mode.
+- Press F5 to run the VS Code extension in development environment (`Launch Client`). VS Code will automatically compile all packages and build the extension file in watch mode.
 
 Or if you prefer the command line interface:
 
@@ -48,6 +48,8 @@ Or if you prefer the command line interface:
 - `npm run commit` to run the [`gitmoji` CLI][gitmoji]. You actually don't have to worry about commit message as long as you're creating PR, as I can always change it.
 
 Please refrain from using `mocha --watch`, as it might interface with and break the snapshot testing.
+
+You can debug tests with breakpoints by running the `Run Unit Tests` configuration and setting your breakpoints accordingly. If you want to run a specific subset of tests, add `.only` after the test block (e.g. `describe.only()`, `it.only()`).
 
 ### Code style
 


### PR DESCRIPTION
useful when you're trying to test some functionality and are able to mock your context within a unit test.

nice to not have to run the entire extension window when a feature is earlier in development

sample:

![add-test-debugger-configuration](https://github.com/SpyglassMC/Spyglass/assets/13565346/5d67a091-6f50-4c2a-a219-3eacdd0f9033)
