### PR TITLE
⚡️ Optimize struct field duplicate filtering

### DIFF
--- a/__snapshots__/packages/mcdoc/test-out/runtime/checker.spec.js
+++ b/__snapshots__/packages/mcdoc/test-out/runtime/checker.spec.js
@@ -322,7 +322,7 @@ exports['mcdoc runtime checker typeDefinition “struct { ...struct { foo: doubl
       "kind": "literal",
       "value": {
         "kind": "string",
-        "value": "bar"
+        "value": "foo"
       }
     }
   },
@@ -339,7 +339,7 @@ exports['mcdoc runtime checker typeDefinition “struct { ...struct { foo: doubl
       "kind": "literal",
       "value": {
         "kind": "string",
-        "value": "foo"
+        "value": "bar"
       }
     }
   }

--- a/packages/mcdoc/src/runtime/checker/index.ts
+++ b/packages/mcdoc/src/runtime/checker/index.ts
@@ -1111,7 +1111,9 @@ export function simplify<T>(
 				} else if (key.kind === 'literal' && key.value.kind === 'string') {
 					literalFields.set(key.value.value, field)
 				} else if (key.kind === 'union') {
-					key.members.forEach(m => addField(m, field))
+					key.members.forEach(m =>
+						addField(m, { ...field, optional: true })
+					)
 				} else {
 					complexFields = complexFields.filter(other =>
 						!isAssignable(

--- a/packages/mcdoc/src/runtime/checker/index.ts
+++ b/packages/mcdoc/src/runtime/checker/index.ts
@@ -1099,7 +1099,36 @@ export function simplify<T>(
 			}
 			return { kind: 'union', members: members }
 		case 'struct':
-			const fields: SimplifiedStructTypePairField[] = []
+			const literalFields = new Map<string, StructTypePairField>()
+			let complexFields: SimplifiedStructTypePairField[] = []
+
+			function addField(
+				key: string | SimplifiedMcdocType,
+				field: StructTypePairField,
+			) {
+				if (typeof key === 'string') {
+					literalFields.set(key, field)
+				} else if (key.kind === 'literal' && key.value.kind === 'string') {
+					literalFields.set(key.value.value, field)
+				} else if (key.kind === 'union') {
+					key.members.forEach(m => addField(m, field))
+				} else {
+					complexFields = complexFields.filter(other =>
+						!isAssignable(
+							typeof other.key === 'string'
+								? {
+									kind: 'literal',
+									value: { kind: 'string', value: other.key },
+								}
+								: other.key,
+							key,
+							options.context,
+							options.isEquivalent,
+						)
+					)
+					complexFields.push({ ...field, key })
+				}
+			}
 			for (const field of typeDef.fields) {
 				if (field.kind === 'pair') {
 					// Don't simplify the value here. We need to have the correct `node` and `parents`, which we
@@ -1108,43 +1137,58 @@ export function simplify<T>(
 					const key = typeof field.key === 'string'
 						? field.key
 						: simplify(field.key, options, parents)
-					if (typeof key !== 'string' && key.kind === 'union') {
-						for (const subKey of key.members) {
-							fields.push({
-								...field,
-								key: simplifyKey(subKey),
-							})
-						}
-					} else {
-						fields.push({
-							...field,
-							key: simplifyKey(key),
-						})
-					}
+					addField(key, field)
 				} else {
 					const simplifiedSpreadType = simplify(
 						field.type,
 						options,
 						parents,
 					)
-
 					if (simplifiedSpreadType.kind === 'struct') {
-						fields.push(...simplifiedSpreadType.fields)
+						for (const field of simplifiedSpreadType.fields) {
+							addField(field.key, field)
+						}
+					} else {
+						const type = McdocType.toString(simplifiedSpreadType)
+						options.context.logger.warn(
+							`Tried to spread non-struct type ${type}`,
+						)
 					}
 				}
 			}
+			complexFields = complexFields.filter(other =>
+				!isAssignable(
+					typeof other.key === 'string'
+						? {
+							kind: 'literal',
+							value: { kind: 'string', value: other.key },
+						}
+						: other.key,
+					{
+						kind: 'union',
+						members: [...literalFields.keys()].map(k => ({
+							kind: 'literal',
+							value: { kind: 'string', value: k },
+						})),
+					},
+					options.context,
+					options.isEquivalent,
+				)
+			)
 			return {
 				kind: 'struct',
-				fields: fields.filter((f, i) =>
-					fields.findLastIndex(of =>
-						isAssignable(
-							of.key,
-							f.key,
-							options.context,
-							options.isEquivalent,
-						)
-					) === i
-				),
+				fields: [
+					...complexFields,
+					...[...literalFields.entries()].map(([key, field]) =>
+						({
+							...field,
+							key: {
+								kind: 'literal',
+								value: { kind: 'string', value: key },
+							},
+						}) satisfies SimplifiedStructTypePairField
+					),
+				],
 			}
 		case 'enum':
 			return { ...typeDef, enumKind: typeDef.enumKind ?? 'int' }
@@ -1154,14 +1198,6 @@ export function simplify<T>(
 		default:
 			return typeDef
 	}
-}
-function simplifyKey(
-	keyDef: SimplifiedMcdocTypeNoUnion | string,
-): SimplifiedMcdocTypeNoUnion {
-	if (typeof keyDef === 'string') {
-		return { kind: 'literal', value: { kind: 'string', value: keyDef } }
-	}
-	return keyDef
 }
 
 function getValueType(

--- a/packages/mcdoc/src/runtime/checker/index.ts
+++ b/packages/mcdoc/src/runtime/checker/index.ts
@@ -1115,15 +1115,16 @@ export function simplify<T>(
 						addField(m, { ...field, optional: true })
 					)
 				} else {
+					// Only keep fields where the new key is not assignable to an existing field
 					complexFields = complexFields.filter(other =>
 						!isAssignable(
+							key,
 							typeof other.key === 'string'
 								? {
 									kind: 'literal',
 									value: { kind: 'string', value: other.key },
 								}
 								: other.key,
-							key,
 							options.context,
 							options.isEquivalent,
 						)

--- a/packages/mcdoc/src/runtime/checker/index.ts
+++ b/packages/mcdoc/src/runtime/checker/index.ts
@@ -1159,38 +1159,19 @@ export function simplify<T>(
 					}
 				}
 			}
-			complexFields = complexFields.filter(other =>
-				!isAssignable(
-					typeof other.key === 'string'
-						? {
-							kind: 'literal',
-							value: { kind: 'string', value: other.key },
-						}
-						: other.key,
-					{
-						kind: 'union',
-						members: [...literalFields.keys()].map(k => ({
-							kind: 'literal',
-							value: { kind: 'string', value: k },
-						})),
-					},
-					options.context,
-					options.isEquivalent,
-				)
-			)
+			// Literal fields may still be assignable to complex fields,
+			// however this is currently not seen as an issue
 			return {
 				kind: 'struct',
 				fields: [
 					...complexFields,
-					...[...literalFields.entries()].map(([key, field]) =>
-						({
-							...field,
-							key: {
-								kind: 'literal',
-								value: { kind: 'string', value: key },
-							},
-						}) satisfies SimplifiedStructTypePairField
-					),
+					...[...literalFields.entries()].map(([key, field]) => ({
+						...field,
+						key: {
+							kind: 'literal',
+							value: { kind: 'string', value: key },
+						} as const,
+					})),
 				],
 			}
 		case 'enum':

--- a/packages/mcdoc/test/runtime/checker.spec.ts
+++ b/packages/mcdoc/test/runtime/checker.spec.ts
@@ -11,7 +11,7 @@ import { describe, it } from 'mocha'
 import snapshot from 'snap-shot-it'
 import { TextDocument } from 'vscode-languageserver-textdocument'
 
-describe.only('mcdoc runtime checker', () => {
+describe('mcdoc runtime checker', () => {
 	type JsValue = boolean | number | string | JsValue[] | {
 		[key: string]: JsValue
 	}

--- a/packages/mcdoc/test/runtime/checker.spec.ts
+++ b/packages/mcdoc/test/runtime/checker.spec.ts
@@ -11,7 +11,7 @@ import { describe, it } from 'mocha'
 import snapshot from 'snap-shot-it'
 import { TextDocument } from 'vscode-languageserver-textdocument'
 
-describe('mcdoc runtime checker', () => {
+describe.only('mcdoc runtime checker', () => {
 	type JsValue = boolean | number | string | JsValue[] | {
 		[key: string]: JsValue
 	}


### PR DESCRIPTION
Replaces the old `O(n^2)` field de-duplication check in the struct simplify case. Now a map of fields is used for literal keys, and only the complex keys are checks if they are assignable.