### PR TITLE
✨ Add support for new particle format

### DIFF
--- a/packages/java-edition/src/mcfunction/completer/argument.ts
+++ b/packages/java-edition/src/mcfunction/completer/argument.ts
@@ -28,6 +28,7 @@ import * as json from '@spyglassmc/json'
 import { localeQuote, localize } from '@spyglassmc/locales'
 import type * as mcf from '@spyglassmc/mcfunction'
 import { getTagValues } from '../../common/index.js'
+import { ReleaseVersion } from '../../dependency/common.js'
 import {
 	ColorArgumentValues,
 	EntityAnchorArgumentValues,
@@ -297,6 +298,10 @@ const particle: Completer<ParticleNode> = (node, ctx) => {
 	const child = AstNode.findChild(node, ctx.offset, true)
 	if (child) {
 		return completer.dispatch(child, ctx)
+	}
+	const release = ctx.project['loadedVersion'] as ReleaseVersion | undefined
+	if (!release || ReleaseVersion.cmp(release, '1.20.5') >= 0) {
+		return []
 	}
 
 	const id = ResourceLocationNode.toString(node.id, 'short')

--- a/packages/java-edition/src/mcfunction/node/argument.ts
+++ b/packages/java-edition/src/mcfunction/node/argument.ts
@@ -368,12 +368,15 @@ export namespace ObjectiveCriteriaNode {
 export interface ParticleNode extends core.AstNode {
 	type: 'mcfunction:particle'
 	children?: (
+		| core.ResourceLocationNode
+		// Until 1.20.5
 		| core.FloatNode
 		| core.IntegerNode
-		| core.ResourceLocationNode
 		| BlockNode
 		| ItemNode
 		| VectorNode
+		// Since 1.20.5
+		| nbt.NbtCompoundNode
 	)[]
 	id: core.ResourceLocationNode
 }


### PR DESCRIPTION
Closes #1163

I looked at the tests for a bit but I didn't see a good way to test these parsers in multiple versions. Right now `mockProjectData` is hardcoded to 1.15. This might be something to do in a later PR.