### PR TITLE
🐛 Fix semantic token builder not coloring each line of a color token

### DIFF
--- a/__snapshots__/packages/language-server/test-out/util/toLS.spec.js
+++ b/__snapshots__/packages/language-server/test-out/util/toLS.spec.js
@@ -1,0 +1,29 @@
+exports['semanticTokens Tokenize "foo" 1'] = [
+  {
+    "deltaLine": 0,
+    "deltaStartChar": 0,
+    "length": 100,
+    "tokenType": 0,
+    "tokenModifiers": 0
+  }
+]
+
+exports['semanticTokens Tokenize "foo↓bar" 1'] = [
+  {
+    "deltaLine": 0,
+    "deltaStartChar": 0,
+    "length": 100,
+    "tokenType": 0,
+    "tokenModifiers": 0
+  }
+]
+
+exports['semanticTokens Tokenize "foo↓bar↓qux" 1'] = [
+  {
+    "deltaLine": 0,
+    "deltaStartChar": 0,
+    "length": 100,
+    "tokenType": 0,
+    "tokenModifiers": 0
+  }
+]

--- a/__snapshots__/packages/language-server/test-out/util/toLS.spec.js
+++ b/__snapshots__/packages/language-server/test-out/util/toLS.spec.js
@@ -1,4 +1,4 @@
-exports['semanticTokens Tokenize "foo" 1'] = [
+exports['semanticTokens Tokenize "foo" with multiline token support 1'] = [
   {
     "deltaLine": 0,
     "deltaStartChar": 0,
@@ -8,7 +8,7 @@ exports['semanticTokens Tokenize "foo" 1'] = [
   }
 ]
 
-exports['semanticTokens Tokenize "foo↓bar" 1'] = [
+exports['semanticTokens Tokenize "foo" without multiline token support 1'] = [
   {
     "deltaLine": 0,
     "deltaStartChar": 0,
@@ -18,11 +18,55 @@ exports['semanticTokens Tokenize "foo↓bar" 1'] = [
   }
 ]
 
-exports['semanticTokens Tokenize "foo↓bar↓qux" 1'] = [
+exports['semanticTokens Tokenize "foo↓bar" with multiline token support 1'] = [
   {
     "deltaLine": 0,
     "deltaStartChar": 0,
     "length": 100,
+    "tokenType": 0,
+    "tokenModifiers": 0
+  }
+]
+
+exports['semanticTokens Tokenize "foo↓bar" without multiline token support 1'] = [
+  {
+    "deltaLine": 0,
+    "deltaStartChar": 0,
+    "length": 4,
+    "tokenType": 0,
+    "tokenModifiers": 0
+  },
+  {
+    "deltaLine": 1,
+    "deltaStartChar": 0,
+    "length": 3,
+    "tokenType": 0,
+    "tokenModifiers": 0
+  }
+]
+
+exports['semanticTokens Tokenize "foo↓bar↓qux" with multiline token support 1'] = [
+  {
+    "deltaLine": 0,
+    "deltaStartChar": 0,
+    "length": 100,
+    "tokenType": 0,
+    "tokenModifiers": 0
+  }
+]
+
+exports['semanticTokens Tokenize "foo↓bar↓qux" without multiline token support 1'] = [
+  {
+    "deltaLine": 0,
+    "deltaStartChar": 0,
+    "length": 4,
+    "tokenType": 0,
+    "tokenModifiers": 0
+  },
+  {
+    "deltaLine": 2,
+    "deltaStartChar": 0,
+    "length": 3,
     "tokenType": 0,
     "tokenModifiers": 0
   }

--- a/__snapshots__/packages/language-server/test-out/util/toLS.spec.js
+++ b/__snapshots__/packages/language-server/test-out/util/toLS.spec.js
@@ -64,7 +64,14 @@ exports['semanticTokens Tokenize "foo↓bar↓qux" without multiline token suppo
     "tokenModifiers": 0
   },
   {
-    "deltaLine": 2,
+    "deltaLine": 1,
+    "deltaStartChar": 0,
+    "length": 4,
+    "tokenType": 0,
+    "tokenModifiers": 0
+  },
+  {
+    "deltaLine": 1,
     "deltaStartChar": 0,
     "length": 3,
     "tokenType": 0,

--- a/packages/language-server/src/util/toLS.ts
+++ b/packages/language-server/src/util/toLS.ts
@@ -351,7 +351,7 @@ export function semanticTokens(
 				type,
 				modifiers,
 			)
-			for (let i = pos.line + 1; i < endPos.line - 1; i++) {
+			for (let i = pos.line + 1; i <= endPos.line - 1; i++) {
 				const lineLength = doc.getText(
 					ls.Range.create(i, 0, i, MaxCharacterNumber),
 				).length

--- a/packages/language-server/test/util/toLS.spec.ts
+++ b/packages/language-server/test/util/toLS.spec.ts
@@ -1,0 +1,63 @@
+import type * as core from '@spyglassmc/core'
+import { showWhitespaceGlyph } from '@spyglassmc/core/test-out/utils.js'
+import snapshot from 'snap-shot-it'
+import { TextDocument } from 'vscode-languageserver-textdocument'
+import type * as ls from 'vscode-languageserver/node.js'
+import { semanticTokens } from '../../lib/util/toLS.js'
+
+/**
+ * The result of decoding a semantic token from an integer list.
+ * The VSCode API documentation details what the integer list represents here:
+ * https://code.visualstudio.com/api/references/vscode-api#DocumentSemanticTokensProvider.provideDocumentSemanticTokens
+ */
+interface DecodedSemanticToken {
+	deltaLine: number
+	deltaStartChar: number
+	length: number
+	tokenType: number
+	tokenModifiers: number
+}
+const decodeSemanticTokens = (
+	tokens: ls.SemanticTokens['data'],
+): DecodedSemanticToken[] => {
+	if (tokens.length % 5 !== 0) {
+		throw new Error('Array of semantic tokens must be divisible by 5')
+	}
+	const decodedTokens = []
+	for (let i = 0; i < tokens.length; i += 5) {
+		const decodedToken = {
+			deltaLine: tokens[i],
+			deltaStartChar: tokens[i + 1],
+			length: tokens[i + 2],
+			tokenType: tokens[i + 3],
+			tokenModifiers: tokens[i + 4],
+		}
+		decodedTokens.push(decodedToken)
+	}
+	return decodedTokens
+}
+
+describe('semanticTokens', () => {
+	const tokens: core.ColorToken[] = [
+		{
+			range: {
+				start: 0,
+				end: 100,
+			},
+			type: 'comment',
+		},
+	]
+	const suites: { content: string }[] = [
+		{ content: 'foo' },
+		{ content: 'foo\nbar' },
+		{ content: 'foo\nbar\nqux' },
+	]
+	for (const { content } of suites) {
+		const doc = TextDocument.create('file:///test', '', 0, content)
+		const itTitle = `Tokenize "${showWhitespaceGlyph(content)}"`
+		it(itTitle, () => {
+			const { data } = semanticTokens(tokens, doc, true)
+			snapshot(decodeSemanticTokens(data))
+		})
+	}
+})

--- a/packages/language-server/test/util/toLS.spec.ts
+++ b/packages/language-server/test/util/toLS.spec.ts
@@ -52,12 +52,23 @@ describe('semanticTokens', () => {
 		{ content: 'foo\nbar' },
 		{ content: 'foo\nbar\nqux' },
 	]
-	for (const { content } of suites) {
-		const doc = TextDocument.create('file:///test', '', 0, content)
-		const itTitle = `Tokenize "${showWhitespaceGlyph(content)}"`
-		it(itTitle, () => {
-			const { data } = semanticTokens(tokens, doc, true)
-			snapshot(decodeSemanticTokens(data))
-		})
+	for (const hasMultilineTokenSupport of [true, false]) {
+		for (const { content } of suites) {
+			const doc = TextDocument.create('file:///test', '', 0, content)
+			const multilineStr = `${
+				hasMultilineTokenSupport ? 'with' : 'without'
+			} multiline token support`
+			const itTitle = `Tokenize "${
+				showWhitespaceGlyph(content)
+			}" ${multilineStr}`
+			it(itTitle, () => {
+				const { data } = semanticTokens(
+					tokens,
+					doc,
+					hasMultilineTokenSupport,
+				)
+				snapshot(decodeSemanticTokens(data))
+			})
+		}
 	}
 })


### PR DESCRIPTION
# Summary

I'll have some upcoming PRs relating to fixing the colorizer across multiple lines (due to backslash continuation)

I wanted to add tests for this, but it wouldn't be great with snapshots since the return type of `semanticTokens()` is just an array of integers (kinda meaningless to the human eye)

https://github.com/SpyglassMC/Spyglass/blob/9bb9dc1bb0c70f178a6b5efac20816346411d621/packages/language-server/src/util/toLS.ts#L321-L325

---

@SPGoding do you remember what file type you were using to colorize tokens across multiple lines prior to backslash continuation?
  - relevant commit is from 2 years ago: https://github.com/SpyglassMC/Spyglass/commit/e15cf81ec9060f2b7d9055a0faa4c67fba736fd1

---

## Preview

|| before | after |
|-|-|-|
| commands w/line continuation | ![image](https://github.com/SpyglassMC/Spyglass/assets/13565346/631674b6-83bd-4b3e-976c-b4a436a99d4b) | ![image](https://github.com/SpyglassMC/Spyglass/assets/13565346/8c2b92dd-a6e9-4830-98be-c6f19f914b20) |
| comments + macro lines | ![image](https://github.com/SpyglassMC/Spyglass/assets/13565346/87be81a7-7e7d-4c6f-8332-9ead834b3280)|![image](https://github.com/SpyglassMC/Spyglass/assets/13565346/9e79252d-54ea-4eb7-8a7a-6fab38136823) |

---

some noticeable colorization errors still remaining are:

1. commas being miscolored when near line continuation + strings
this is due to `syntax-mcfunction` colorizing strings line-wise, and the comma is caught between the quotes on that line

2. start/end brackets being miscolored/not matching up across line continuation
this is due to `syntax-mcfunction`, as disabling the extension makes the brackets yellow/match properly. see below image:

||
|-|
|![image](https://github.com/SpyglassMC/Spyglass/assets/13565346/7f8037fc-8ec9-4d86-9b63-83c4f0684bd3)|

removing `syntax-mcfunction` as an extension dependency is not an option, so we'll instead probably have to explicitly make tokens for them in Spyglass to override `syntax-mcfunction`'s incorrectly coloring