### PR TITLE
🐛 Re-enable undeclared symbols linter

### DIFF
--- a/packages/core/src/processor/completer/builtin.ts
+++ b/packages/core/src/processor/completer/builtin.ts
@@ -23,7 +23,7 @@ import type { CompleterContext, MetaRegistry } from '../../service/index.js'
 import { LinterConfigValue } from '../../service/index.js'
 import type { RangeLike } from '../../source/index.js'
 import { Range } from '../../source/index.js'
-import type { TagFileCategory } from '../../symbol/index.js'
+import { SymbolUtil, type TagFileCategory } from '../../symbol/index.js'
 import type { ColorTokenType } from '../colorizer/index.js'
 import type { Completer } from './Completer.js'
 import { CompletionItem, CompletionKind } from './Completer.js'
@@ -189,10 +189,13 @@ export const resourceLocation: Completer<ResourceLocationNode> = (
 	const excludeDefaultNamespace = !node.options.isPredicate &&
 		config?.ruleValue !== false
 
-	const getPool = (category: string) =>
-		optimizePool(
-			Object.keys(ctx.symbols.getVisibleSymbols(category, ctx.doc.uri)),
+	const getPool = (category: string) => {
+		const symbols = ctx.symbols.getVisibleSymbols(category, ctx.doc.uri)
+		const declarations = Object.entries(symbols).flatMap(([key, symbol]) =>
+			SymbolUtil.isDeclared(symbol) ? [key] : []
 		)
+		return optimizePool(declarations)
+	}
 	const optimizePool = (pool: readonly string[]) => {
 		const defaultNsPrefix =
 			`${ResourceLocation.DefaultNamespace}${ResourceLocation.NamespacePathSep}`

--- a/packages/core/src/processor/linter/builtin/undeclaredSymbol.ts
+++ b/packages/core/src/processor/linter/builtin/undeclaredSymbol.ts
@@ -1,45 +1,48 @@
+import { localeQuote, localize } from '@spyglassmc/locales'
 import type { DeepReadonly } from '../../../common/index.js'
 import { Arrayable, ResourceLocation } from '../../../common/index.js'
 import type { AstNode } from '../../../node/index.js'
 import type { LinterContext } from '../../../service/index.js'
-import { SymbolLinterConfig as Config } from '../../../service/index.js'
+import {
+	LinterSeverity,
+	SymbolLinterConfig as Config,
+} from '../../../service/index.js'
 import type { Symbol } from '../../../symbol/index.js'
-import { SymbolVisibility } from '../../../symbol/index.js'
+import { SymbolUtil, SymbolVisibility } from '../../../symbol/index.js'
 import type { Linter } from '../Linter.js'
 
-// import { localeQuote, localize } from '@spyglassmc/locales'
-// import type { DeepReadonly } from '../../../common/index.js'
-// import { Arrayable, ResourceLocation } from '../../../common/index.js'
-// import type { AstNode } from '../../../node/index.js'
-// import type { LinterContext } from '../../../service/index.js'
-// import { LinterSeverity, SymbolLinterConfig as Config } from '../../../service/index.js'
-// import type { Symbol } from '../../../symbol/index.js'
-// import { SymbolUtil, SymbolVisibility } from '../../../symbol/index.js'
-// import type { Linter } from '../Linter.js'
-
 export const undeclaredSymbol: Linter<AstNode> = (node, ctx) => {
-	// if (!node.symbol || SymbolUtil.isDeclared(node.symbol)) {
-	// 	return
-	// }
-	// const action = getAction(ctx.ruleValue as Config, node.symbol, ctx)
-	// if (Config.Action.isDeclare(action)) {
-	// 	ctx.symbols
-	// 		.query({ doc: ctx.doc, node }, node.symbol.category, ...node.symbol.path)
-	// 		.amend({
-	// 			data: { visibility: getVisibility(action.declare) },
-	// 			usage: { type: 'declaration', node },
-	// 		})
-	// }
-	// if (Config.Action.isReport(action)) {
-	// 	const severityOverride = action.report === 'inherit' ? undefined : LinterSeverity.toErrorSeverity(action.report)
-	// 	ctx.err.lint(
-	// 		localize('linter.undeclared-symbol.message',
-	// 			node.symbol.category,
-	// 			localeQuote(node.symbol.identifier)
-	// 		),
-	// 		node, undefined, severityOverride
-	// 	)
-	// }
+	if (!node.symbol || SymbolUtil.isDeclared(node.symbol)) {
+		return
+	}
+	const action = getAction(ctx.ruleValue as Config, node.symbol, ctx)
+	if (Config.Action.isDeclare(action)) {
+		ctx.symbols
+			.query(
+				{ doc: ctx.doc, node },
+				node.symbol.category,
+				...node.symbol.path,
+			)
+			.amend({
+				data: { visibility: getVisibility(action.declare) },
+				usage: { type: 'declaration', node },
+			})
+	}
+	if (Config.Action.isReport(action)) {
+		const severityOverride = action.report === 'inherit'
+			? undefined
+			: LinterSeverity.toErrorSeverity(action.report)
+		ctx.err.lint(
+			localize(
+				'linter.undeclared-symbol.message',
+				node.symbol.category,
+				localeQuote(node.symbol.identifier),
+			),
+			node,
+			undefined,
+			severityOverride,
+		)
+	}
 }
 
 function getAction(


### PR DESCRIPTION
Fixes #1220 

Also improves the resource location completer so it no longer suggests the current or other undeclared symbols.
|Before|After|
|---|---|
|![image](https://github.com/SpyglassMC/Spyglass/assets/17352009/05880d83-2324-4333-9ce6-ed9feb117e14)|![image](https://github.com/SpyglassMC/Spyglass/assets/17352009/42ac376a-7a6b-462d-8759-bfdac05994ed)|
