### PR TITLE
🔧 Remove attributed type in favor of attributes array on all types

### DIFF
--- a/__snapshots__/packages/mcdoc/test-out/__fixture__/attributed_types.spec.js
+++ b/__snapshots__/packages/mcdoc/test-out/__fixture__/attributed_types.spec.js
@@ -30,13 +30,12 @@ exports['mcdoc __fixture__ attributed types 1'] = {
       "::test::NoValue": {
         "data": {
           "typeDef": {
-            "kind": "attributed",
-            "attribute": {
-              "name": "deprecated"
-            },
-            "child": {
-              "kind": "boolean"
-            }
+            "kind": "boolean",
+            "attributes": [
+              {
+                "name": "deprecated"
+              }
+            ]
           }
         },
         "subcategory": "type_alias",
@@ -78,20 +77,19 @@ exports['mcdoc __fixture__ attributed types 1'] = {
       "::test::SimpleValue": {
         "data": {
           "typeDef": {
-            "kind": "attributed",
-            "attribute": {
-              "name": "since",
-              "value": {
-                "kind": "literal",
+            "kind": "boolean",
+            "attributes": [
+              {
+                "name": "since",
                 "value": {
-                  "kind": "double",
-                  "value": 1.19
+                  "kind": "literal",
+                  "value": {
+                    "kind": "double",
+                    "value": 1.19
+                  }
                 }
               }
-            },
-            "child": {
-              "kind": "boolean"
-            }
+            ]
           }
         },
         "subcategory": "type_alias",
@@ -130,32 +128,32 @@ exports['mcdoc __fixture__ attributed types 1'] = {
           }
         ]
       },
-      "::test::TreeValue": {
+      "::test::Multiple": {
         "data": {
           "typeDef": {
-            "kind": "attributed",
-            "attribute": {
-              "name": "id",
-              "value": {
-                "kind": "tree",
-                "values": {
-                  "registry": {
-                    "kind": "literal",
-                    "value": {
-                      "kind": "string",
-                      "value": "worldgen/biome"
-                    }
-                  },
-                  "tags": {
-                    "kind": "reference",
-                    "path": "::test::allowed"
+            "kind": "boolean",
+            "attributes": [
+              {
+                "name": "since",
+                "value": {
+                  "kind": "literal",
+                  "value": {
+                    "kind": "double",
+                    "value": 1.17
+                  }
+                }
+              },
+              {
+                "name": "until",
+                "value": {
+                  "kind": "literal",
+                  "value": {
+                    "kind": "double",
+                    "value": 1.2
                   }
                 }
               }
-            },
-            "child": {
-              "kind": "string"
-            }
+            ]
           }
         },
         "subcategory": "type_alias",
@@ -164,7 +162,7 @@ exports['mcdoc __fixture__ attributed types 1'] = {
             "uri": "file:///test.mcdoc",
             "range": {
               "start": 83,
-              "end": 92
+              "end": 91
             },
             "posRange": {
               "start": {
@@ -173,12 +171,12 @@ exports['mcdoc __fixture__ attributed types 1'] = {
               },
               "end": {
                 "line": 2,
-                "character": 14
+                "character": 13
               }
             },
             "fullRange": {
               "start": 78,
-              "end": 148
+              "end": 130
             },
             "fullPosRange": {
               "start": {
@@ -194,35 +192,31 @@ exports['mcdoc __fixture__ attributed types 1'] = {
           }
         ]
       },
-      "::test::EnumValue": {
+      "::test::TreeValue": {
         "data": {
           "typeDef": {
-            "kind": "attributed",
-            "attribute": {
-              "name": "bitfield",
-              "value": {
-                "kind": "tree",
-                "values": {
-                  "0": {
-                    "kind": "enum",
-                    "enumKind": "int",
-                    "values": [
-                      {
-                        "identifier": "HandAll",
-                        "value": 1
-                      },
-                      {
-                        "identifier": "BootsAll",
-                        "value": 2
+            "kind": "string",
+            "attributes": [
+              {
+                "name": "id",
+                "value": {
+                  "kind": "tree",
+                  "values": {
+                    "registry": {
+                      "kind": "literal",
+                      "value": {
+                        "kind": "string",
+                        "value": "worldgen/biome"
                       }
-                    ]
+                    },
+                    "tags": {
+                      "kind": "reference",
+                      "path": "::test::allowed"
+                    }
                   }
                 }
               }
-            },
-            "child": {
-              "kind": "int"
-            }
+            ]
           }
         },
         "subcategory": "type_alias",
@@ -230,8 +224,8 @@ exports['mcdoc __fixture__ attributed types 1'] = {
           {
             "uri": "file:///test.mcdoc",
             "range": {
-              "start": 153,
-              "end": 162
+              "start": 135,
+              "end": 144
             },
             "posRange": {
               "start": {
@@ -244,8 +238,8 @@ exports['mcdoc __fixture__ attributed types 1'] = {
               }
             },
             "fullRange": {
-              "start": 148,
-              "end": 224
+              "start": 130,
+              "end": 200
             },
             "fullPosRange": {
               "start": {
@@ -253,7 +247,73 @@ exports['mcdoc __fixture__ attributed types 1'] = {
                 "character": 0
               },
               "end": {
-                "line": 6,
+                "line": 4,
+                "character": 0
+              }
+            },
+            "contributor": "binder"
+          }
+        ]
+      },
+      "::test::EnumValue": {
+        "data": {
+          "typeDef": {
+            "kind": "int",
+            "attributes": [
+              {
+                "name": "bitfield",
+                "value": {
+                  "kind": "tree",
+                  "values": {
+                    "0": {
+                      "kind": "enum",
+                      "enumKind": "int",
+                      "values": [
+                        {
+                          "identifier": "HandAll",
+                          "value": 1
+                        },
+                        {
+                          "identifier": "BootsAll",
+                          "value": 2
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        },
+        "subcategory": "type_alias",
+        "definition": [
+          {
+            "uri": "file:///test.mcdoc",
+            "range": {
+              "start": 205,
+              "end": 214
+            },
+            "posRange": {
+              "start": {
+                "line": 4,
+                "character": 5
+              },
+              "end": {
+                "line": 4,
+                "character": 14
+              }
+            },
+            "fullRange": {
+              "start": 200,
+              "end": 276
+            },
+            "fullPosRange": {
+              "start": {
+                "line": 4,
+                "character": 0
+              },
+              "end": {
+                "line": 7,
                 "character": 7
               }
             },
@@ -283,16 +343,16 @@ exports['mcdoc __fixture__ attributed types 1'] = {
           {
             "uri": "file:///test.mcdoc",
             "range": {
-              "start": 176,
-              "end": 180
+              "start": 228,
+              "end": 232
             },
             "posRange": {
               "start": {
-                "line": 3,
+                "line": 4,
                 "character": 28
               },
               "end": {
-                "line": 3,
+                "line": 4,
                 "character": 32
               }
             },
@@ -307,7 +367,7 @@ exports['mcdoc __fixture__ attributed types 1'] = {
       "type": "file",
       "range": {
         "start": 0,
-        "end": 224
+        "end": 276
       },
       "children": [
         {
@@ -489,7 +549,143 @@ exports['mcdoc __fixture__ attributed types 1'] = {
                   "type": "mcdoc:identifier",
                   "range": {
                     "start": 83,
-                    "end": 92
+                    "end": 91
+                  },
+                  "value": "Multiple",
+                  "symbol": {
+                    "category": "mcdoc",
+                    "path": [
+                      "::test::Multiple"
+                    ]
+                  }
+                },
+                {
+                  "type": "mcdoc:type/boolean",
+                  "children": [
+                    {
+                      "type": "mcdoc:attribute",
+                      "children": [
+                        {
+                          "type": "mcdoc:identifier",
+                          "range": {
+                            "start": 96,
+                            "end": 101
+                          },
+                          "value": "since"
+                        },
+                        {
+                          "type": "mcdoc:type/literal",
+                          "children": [
+                            {
+                              "type": "mcdoc:typed_number",
+                              "children": [
+                                {
+                                  "type": "float",
+                                  "range": {
+                                    "start": 102,
+                                    "end": 106
+                                  },
+                                  "value": 1.17
+                                }
+                              ],
+                              "range": {
+                                "start": 102,
+                                "end": 106
+                              }
+                            }
+                          ],
+                          "range": {
+                            "start": 102,
+                            "end": 106
+                          }
+                        }
+                      ],
+                      "range": {
+                        "start": 94,
+                        "end": 108
+                      }
+                    },
+                    {
+                      "type": "mcdoc:attribute",
+                      "children": [
+                        {
+                          "type": "mcdoc:identifier",
+                          "range": {
+                            "start": 110,
+                            "end": 115
+                          },
+                          "value": "until"
+                        },
+                        {
+                          "type": "mcdoc:type/literal",
+                          "children": [
+                            {
+                              "type": "mcdoc:typed_number",
+                              "children": [
+                                {
+                                  "type": "float",
+                                  "range": {
+                                    "start": 116,
+                                    "end": 120
+                                  },
+                                  "value": 1.2
+                                }
+                              ],
+                              "range": {
+                                "start": 116,
+                                "end": 120
+                              }
+                            }
+                          ],
+                          "range": {
+                            "start": 116,
+                            "end": 120
+                          }
+                        }
+                      ],
+                      "range": {
+                        "start": 108,
+                        "end": 122
+                      }
+                    },
+                    {
+                      "type": "mcdoc:literal",
+                      "range": {
+                        "start": 122,
+                        "end": 129
+                      },
+                      "value": "boolean",
+                      "colorTokenType": "type"
+                    }
+                  ],
+                  "range": {
+                    "start": 94,
+                    "end": 130
+                  }
+                }
+              ],
+              "range": {
+                "start": 78,
+                "end": 130
+              }
+            },
+            {
+              "type": "mcdoc:type_alias",
+              "children": [
+                {
+                  "type": "mcdoc:literal",
+                  "range": {
+                    "start": 130,
+                    "end": 134
+                  },
+                  "value": "type",
+                  "colorTokenType": "keyword"
+                },
+                {
+                  "type": "mcdoc:identifier",
+                  "range": {
+                    "start": 135,
+                    "end": 144
                   },
                   "value": "TreeValue",
                   "symbol": {
@@ -508,16 +704,16 @@ exports['mcdoc __fixture__ attributed types 1'] = {
                         {
                           "type": "mcdoc:identifier",
                           "range": {
-                            "start": 97,
-                            "end": 99
+                            "start": 149,
+                            "end": 151
                           },
                           "value": "id"
                         },
                         {
                           "type": "mcdoc:attribute/tree",
                           "range": {
-                            "start": 100,
-                            "end": 138
+                            "start": 152,
+                            "end": 190
                           },
                           "children": [
                             {
@@ -526,8 +722,8 @@ exports['mcdoc __fixture__ attributed types 1'] = {
                                 {
                                   "type": "mcdoc:identifier",
                                   "range": {
-                                    "start": 100,
-                                    "end": 108
+                                    "start": 152,
+                                    "end": 160
                                   },
                                   "value": "registry"
                                 },
@@ -537,8 +733,8 @@ exports['mcdoc __fixture__ attributed types 1'] = {
                                     {
                                       "type": "string",
                                       "range": {
-                                        "start": 109,
-                                        "end": 125
+                                        "start": 161,
+                                        "end": 177
                                       },
                                       "value": "worldgen/biome",
                                       "valueMap": [
@@ -548,23 +744,23 @@ exports['mcdoc __fixture__ attributed types 1'] = {
                                             "end": 0
                                           },
                                           "outer": {
-                                            "start": 110,
-                                            "end": 110
+                                            "start": 162,
+                                            "end": 162
                                           }
                                         }
                                       ]
                                     }
                                   ],
                                   "range": {
-                                    "start": 109,
-                                    "end": 125
+                                    "start": 161,
+                                    "end": 177
                                   }
                                 },
                                 {
                                   "type": "mcdoc:identifier",
                                   "range": {
-                                    "start": 126,
-                                    "end": 130
+                                    "start": 178,
+                                    "end": 182
                                   },
                                   "value": "tags"
                                 },
@@ -577,27 +773,27 @@ exports['mcdoc __fixture__ attributed types 1'] = {
                                         {
                                           "type": "mcdoc:identifier",
                                           "range": {
-                                            "start": 131,
-                                            "end": 138
+                                            "start": 183,
+                                            "end": 190
                                           },
                                           "value": "allowed"
                                         }
                                       ],
                                       "range": {
-                                        "start": 131,
-                                        "end": 138
+                                        "start": 183,
+                                        "end": 190
                                       }
                                     }
                                   ],
                                   "range": {
-                                    "start": 131,
-                                    "end": 138
+                                    "start": 183,
+                                    "end": 190
                                   }
                                 }
                               ],
                               "range": {
-                                "start": 100,
-                                "end": 138
+                                "start": 152,
+                                "end": 190
                               }
                             }
                           ],
@@ -605,29 +801,29 @@ exports['mcdoc __fixture__ attributed types 1'] = {
                         }
                       ],
                       "range": {
-                        "start": 95,
-                        "end": 141
+                        "start": 147,
+                        "end": 193
                       }
                     },
                     {
                       "type": "mcdoc:literal",
                       "range": {
-                        "start": 141,
-                        "end": 147
+                        "start": 193,
+                        "end": 199
                       },
                       "value": "string",
                       "colorTokenType": "type"
                     }
                   ],
                   "range": {
-                    "start": 95,
-                    "end": 148
+                    "start": 147,
+                    "end": 200
                   }
                 }
               ],
               "range": {
-                "start": 78,
-                "end": 148
+                "start": 130,
+                "end": 200
               }
             },
             {
@@ -636,8 +832,8 @@ exports['mcdoc __fixture__ attributed types 1'] = {
                 {
                   "type": "mcdoc:literal",
                   "range": {
-                    "start": 148,
-                    "end": 152
+                    "start": 200,
+                    "end": 204
                   },
                   "value": "type",
                   "colorTokenType": "keyword"
@@ -645,8 +841,8 @@ exports['mcdoc __fixture__ attributed types 1'] = {
                 {
                   "type": "mcdoc:identifier",
                   "range": {
-                    "start": 153,
-                    "end": 162
+                    "start": 205,
+                    "end": 214
                   },
                   "value": "EnumValue",
                   "symbol": {
@@ -665,16 +861,16 @@ exports['mcdoc __fixture__ attributed types 1'] = {
                         {
                           "type": "mcdoc:identifier",
                           "range": {
-                            "start": 167,
-                            "end": 175
+                            "start": 219,
+                            "end": 227
                           },
                           "value": "bitfield"
                         },
                         {
                           "type": "mcdoc:attribute/tree",
                           "range": {
-                            "start": 176,
-                            "end": 218
+                            "start": 228,
+                            "end": 270
                           },
                           "children": [
                             {
@@ -686,8 +882,8 @@ exports['mcdoc __fixture__ attributed types 1'] = {
                                     {
                                       "type": "mcdoc:literal",
                                       "range": {
-                                        "start": 176,
-                                        "end": 180
+                                        "start": 228,
+                                        "end": 232
                                       },
                                       "value": "enum",
                                       "colorTokenType": "keyword",
@@ -701,8 +897,8 @@ exports['mcdoc __fixture__ attributed types 1'] = {
                                     {
                                       "type": "mcdoc:literal",
                                       "range": {
-                                        "start": 181,
-                                        "end": 184
+                                        "start": 233,
+                                        "end": 236
                                       },
                                       "value": "int",
                                       "colorTokenType": "type"
@@ -716,8 +912,8 @@ exports['mcdoc __fixture__ attributed types 1'] = {
                                             {
                                               "type": "mcdoc:identifier",
                                               "range": {
-                                                "start": 189,
-                                                "end": 196
+                                                "start": 241,
+                                                "end": 248
                                               },
                                               "value": "HandAll"
                                             },
@@ -727,21 +923,21 @@ exports['mcdoc __fixture__ attributed types 1'] = {
                                                 {
                                                   "type": "integer",
                                                   "range": {
-                                                    "start": 199,
-                                                    "end": 200
+                                                    "start": 251,
+                                                    "end": 252
                                                   },
                                                   "value": 1
                                                 }
                                               ],
                                               "range": {
-                                                "start": 199,
-                                                "end": 200
+                                                "start": 251,
+                                                "end": 252
                                               }
                                             }
                                           ],
                                           "range": {
-                                            "start": 189,
-                                            "end": 200
+                                            "start": 241,
+                                            "end": 252
                                           }
                                         },
                                         {
@@ -750,8 +946,8 @@ exports['mcdoc __fixture__ attributed types 1'] = {
                                             {
                                               "type": "mcdoc:identifier",
                                               "range": {
-                                                "start": 203,
-                                                "end": 211
+                                                "start": 255,
+                                                "end": 263
                                               },
                                               "value": "BootsAll"
                                             },
@@ -761,39 +957,39 @@ exports['mcdoc __fixture__ attributed types 1'] = {
                                                 {
                                                   "type": "integer",
                                                   "range": {
-                                                    "start": 214,
-                                                    "end": 215
+                                                    "start": 266,
+                                                    "end": 267
                                                   },
                                                   "value": 2
                                                 }
                                               ],
                                               "range": {
-                                                "start": 214,
-                                                "end": 215
+                                                "start": 266,
+                                                "end": 267
                                               }
                                             }
                                           ],
                                           "range": {
-                                            "start": 203,
-                                            "end": 215
+                                            "start": 255,
+                                            "end": 267
                                           }
                                         }
                                       ],
                                       "range": {
-                                        "start": 186,
-                                        "end": 218
+                                        "start": 238,
+                                        "end": 270
                                       }
                                     }
                                   ],
                                   "range": {
-                                    "start": 176,
-                                    "end": 218
+                                    "start": 228,
+                                    "end": 270
                                   }
                                 }
                               ],
                               "range": {
-                                "start": 176,
-                                "end": 218
+                                "start": 228,
+                                "end": 270
                               }
                             }
                           ],
@@ -801,35 +997,35 @@ exports['mcdoc __fixture__ attributed types 1'] = {
                         }
                       ],
                       "range": {
-                        "start": 165,
-                        "end": 221
+                        "start": 217,
+                        "end": 273
                       }
                     },
                     {
                       "type": "mcdoc:literal",
                       "range": {
-                        "start": 221,
-                        "end": 224
+                        "start": 273,
+                        "end": 276
                       },
                       "value": "int",
                       "colorTokenType": "type"
                     }
                   ],
                   "range": {
-                    "start": 165,
-                    "end": 224
+                    "start": 217,
+                    "end": 276
                   }
                 }
               ],
               "range": {
-                "start": 148,
-                "end": 224
+                "start": 200,
+                "end": 276
               }
             }
           ],
           "range": {
             "start": 0,
-            "end": 224
+            "end": 276
           }
         }
       ],

--- a/__snapshots__/packages/mcdoc/test-out/__fixture__/dispatcher/random_number_generator.spec.js
+++ b/__snapshots__/packages/mcdoc/test-out/__fixture__/dispatcher/random_number_generator.spec.js
@@ -618,45 +618,44 @@ exports['mcdoc __fixture__ dispatcher/random number generator 1'] = {
           "binomial": {
             "data": {
               "typeDef": {
-                "kind": "attributed",
-                "attribute": {
-                  "name": "since",
-                  "value": {
-                    "kind": "literal",
-                    "value": {
-                      "kind": "double",
-                      "value": 1.18
+                "kind": "struct",
+                "fields": [
+                  {
+                    "kind": "pair",
+                    "key": "n",
+                    "type": {
+                      "kind": "int",
+                      "valueRange": {
+                        "kind": 0,
+                        "min": 0
+                      }
+                    }
+                  },
+                  {
+                    "kind": "pair",
+                    "key": "p",
+                    "type": {
+                      "kind": "float",
+                      "valueRange": {
+                        "kind": 0,
+                        "min": 0,
+                        "max": 1
+                      }
                     }
                   }
-                },
-                "child": {
-                  "kind": "struct",
-                  "fields": [
-                    {
-                      "kind": "pair",
-                      "key": "n",
-                      "type": {
-                        "kind": "int",
-                        "valueRange": {
-                          "kind": 0,
-                          "min": 0
-                        }
-                      }
-                    },
-                    {
-                      "kind": "pair",
-                      "key": "p",
-                      "type": {
-                        "kind": "float",
-                        "valueRange": {
-                          "kind": 0,
-                          "min": 0,
-                          "max": 1
-                        }
+                ],
+                "attributes": [
+                  {
+                    "name": "since",
+                    "value": {
+                      "kind": "literal",
+                      "value": {
+                        "kind": "double",
+                        "value": 1.18
                       }
                     }
-                  ]
-                }
+                  }
+                ]
               }
             },
             "definition": [

--- a/__snapshots__/packages/mcdoc/test-out/__fixture__/struct/nested_spread.spec.js
+++ b/__snapshots__/packages/mcdoc/test-out/__fixture__/struct/nested_spread.spec.js
@@ -47,31 +47,30 @@ exports['mcdoc __fixture__ struct/nested spread 1'] = {
                   }
                 ],
                 "type": {
-                  "kind": "attributed",
-                  "attribute": {
-                    "name": "expandable"
-                  },
-                  "child": {
-                    "kind": "struct",
-                    "fields": [
-                      {
-                        "kind": "spread",
-                        "type": {
-                          "kind": "dispatcher",
-                          "parallelIndices": [
-                            {
-                              "kind": "dynamic",
-                              "accessor": [
-                                "%parent",
-                                "type"
-                              ]
-                            }
-                          ],
-                          "registry": "minecraft:carver_config"
-                        }
+                  "kind": "struct",
+                  "fields": [
+                    {
+                      "kind": "spread",
+                      "type": {
+                        "kind": "dispatcher",
+                        "parallelIndices": [
+                          {
+                            "kind": "dynamic",
+                            "accessor": [
+                              "%parent",
+                              "type"
+                            ]
+                          }
+                        ],
+                        "registry": "minecraft:carver_config"
                       }
-                    ]
-                  }
+                    }
+                  ],
+                  "attributes": [
+                    {
+                      "name": "expandable"
+                    }
+                  ]
                 }
               }
             ]
@@ -116,31 +115,30 @@ exports['mcdoc __fixture__ struct/nested spread 1'] = {
       "::test::<anonymous 0>": {
         "data": {
           "typeDef": {
-            "kind": "attributed",
-            "attribute": {
-              "name": "expandable"
-            },
-            "child": {
-              "kind": "struct",
-              "fields": [
-                {
-                  "kind": "spread",
-                  "type": {
-                    "kind": "dispatcher",
-                    "parallelIndices": [
-                      {
-                        "kind": "dynamic",
-                        "accessor": [
-                          "%parent",
-                          "type"
-                        ]
-                      }
-                    ],
-                    "registry": "minecraft:carver_config"
-                  }
+            "kind": "struct",
+            "fields": [
+              {
+                "kind": "spread",
+                "type": {
+                  "kind": "dispatcher",
+                  "parallelIndices": [
+                    {
+                      "kind": "dynamic",
+                      "accessor": [
+                        "%parent",
+                        "type"
+                      ]
+                    }
+                  ],
+                  "registry": "minecraft:carver_config"
                 }
-              ]
-            }
+              }
+            ],
+            "attributes": [
+              {
+                "name": "expandable"
+              }
+            ]
           }
         },
         "subcategory": "struct",

--- a/__snapshots__/packages/mcdoc/test-out/__fixture__/struct/simple.spec.js
+++ b/__snapshots__/packages/mcdoc/test-out/__fixture__/struct/simple.spec.js
@@ -55,13 +55,12 @@ exports['mcdoc __fixture__ struct/simple 1'] = {
                 ],
                 "key": "Bar",
                 "type": {
-                  "kind": "attributed",
-                  "attribute": {
-                    "name": "id"
-                  },
-                  "child": {
-                    "kind": "string"
-                  }
+                  "kind": "string",
+                  "attributes": [
+                    {
+                      "name": "id"
+                    }
+                  ]
                 },
                 "optional": true
               }

--- a/__snapshots__/packages/mcdoc/test-out/__fixture__/type_alias/attributed.spec.js
+++ b/__snapshots__/packages/mcdoc/test-out/__fixture__/type_alias/attributed.spec.js
@@ -30,24 +30,23 @@ exports['mcdoc __fixture__ type alias/attributed 1'] = {
       "::test::Foo": {
         "data": {
           "typeDef": {
-            "kind": "attributed",
-            "attribute": {
-              "name": "since",
-              "value": {
-                "kind": "literal",
+            "kind": "literal",
+            "value": {
+              "kind": "boolean",
+              "value": true
+            },
+            "attributes": [
+              {
+                "name": "since",
                 "value": {
-                  "kind": "double",
-                  "value": 1.18
+                  "kind": "literal",
+                  "value": {
+                    "kind": "double",
+                    "value": 1.18
+                  }
                 }
               }
-            },
-            "child": {
-              "kind": "literal",
-              "value": {
-                "kind": "boolean",
-                "value": true
-              }
-            }
+            ]
           }
         },
         "subcategory": "type_alias",

--- a/packages/java-edition/src/json/checker/index.ts
+++ b/packages/java-edition/src/json/checker/index.ts
@@ -184,7 +184,6 @@ export function fieldValue(type: mcdoc.McdocType): core.SyncChecker<JsonNode> {
 			type.kind !== 'literal' &&
 			type.kind !== 'reference' &&
 			type.kind !== 'union' &&
-			type.kind !== 'attributed' &&
 			type.kind !== 'unsafe' &&
 			type.kind !== 'concrete' &&
 			type.kind !== 'indexed' &&
@@ -339,10 +338,6 @@ export function fieldValue(type: mcdoc.McdocType): core.SyncChecker<JsonNode> {
 						) as core.SyncChecker<JsonNode>
 					)(node, ctx)
 				}
-				break
-			case 'attributed':
-				// TODO: don't just ignore the attribute
-				fieldValue(type.child)(node, ctx)
 				break
 		}
 	}

--- a/packages/mcdoc/src/binder/index.ts
+++ b/packages/mcdoc/src/binder/index.ts
@@ -228,8 +228,7 @@ function hoist(node: ModuleNode, ctx: McdocBinderContext): void {
 			if (typeParams) {
 				bindTypeParamBlock(node, typeParams, ans, ctx)
 			}
-			ans.typeDef = attributeType(ans.typeDef, attributes, ctx)
-
+			appendAttributes(ans.typeDef, attributes, ctx);
 			return ans
 		})
 	}
@@ -397,7 +396,7 @@ async function bindDispatchStatement(
 		if (typeParams) {
 			bindTypeParamBlock(node, typeParams, data, ctx)
 		}
-		data.typeDef = attributeType(data.typeDef, attributes, ctx)
+		appendAttributes(data.typeDef, attributes, ctx);
 
 		for (const key of parallelIndices) {
 			if (DynamicIndexNode.is(key)) {
@@ -848,25 +847,20 @@ function wrapType(
 			}
 		}
 	}
-	ans = attributeType(ans, attributes, ctx)
+	ans.attributes = convertAttributes(attributes, ctx)
 	return ans
 }
 
-function attributeType(
-	type: McdocType,
-	attributes: AttributeNode[],
-	ctx: McdocBinderContext,
-): McdocType {
-	for (const attribute of attributes) {
-		type = {
-			kind: 'attributed',
-			attribute: convertAttribute(attribute, ctx),
-			child: type,
+function appendAttributes(typeDef: McdocType, attributes: AttributeNode[], ctx: McdocBinderContext) {
+	const convertedAttributes = convertAttributes(attributes, ctx);
+	if (convertedAttributes) {
+		if (typeDef.attributes) {
+			typeDef.attributes = [ ...typeDef.attributes, ...convertedAttributes ];
+		} else {
+			typeDef.attributes = convertedAttributes;
 		}
 	}
-	return type
 }
-
 function convertAttributes(
 	nodes: AttributeNode[],
 	ctx: McdocBinderContext,

--- a/packages/mcdoc/src/binder/index.ts
+++ b/packages/mcdoc/src/binder/index.ts
@@ -228,7 +228,7 @@ function hoist(node: ModuleNode, ctx: McdocBinderContext): void {
 			if (typeParams) {
 				bindTypeParamBlock(node, typeParams, ans, ctx)
 			}
-			appendAttributes(ans.typeDef, attributes, ctx);
+			appendAttributes(ans.typeDef, attributes, ctx)
 			return ans
 		})
 	}
@@ -396,7 +396,7 @@ async function bindDispatchStatement(
 		if (typeParams) {
 			bindTypeParamBlock(node, typeParams, data, ctx)
 		}
-		appendAttributes(data.typeDef, attributes, ctx);
+		appendAttributes(data.typeDef, attributes, ctx)
 
 		for (const key of parallelIndices) {
 			if (DynamicIndexNode.is(key)) {
@@ -851,13 +851,17 @@ function wrapType(
 	return ans
 }
 
-function appendAttributes(typeDef: McdocType, attributes: AttributeNode[], ctx: McdocBinderContext) {
-	const convertedAttributes = convertAttributes(attributes, ctx);
+function appendAttributes(
+	typeDef: McdocType,
+	attributes: AttributeNode[],
+	ctx: McdocBinderContext,
+) {
+	const convertedAttributes = convertAttributes(attributes, ctx)
 	if (convertedAttributes) {
 		if (typeDef.attributes) {
-			typeDef.attributes = [ ...typeDef.attributes, ...convertedAttributes ];
+			typeDef.attributes = [...typeDef.attributes, ...convertedAttributes]
 		} else {
-			typeDef.attributes = convertedAttributes;
+			typeDef.attributes = convertedAttributes
 		}
 	}
 }

--- a/packages/mcdoc/src/type/index.ts
+++ b/packages/mcdoc/src/type/index.ts
@@ -48,68 +48,59 @@ export interface DispatcherData {
 	parallelIndices: ParallelIndices
 }
 
-export interface DispatcherType extends DispatcherData {
+export interface DispatcherType extends DispatcherData, McdocBaseType {
 	kind: 'dispatcher'
 }
 
-export interface StructType {
+export interface StructType extends McdocBaseType {
 	kind: 'struct'
 	fields: StructTypeField[]
 }
 export type StructTypeField = StructTypePairField | StructTypeSpreadField
-export interface StructTypePairField {
+export interface StructTypePairField extends McdocBaseType {
 	kind: 'pair'
-	attributes?: Attribute[]
 	key: string | McdocType
 	type: McdocType
 	optional?: boolean
 }
-export interface StructTypeSpreadField {
+export interface StructTypeSpreadField extends McdocBaseType {
 	kind: 'spread'
-	attributes?: Attribute[]
 	type: McdocType
 }
 
-export interface EnumType {
+export interface EnumType extends McdocBaseType {
 	kind: 'enum'
 	enumKind?: EnumKind
 	values: EnumTypeField[]
 }
-export interface EnumTypeField {
-	attributes?: Attribute[]
+export interface EnumTypeField extends McdocBaseType {
 	identifier: string
 	value: string | number | bigint
 }
 
-export interface ReferenceType {
+export interface ReferenceType extends McdocBaseType {
 	kind: 'reference'
 	path?: string
 }
 
-export interface UnionType<T extends McdocType = McdocType> {
+export interface UnionType<T extends McdocType = McdocType> extends McdocBaseType {
 	kind: 'union'
 	members: T[]
 }
 
-export interface AttributedType {
-	kind: 'attributed'
-	attribute: Attribute
-	child: McdocType
-}
-
-export interface IndexedType {
+export interface IndexedType extends McdocBaseType {
 	kind: 'indexed'
 	parallelIndices: Index[]
 	child: McdocType
 }
 
-export interface TemplateType {
+export interface TemplateType extends McdocBaseType {
 	kind: 'template'
 	child: McdocType
 	typeParams: { path: string }[]
 }
 
-export interface ConcreteType {
+export interface ConcreteType extends McdocBaseType {
 	kind: 'concrete'
 	child: McdocType
 	typeArgs: McdocType[]
@@ -128,11 +119,11 @@ export function createEmptyUnion(
 	}
 }
 
-export interface KeywordType {
+export interface KeywordType extends McdocBaseType {
 	kind: 'any' | 'boolean' | 'unsafe'
 }
 
-export interface StringType {
+export interface StringType extends McdocBaseType {
 	kind: 'string'
 	lengthRange?: NumericRange
 }
@@ -153,12 +144,12 @@ export interface LiteralNumericValue {
 	kind: NumericTypeKind
 	value: number
 }
-export interface LiteralType {
+export interface LiteralType extends McdocBaseType {
 	kind: 'literal'
 	value: LiteralValue
 }
 
-export interface NumericType {
+export interface NumericType extends McdocBaseType {
 	kind: NumericTypeKind
 	valueRange?: NumericRange
 }
@@ -181,7 +172,7 @@ export const NumericTypeKinds = Object.freeze(
 )
 export type NumericTypeKind = (typeof NumericTypeKinds)[number]
 
-export interface PrimitiveArrayType {
+export interface PrimitiveArrayType extends McdocBaseType {
 	kind: 'byte_array' | 'int_array' | 'long_array'
 	valueRange?: NumericRange
 	lengthRange?: NumericRange
@@ -199,15 +190,19 @@ export const PrimitiveArrayKinds = Object.freeze(
 )
 export type PrimitiveArrayKind = (typeof PrimitiveArrayKinds)[number]
 
-export interface ListType {
+export interface ListType extends McdocBaseType {
 	kind: 'list'
 	item: McdocType
 	lengthRange?: NumericRange
 }
 
-export interface TupleType {
+export interface TupleType extends McdocBaseType {
 	kind: 'tuple'
 	items: McdocType[]
+}
+
+export interface McdocBaseType {
+	attributes?: Attribute[]
 }
 
 export type McdocType =
@@ -223,7 +218,6 @@ export type McdocType =
 	| StructType
 	| TupleType
 	| UnionType
-	| AttributedType
 	| IndexedType
 	| TemplateType
 	| ConcreteType
@@ -264,89 +258,116 @@ export namespace McdocType {
 		if (type === undefined) {
 			return '<unknown>'
 		}
+		let attributesString = ''
+		if (type.attributes?.length) {
+			for (const attribute of type.attributes) {
+				attributesString += `#[${attribute.name}${attribute.value ? '=<value ...>' : ''}] `
+			}
+		}
+		let typeString: string;
 		switch (type.kind) {
 			case 'any':
 			case 'boolean':
-				return type.kind
-			case 'attributed':
-				return `#[${type.attribute.name}${
-					type.attribute.value ? '=<value ...>' : ''
-				}] ${toString(type.child)}`
+				typeString = type.kind
+				break;
 			case 'byte':
-				return `byte${rangeToString(type.valueRange)}`
+				typeString = `byte${rangeToString(type.valueRange)}`
+				break;
 			case 'byte_array':
-				return `byte${rangeToString(type.valueRange)}[]${
+				typeString = `byte${rangeToString(type.valueRange)}[]${
 					rangeToString(
 						type.lengthRange,
 					)
 				}`
+				break;
 			case 'concrete':
-				return `${toString(type.child)}${
+				typeString = `${toString(type.child)}${
 					type.typeArgs.length
 						? `<${type.typeArgs.map(toString).join(', ')}>`
 						: ''
 				}`
+				break;
 			case 'dispatcher':
-				return `${type.registry ?? 'spyglass:unknown'}[${
+				typeString = `${type.registry ?? 'spyglass:unknown'}[${
 					indicesToString(
 						type.parallelIndices,
 					)
 				}]`
+				break;
 			case 'double':
-				return `double${rangeToString(type.valueRange)}`
+				typeString = `double${rangeToString(type.valueRange)}`
+				break;
 			case 'enum':
-				return '<enum ...>'
+				typeString = '<enum ...>'
+				break;
 			case 'float':
-				return `float${rangeToString(type.valueRange)}`
+				typeString = `float${rangeToString(type.valueRange)}`
+				break;
 			case 'indexed':
-				return `${toString(type.child)}${
+				typeString = `${toString(type.child)}${
 					indicesToString(type.parallelIndices)
 				}`
+				break;
 			case 'int':
-				return `int${rangeToString(type.valueRange)}`
+				typeString = `int${rangeToString(type.valueRange)}`
+				break;
 			case 'int_array':
-				return `int${rangeToString(type.valueRange)}[]${
+				typeString = `int${rangeToString(type.valueRange)}[]${
 					rangeToString(
 						type.lengthRange,
 					)
 				}`
+				break;
 			case 'list':
-				return `[${toString(type.item)}]${rangeToString(type.lengthRange)}`
+				typeString = `[${toString(type.item)}]${rangeToString(type.lengthRange)}`
+				break;
 			case 'literal':
-				return `${type.value}`
+				typeString = `${type.value}`
+				break;
 			case 'long':
-				return `long${rangeToString(type.valueRange)}`
+				typeString = `long${rangeToString(type.valueRange)}`
+				break;
 			case 'long_array':
-				return `long${rangeToString(type.valueRange)}[]${
+				typeString = `long${rangeToString(type.valueRange)}[]${
 					rangeToString(
 						type.lengthRange,
 					)
 				}`
+				break;
 			case 'reference':
-				return type.path ?? '<unknown_reference>'
+				typeString = type.path ?? '<unknown_reference>'
+				break;
 			case 'short':
-				return `short${rangeToString(type.valueRange)}`
+				typeString = `short${rangeToString(type.valueRange)}`
+				break;
 			case 'string':
-				return `string${rangeToString(type.lengthRange)}`
+				typeString = `string${rangeToString(type.lengthRange)}`
+				break;
 			case 'struct':
-				return '<struct ...>'
+				typeString = '<struct ...>'
+				break;
 			case 'template':
-				return `${toString(type.child)}${
+				typeString = `${toString(type.child)}${
 					type.typeParams.length
 						? `<${type.typeParams.map((v) => `?${v.path}`).join(', ')}>`
 						: ''
 				}`
+				break;
 			case 'tuple':
-				return `[${type.items.map((v) => toString(v)).join(',')}${
+				typeString = `[${type.items.map((v) => toString(v)).join(',')}${
 					type.items.length === 1 ? ',' : ''
 				}]`
+				break;
 			case 'union':
-				return `(${type.members.map(toString).join(' | ')})`
+				typeString = `(${type.members.map(toString).join(' | ')})`
+				break;
 			case 'unsafe':
-				return 'unsafe'
+				typeString = 'unsafe'
+				break;
 			default:
-				return Dev.assertNever(type)
+				Dev.assertNever(type)
 		}
+		return attributesString + typeString
 	}
 }
 

--- a/packages/mcdoc/src/type/index.ts
+++ b/packages/mcdoc/src/type/index.ts
@@ -83,7 +83,9 @@ export interface ReferenceType extends McdocBaseType {
 	path?: string
 }
 
-export interface UnionType<T extends McdocType = McdocType> extends McdocBaseType {
+export interface UnionType<T extends McdocType = McdocType>
+	extends McdocBaseType
+{
 	kind: 'union'
 	members: T[]
 }
@@ -261,109 +263,113 @@ export namespace McdocType {
 		let attributesString = ''
 		if (type.attributes?.length) {
 			for (const attribute of type.attributes) {
-				attributesString += `#[${attribute.name}${attribute.value ? '=<value ...>' : ''}] `
+				attributesString += `#[${attribute.name}${
+					attribute.value ? '=<value ...>' : ''
+				}] `
 			}
 		}
-		let typeString: string;
+		let typeString: string
 		switch (type.kind) {
 			case 'any':
 			case 'boolean':
 				typeString = type.kind
-				break;
+				break
 			case 'byte':
 				typeString = `byte${rangeToString(type.valueRange)}`
-				break;
+				break
 			case 'byte_array':
 				typeString = `byte${rangeToString(type.valueRange)}[]${
 					rangeToString(
 						type.lengthRange,
 					)
 				}`
-				break;
+				break
 			case 'concrete':
 				typeString = `${toString(type.child)}${
 					type.typeArgs.length
 						? `<${type.typeArgs.map(toString).join(', ')}>`
 						: ''
 				}`
-				break;
+				break
 			case 'dispatcher':
 				typeString = `${type.registry ?? 'spyglass:unknown'}[${
 					indicesToString(
 						type.parallelIndices,
 					)
 				}]`
-				break;
+				break
 			case 'double':
 				typeString = `double${rangeToString(type.valueRange)}`
-				break;
+				break
 			case 'enum':
 				typeString = '<enum ...>'
-				break;
+				break
 			case 'float':
 				typeString = `float${rangeToString(type.valueRange)}`
-				break;
+				break
 			case 'indexed':
 				typeString = `${toString(type.child)}${
 					indicesToString(type.parallelIndices)
 				}`
-				break;
+				break
 			case 'int':
 				typeString = `int${rangeToString(type.valueRange)}`
-				break;
+				break
 			case 'int_array':
 				typeString = `int${rangeToString(type.valueRange)}[]${
 					rangeToString(
 						type.lengthRange,
 					)
 				}`
-				break;
+				break
 			case 'list':
-				typeString = `[${toString(type.item)}]${rangeToString(type.lengthRange)}`
-				break;
+				typeString = `[${toString(type.item)}]${
+					rangeToString(type.lengthRange)
+				}`
+				break
 			case 'literal':
 				typeString = `${type.value}`
-				break;
+				break
 			case 'long':
 				typeString = `long${rangeToString(type.valueRange)}`
-				break;
+				break
 			case 'long_array':
 				typeString = `long${rangeToString(type.valueRange)}[]${
 					rangeToString(
 						type.lengthRange,
 					)
 				}`
-				break;
+				break
 			case 'reference':
 				typeString = type.path ?? '<unknown_reference>'
-				break;
+				break
 			case 'short':
 				typeString = `short${rangeToString(type.valueRange)}`
-				break;
+				break
 			case 'string':
 				typeString = `string${rangeToString(type.lengthRange)}`
-				break;
+				break
 			case 'struct':
 				typeString = '<struct ...>'
-				break;
+				break
 			case 'template':
 				typeString = `${toString(type.child)}${
 					type.typeParams.length
 						? `<${type.typeParams.map((v) => `?${v.path}`).join(', ')}>`
 						: ''
 				}`
-				break;
+				break
 			case 'tuple':
 				typeString = `[${type.items.map((v) => toString(v)).join(',')}${
 					type.items.length === 1 ? ',' : ''
 				}]`
-				break;
+				break
 			case 'union':
 				typeString = `(${type.members.map(toString).join(' | ')})`
-				break;
+				break
 			case 'unsafe':
 				typeString = 'unsafe'
-				break;
+				break
 			default:
 				Dev.assertNever(type)
 		}

--- a/packages/mcdoc/test/__fixture__.mcdoc
+++ b/packages/mcdoc/test/__fixture__.mcdoc
@@ -71,6 +71,7 @@ type TupleTest1 = [string, boolean]
 //== attributed types
 type NoValue = #[deprecated] boolean
 type SimpleValue = #[since=1.19] boolean
+type Multiple = #[since=1.17] #[until=1.20] boolean
 type TreeValue = #[id(registry="worldgen/biome",tags=allowed)] string
 type EnumValue = #[bitfield(enum(int) {
 	HandAll = 1,

--- a/packages/nbt/src/checker/index.ts
+++ b/packages/nbt/src/checker/index.ts
@@ -431,7 +431,6 @@ export function fieldValue(
 			type.kind !== 'literal' &&
 			type.kind !== 'reference' &&
 			type.kind !== 'union' &&
-			type.kind !== 'attributed' &&
 			type.kind !== 'unsafe' &&
 			type.kind !== 'concrete' &&
 			type.kind !== 'indexed' &&
@@ -623,10 +622,6 @@ export function fieldValue(
 						) as core.SyncChecker<NbtNode>
 					)(node, ctx)
 				}
-				break
-			case 'attributed':
-				// TODO: don't just ignore the attribute
-				fieldValue(type.child, options)(node, ctx)
 				break
 		}
 	}


### PR DESCRIPTION
## Motivation
The attributed type contained a single attribute with another child, which itself could be an attributed type for multiple attributes on a single type.

This can be quite annoying to deal with, especially when different processes still need to be able to access attributes, but also you want to check whether a type node is of a certain type.

With the old concept, you'd need to essentially recurse into the type tree for as long as the current node is still an attributed type.

With this, all types can simply have attributes and they can be dealt with when appropriate.

This is also more consistent with `StructTypeField` and `EnumTypeField`.