### PR TITLE
🔧 Add long timeout arg to unit test launch configuration

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -26,6 +26,7 @@
 			"request": "launch",
 			"name": "Run Unit Tests",
 			"program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
+			"args": ["--timeout", "999999"],
 			"console": "integratedTerminal",
 			"internalConsoleOptions": "neverOpen"
 		}


### PR DESCRIPTION
- when you're debugging these, it's not unlikely you'd be in a test longer than 30s (the default timeout)
- new default is 999999s (11.5 days)

---

- split from https://github.com/SpyglassMC/Spyglass/pull/1180