### PR TITLE
🎨 Change format rules

### DIFF
--- a/.dprint.jsonc
+++ b/.dprint.jsonc
@@ -1,6 +1,6 @@
 {
   "indentWidth": 3,
-  "lineWidth": 80,
+  "lineWidth": 100,
   "newLineKind": "lf",
   "useTabs": true,
   "typescript": {

--- a/.dprint.jsonc
+++ b/.dprint.jsonc
@@ -4,7 +4,7 @@
   "newLineKind": "lf",
   "useTabs": true,
   "typescript": {
-    "binaryExpression.operatorPosition": "sameLine",
+    "binaryExpression.operatorPosition": "nextLine",
     "quoteStyle": "preferSingle",
     "semiColons": "asi"
   },

--- a/packages/core/src/common/Dev.ts
+++ b/packages/core/src/common/Dev.ts
@@ -36,8 +36,8 @@ export namespace Dev {
 			switch (typeof current) {
 				case 'bigint': {
 					const bits = Math.ceil(Math.log2(Number(current)))
-					ans += (2 + Math.ceil(bits / (ByteToBits * PointerSize))) *
-						PointerSize // https://stackoverflow.com/a/54298760
+					ans += (2 + Math.ceil(bits / (ByteToBits * PointerSize)))
+						* PointerSize // https://stackoverflow.com/a/54298760
 					break
 				}
 				case 'boolean':

--- a/packages/core/src/common/Dev.ts
+++ b/packages/core/src/common/Dev.ts
@@ -1,7 +1,5 @@
 export namespace Dev {
-	export function assertDefined<T>(
-		value: T,
-	): asserts value is Exclude<T, undefined> {
+	export function assertDefined<T>(value: T): asserts value is Exclude<T, undefined> {
 		if (value === undefined) {
 			throw new Error(`'${Dev.stringify(value)}' is 'undefined'`)
 		}
@@ -11,13 +9,7 @@ export namespace Dev {
 	}
 	export function assertTrue(value: boolean, message: string): void {
 		if (!value) {
-			throw new Error(
-				`Assertion failed: ${message}. '${
-					Dev.stringify(
-						value,
-					)
-				}' should be true.`,
-			)
+			throw new Error(`Assertion failed: ${message}. '${Dev.stringify(value)}' should be true.`)
 		}
 	}
 	/**
@@ -36,8 +28,7 @@ export namespace Dev {
 			switch (typeof current) {
 				case 'bigint': {
 					const bits = Math.ceil(Math.log2(Number(current)))
-					ans += (2 + Math.ceil(bits / (ByteToBits * PointerSize)))
-						* PointerSize // https://stackoverflow.com/a/54298760
+					ans += (2 + Math.ceil(bits / (ByteToBits * PointerSize))) * PointerSize // https://stackoverflow.com/a/54298760
 					break
 				}
 				case 'boolean':
@@ -86,9 +77,7 @@ export namespace Dev {
 				// Most likely "Maximum callstack size exceeded".
 				// Fall back to a shallow string representation.
 				return `{ ${
-					Object.entries(value)
-						.map(([k, v]) => `'${k}': '${String(v)}'`)
-						.join(', ')
+					Object.entries(value).map(([k, v]) => `'${k}': '${String(v)}'`).join(', ')
 				} }`
 			}
 		} else if (typeof value === 'symbol') {

--- a/packages/core/src/common/ReadonlyProxy.ts
+++ b/packages/core/src/common/ReadonlyProxy.ts
@@ -1,13 +1,9 @@
 import { emplaceMap, isObject } from './util.js'
 
 type DeepReadonlyValue<T> = T extends object ? DeepReadonly<T> : T
-export type DeepReadonly<T extends object> = {
-	readonly [K in keyof T]: DeepReadonlyValue<T[K]>
-}
+export type DeepReadonly<T extends object> = { readonly [K in keyof T]: DeepReadonlyValue<T[K]> }
 
-export type ReadWrite<T extends object> = {
-	-readonly [K in keyof T]: T[K]
-}
+export type ReadWrite<T extends object> = { -readonly [K in keyof T]: T[K] }
 
 export namespace ReadonlyProxy {
 	export function create<T extends object>(obj: T): DeepReadonly<T> {
@@ -21,22 +17,16 @@ class ReadonlyProxyHandler<T extends object> implements ProxyHandler<T> {
 	get(target: T, p: string | symbol, receiver: any): any {
 		const value = Reflect.get(target, p, receiver)
 		if (p !== 'prototype' && isObject(value)) {
-			return emplaceMap(this.map, p, {
-				insert: () => ReadonlyProxy.create(value),
-			})
+			return emplaceMap(this.map, p, { insert: () => ReadonlyProxy.create(value) })
 		}
 		return value
 	}
 
 	set(_target: T, p: string | symbol, _value: any, _receiver: any): boolean {
-		throw new TypeError(
-			`Cannot set property '${String(p)}' on a readonly proxy`,
-		)
+		throw new TypeError(`Cannot set property '${String(p)}' on a readonly proxy`)
 	}
 
 	deleteProperty(_target: T, p: string | symbol): boolean {
-		throw new TypeError(
-			`Cannot delete property '${String(p)}' on a readonly proxy`,
-		)
+		throw new TypeError(`Cannot delete property '${String(p)}' on a readonly proxy`)
 	}
 }

--- a/packages/core/src/common/StateProxy.ts
+++ b/packages/core/src/common/StateProxy.ts
@@ -98,11 +98,11 @@ class StateProxyHandler<T extends object> implements ProxyHandler<T> {
 
 	set(target: T, p: string | symbol, value: any, receiver: any): boolean {
 		if (
-			p === BranchOff ||
-			p === Is ||
-			p === Origin ||
-			p === Redo ||
-			p === Undo
+			p === BranchOff
+			|| p === Is
+			|| p === Origin
+			|| p === Redo
+			|| p === Undo
 		) {
 			throw new TypeError(`Cannot set ${String(p)}`)
 		}

--- a/packages/core/src/common/TwoWayMap.ts
+++ b/packages/core/src/common/TwoWayMap.ts
@@ -56,10 +56,7 @@ export class TwoWayMap<K, V> implements Map<K, V> {
 		return this
 	}
 
-	forEach(
-		callbackfn: (value: V, key: K, map: TwoWayMap<K, V>) => void,
-		thisArg?: any,
-	): void {
+	forEach(callbackfn: (value: V, key: K, map: TwoWayMap<K, V>) => void, thisArg?: any): void {
 		for (const [key, value] of this._map) {
 			callbackfn.apply(thisArg, [value, key, this])
 		}

--- a/packages/core/src/common/externals/BrowserExternals.ts
+++ b/packages/core/src/common/externals/BrowserExternals.ts
@@ -16,10 +16,7 @@ import type {
 
 type Listener = (...args: unknown[]) => unknown
 class BrowserEventEmitter implements ExternalEventEmitter {
-	readonly #listeners = new Map<
-		string,
-		{ all: Set<Listener>; once: Set<Listener> }
-	>()
+	readonly #listeners = new Map<string, { all: Set<Listener>; once: Set<Listener> }>()
 
 	emit(eventName: string, ...args: unknown[]): boolean {
 		const listeners = this.#listeners.get(eventName)
@@ -57,10 +54,7 @@ class BrowserEventEmitter implements ExternalEventEmitter {
 }
 
 class BrowserExternalDownloader implements ExternalDownloader {
-	async get(
-		uri: RemoteUriString,
-		options: ExternalDownloaderOptions = {},
-	): Promise<Uint8Array> {
+	async get(uri: RemoteUriString, options: ExternalDownloaderOptions = {}): Promise<Uint8Array> {
 		const headers = new Headers()
 		for (const [name, value] of Object.entries(options?.headers ?? {})) {
 			const values = typeof value === 'string' ? [value] : value
@@ -68,10 +62,7 @@ class BrowserExternalDownloader implements ExternalDownloader {
 				headers.append(name, v)
 			}
 		}
-		const res = await fetch(uri, {
-			headers,
-			redirect: 'follow',
-		})
+		const res = await fetch(uri, { headers, redirect: 'follow' })
 		if (!res.ok) {
 			throw new Error(`Status code ${res.status}: ${res.ok}`)
 		} else {
@@ -100,22 +91,14 @@ class BrowserFsWatcher implements FsWatcher {
 
 class BrowserFileSystem implements ExternalFileSystem {
 	private static readonly LocalStorageKey = 'spyglassmc-browser-fs'
-	private states: Record<
-		string,
-		{ type: 'file'; content: string } | { type: 'directory' }
-	>
+	private states: Record<string, { type: 'file'; content: string } | { type: 'directory' }>
 
 	constructor() {
-		this.states = JSON.parse(
-			localStorage.getItem(BrowserFileSystem.LocalStorageKey) ?? '{}',
-		)
+		this.states = JSON.parse(localStorage.getItem(BrowserFileSystem.LocalStorageKey) ?? '{}')
 	}
 
 	private saveStates() {
-		localStorage.setItem(
-			BrowserFileSystem.LocalStorageKey,
-			JSON.stringify(this.states),
-		)
+		localStorage.setItem(BrowserFileSystem.LocalStorageKey, JSON.stringify(this.states))
 	}
 
 	async chmod(_location: FsLocation, _mode: number): Promise<void> {
@@ -126,9 +109,7 @@ class BrowserFileSystem implements ExternalFileSystem {
 	}
 	async mkdir(
 		location: FsLocation,
-		_options?:
-			| { mode?: number | undefined; recursive?: boolean | undefined }
-			| undefined,
+		_options?: { mode?: number | undefined; recursive?: boolean | undefined } | undefined,
 	): Promise<void> {
 		location = fileUtil.ensureEndingSlash(location.toString())
 		if (this.states[location]) {
@@ -150,18 +131,13 @@ class BrowserFileSystem implements ExternalFileSystem {
 	async showFile(_path: FsLocation): Promise<void> {
 		throw new Error('showFile not supported on browser')
 	}
-	async stat(
-		location: FsLocation,
-	): Promise<{ isDirectory(): boolean; isFile(): boolean }> {
+	async stat(location: FsLocation): Promise<{ isDirectory(): boolean; isFile(): boolean }> {
 		location = location.toString()
 		const entry = this.states[location]
 		if (!entry) {
 			throw new Error(`ENOENT: ${location}`)
 		}
-		return {
-			isDirectory: () => entry.type === 'directory',
-			isFile: () => entry.type === 'file',
-		}
+		return { isDirectory: () => entry.type === 'directory', isFile: () => entry.type === 'file' }
 	}
 	async unlink(location: FsLocation): Promise<void> {
 		location = location.toString()
@@ -217,9 +193,7 @@ export const BrowserExternals: Externals = {
 			return e instanceof Error && e.message.startsWith(kind)
 		},
 	},
-	event: {
-		EventEmitter: BrowserEventEmitter,
-	},
+	event: { EventEmitter: BrowserEventEmitter },
 	fs: new BrowserFileSystem(),
 }
 

--- a/packages/core/src/common/externals/BrowserExternals.ts
+++ b/packages/core/src/common/externals/BrowserExternals.ts
@@ -1,7 +1,4 @@
-import {
-	decode as arrayBufferFromBase64,
-	encode as arrayBufferToBase64,
-} from 'base64-arraybuffer'
+import { decode as arrayBufferFromBase64, encode as arrayBufferToBase64 } from 'base64-arraybuffer'
 import pako from 'pako'
 import { fileUtil } from '../../service/fileUtil.js'
 import type {

--- a/packages/core/src/common/externals/NodeJsExternals.ts
+++ b/packages/core/src/common/externals/NodeJsExternals.ts
@@ -27,27 +27,15 @@ const gunzip = promisify(zlib.gunzip)
 const gzip = promisify(zlib.gzip)
 
 class NodeJsExternalDownloader implements ExternalDownloader {
-	get(
-		uri: RemoteUriString,
-		options: ExternalDownloaderOptions = {},
-	): Promise<Uint8Array> {
+	get(uri: RemoteUriString, options: ExternalDownloaderOptions = {}): Promise<Uint8Array> {
 		const protocol = new Uri(uri).protocol
 		return new Promise((resolve, reject) => {
 			const backend = protocol === 'http:' ? http : https
 			backend.get(uri, options, (res: IncomingMessage) => {
 				if (res.statusCode !== 200) {
-					reject(
-						new Error(
-							`Status code ${res.statusCode}: ${res.statusMessage}`,
-						),
-					)
+					reject(new Error(`Status code ${res.statusCode}: ${res.statusMessage}`))
 				} else {
-					resolve(
-						promisifyAsyncIterable(
-							res,
-							(chunks) => Buffer.concat(chunks),
-						),
-					)
+					resolve(promisifyAsyncIterable(res, (chunks) => Buffer.concat(chunks)))
 				}
 			})
 		})
@@ -84,20 +72,15 @@ export const NodeJsExternals: Externals = {
 			return e instanceof Error && (e as NodeJS.ErrnoException).code === kind
 		},
 	},
-	event: {
-		EventEmitter,
-	},
+	event: { EventEmitter },
 	fs: {
 		chmod(location, mode) {
 			return fsp.chmod(toFsPathLike(location), mode)
 		},
 		async getAllFiles(location) {
-			return (
-				await globby(toPath(location) + '**/*', {
-					absolute: true,
-					dot: true,
-				})
-			).map(uriFromPath)
+			return (await globby(toPath(location) + '**/*', { absolute: true, dot: true })).map(
+				uriFromPath,
+			)
 		},
 		async mkdir(location, options) {
 			return void (await fsp.mkdir(toFsPathLike(location), options))
@@ -169,12 +152,13 @@ class ChokidarWatcherWrapper extends EventEmitter implements FsWatcher {
 
 	constructor(watcher: chokidar.FSWatcher) {
 		super()
-		this.#watcher = watcher
-			.on('ready', () => this.emit('ready'))
-			.on('add', (path) => this.emit('add', uriFromPath(path)))
-			.on('change', (path) => this.emit('change', uriFromPath(path)))
-			.on('unlink', (path) => this.emit('unlink', uriFromPath(path)))
-			.on('error', (e) => this.emit('error', e))
+		this.#watcher = watcher.on('ready', () => this.emit('ready')).on(
+			'add',
+			(path) => this.emit('add', uriFromPath(path)),
+		).on('change', (path) => this.emit('change', uriFromPath(path))).on(
+			'unlink',
+			(path) => this.emit('unlink', uriFromPath(path)),
+		).on('error', (e) => this.emit('error', e))
 	}
 
 	close(): Promise<void> {

--- a/packages/core/src/common/externals/NodeJsExternals.ts
+++ b/packages/core/src/common/externals/NodeJsExternals.ts
@@ -152,13 +152,12 @@ class ChokidarWatcherWrapper extends EventEmitter implements FsWatcher {
 
 	constructor(watcher: chokidar.FSWatcher) {
 		super()
-		this.#watcher = watcher.on('ready', () => this.emit('ready')).on(
-			'add',
-			(path) => this.emit('add', uriFromPath(path)),
-		).on('change', (path) => this.emit('change', uriFromPath(path))).on(
-			'unlink',
-			(path) => this.emit('unlink', uriFromPath(path)),
-		).on('error', (e) => this.emit('error', e))
+		this.#watcher = watcher
+			.on('ready', () => this.emit('ready'))
+			.on('add', (path) => this.emit('add', uriFromPath(path)))
+			.on('change', (path) => this.emit('change', uriFromPath(path)))
+			.on('unlink', (path) => this.emit('unlink', uriFromPath(path)))
+			.on('error', (e) => this.emit('error', e))
 	}
 
 	close(): Promise<void> {

--- a/packages/core/src/common/externals/downloader.ts
+++ b/packages/core/src/common/externals/downloader.ts
@@ -18,15 +18,10 @@ export interface ExternalDownloader {
 	/**
 	 * @throws
 	 */
-	get(
-		uri: RemoteUriString,
-		options?: ExternalDownloaderOptions,
-	): Promise<Uint8Array>
+	get(uri: RemoteUriString, options?: ExternalDownloaderOptions): Promise<Uint8Array>
 }
 export namespace ExternalDownloader {
-	export function mock(
-		options: ExternalDownloaderMockOptions,
-	): ExternalDownloader {
+	export function mock(options: ExternalDownloaderMockOptions): ExternalDownloader {
 		return new ExternalDownloaderMock(options)
 	}
 }

--- a/packages/core/src/common/externals/index.ts
+++ b/packages/core/src/common/externals/index.ts
@@ -19,12 +19,8 @@ export interface Externals {
 		getSha1: (data: string | Uint8Array) => Promise<string>
 	}
 	downloader: ExternalDownloader
-	error: {
-		isKind: (e: unknown, kind: ExternalErrorKind) => boolean
-	}
-	event: {
-		EventEmitter: new() => ExternalEventEmitter
-	}
+	error: { isKind: (e: unknown, kind: ExternalErrorKind) => boolean }
+	event: { EventEmitter: new() => ExternalEventEmitter }
 	fs: ExternalFileSystem
 }
 
@@ -56,10 +52,7 @@ export interface ExternalFileSystem {
 	/**
 	 * @param options `mode` - File mode bit mask (e.g. `0o775`).
 	 */
-	mkdir(
-		location: FsLocation,
-		options?: { mode?: number; recursive?: boolean },
-	): Promise<void>
+	mkdir(location: FsLocation, options?: { mode?: number; recursive?: boolean }): Promise<void>
 	readFile(location: FsLocation): Promise<Uint8Array>
 	/**
 	 * Show the file/directory in the platform-specific explorer program.
@@ -67,10 +60,7 @@ export interface ExternalFileSystem {
 	 * Should not be called with unsanitized user-input path due to the possibility of arbitrary code execution.
 	 */
 	showFile(path: FsLocation): Promise<void>
-	stat(location: FsLocation): Promise<{
-		isDirectory(): boolean
-		isFile(): boolean
-	}>
+	stat(location: FsLocation): Promise<{ isDirectory(): boolean; isFile(): boolean }>
 	unlink(location: FsLocation): Promise<void>
 	watch(location: FsLocation): FsWatcher
 	/**

--- a/packages/core/src/common/util.ts
+++ b/packages/core/src/common/util.ts
@@ -41,8 +41,7 @@ export function SingletonPromise(
 		descripter: PropertyDescriptor,
 	) => {
 		const promises = new Map<unknown, Promise<unknown>>()
-		const decoratedMethod: (...args: unknown[]) => Promise<unknown> =
-			descripter.value
+		const decoratedMethod: (...args: unknown[]) => Promise<unknown> = descripter.value
 		// The `function` syntax is used to preserve `this` context from the decorated method.
 		descripter.value = function(...args: unknown[]) {
 			const key = getKey(args)

--- a/packages/core/src/common/util.ts
+++ b/packages/core/src/common/util.ts
@@ -35,11 +35,7 @@ export type IntervalId = any
 export function SingletonPromise(
 	getKey: (args: any[]) => any = (args) => args[0],
 ): MethodDecorator {
-	return (
-		_target: Object,
-		_key: string | symbol,
-		descripter: PropertyDescriptor,
-	) => {
+	return (_target: Object, _key: string | symbol, descripter: PropertyDescriptor) => {
 		const promises = new Map<unknown, Promise<unknown>>()
 		const decoratedMethod: (...args: unknown[]) => Promise<unknown> = descripter.value
 		// The `function` syntax is used to preserve `this` context from the decorated method.
@@ -87,11 +83,7 @@ export function Delay(
 	ms: number,
 	getKey: (args: any[]) => any = (args) => args[0],
 ): MethodDecorator {
-	return (
-		_target: Object,
-		_key: string | symbol,
-		descripter: PropertyDescriptor,
-	) => {
+	return (_target: Object, _key: string | symbol, descripter: PropertyDescriptor) => {
 		const timeouts = new Map<unknown, IntervalId>()
 		const decoratedMethod: (...args: unknown[]) => unknown = descripter.value
 		// The `function` syntax is used to preserve `this` context from the decorated method.
@@ -195,10 +187,7 @@ export function promisifyAsyncIterable<T, U>(
 	})()
 }
 
-export async function parseGzippedJson(
-	externals: Externals,
-	buffer: Uint8Array,
-): Promise<unknown> {
+export async function parseGzippedJson(externals: Externals, buffer: Uint8Array): Promise<unknown> {
 	return JSON.parse(bufferToString(await externals.archive.gunzip(buffer)))
 }
 
@@ -209,10 +198,7 @@ export function isPojo(value: unknown): value is Record<string, unknown> {
 	return !!value && typeof value === 'object' && !Array.isArray(value)
 }
 
-export function merge<T extends Record<string, any>>(
-	a: T,
-	b: Record<string, any>,
-): T {
+export function merge<T extends Record<string, any>>(a: T, b: Record<string, any>): T {
 	const ans = rfdc()(a)
 	for (const [key, value] of Object.entries(b) as [keyof typeof ans, any][]) {
 		if (isPojo(ans[key]) && isPojo(value)) {
@@ -241,10 +227,7 @@ export namespace Lazy {
 	export type ComplexLazy<T> = ResolvedLazy<T> | UnresolvedLazy<T>
 
 	export function create<T>(getter: (this: void) => T): UnresolvedLazy<T> {
-		return {
-			discriminator: LazyDiscriminator,
-			getter,
-		}
+		return { discriminator: LazyDiscriminator, getter }
 	}
 
 	export function isComplex<T = any>(lazy: any): lazy is ComplexLazy<T> {
@@ -256,9 +239,7 @@ export namespace Lazy {
 	}
 
 	export function resolve<T>(lazy: Lazy<T>): T {
-		return isUnresolved(lazy)
-			? ((lazy as ResolvedLazy<T>).value = lazy.getter())
-			: lazy
+		return isUnresolved(lazy) ? ((lazy as ResolvedLazy<T>).value = lazy.getter()) : lazy
 	}
 }
 
@@ -275,19 +256,17 @@ export function getStates(
 	const ans: Record<string, Set<string>> = {}
 	ids = ids.map(ResourceLocation.lengthen)
 	for (const id of ids) {
-		ctx.symbols
-			.query(ctx.doc, category, id)
-			.forEachMember((state, stateQuery) => {
-				const values = Object.keys(stateQuery.visibleMembers)
-				const set = (ans[state] ??= new Set())
-				const defaultValue = stateQuery.symbol?.relations?.default
-				if (defaultValue) {
-					set.add(defaultValue.path[defaultValue.path.length - 1])
-				}
-				for (const value of values) {
-					set.add(value)
-				}
-			})
+		ctx.symbols.query(ctx.doc, category, id).forEachMember((state, stateQuery) => {
+			const values = Object.keys(stateQuery.visibleMembers)
+			const set = (ans[state] ??= new Set())
+			const defaultValue = stateQuery.symbol?.relations?.default
+			if (defaultValue) {
+				set.add(defaultValue.path[defaultValue.path.length - 1])
+			}
+			for (const value of values) {
+				set.add(value)
+			}
+		})
 	}
 	return Object.fromEntries(Object.entries(ans).map(([k, v]) => [k, [...v]]))
 }
@@ -299,10 +278,7 @@ export function isIterable(value: unknown): value is Iterable<unknown> {
 }
 
 // #region ESNext functions polyfill
-export function atArray<T>(
-	array: readonly T[] | undefined,
-	index: number,
-): T | undefined {
+export function atArray<T>(array: readonly T[] | undefined, index: number): T | undefined {
 	return index >= 0 ? array?.[index] : array?.[array.length + index]
 }
 

--- a/packages/core/src/node/AstNode.ts
+++ b/packages/core/src/node/AstNode.ts
@@ -23,12 +23,10 @@ export interface AstNode {
 export namespace AstNode {
 	/* istanbul ignore next */
 	export function is(obj: unknown): obj is AstNode {
-		return (
-			!!obj
+		return (!!obj
 			&& typeof obj === 'object'
 			&& typeof (obj as AstNode).type === 'string'
-			&& Range.is((obj as AstNode).range)
-		)
+			&& Range.is((obj as AstNode).range))
 	}
 
 	export function setParents(node: AstNode): void {
@@ -49,9 +47,7 @@ export namespace AstNode {
 		if (!node.children) {
 			return -1
 		}
-		const comparator = typeof needle === 'number'
-			? Range.compareOffset
-			: Range.compare
+		const comparator = typeof needle === 'number' ? Range.compareOffset : Range.compare
 		return binarySearch(
 			node.children,
 			needle,
@@ -102,14 +98,8 @@ export namespace AstNode {
 		node: N,
 		needle: number | Range,
 		endInclusive = false,
-	):
-		| (N['children'] extends readonly unknown[] ? N['children'][number]
-			: undefined)
-		| undefined
-	{
-		return node.children?.[
-			findLastChildIndex(node, needle, endInclusive)
-		] as any
+	): (N['children'] extends readonly unknown[] ? N['children'][number] : undefined) | undefined {
+		return node.children?.[findLastChildIndex(node, needle, endInclusive)] as any
 	}
 
 	interface FindRecursivelyOptions<P = (node: AstNode) => boolean> {
@@ -124,15 +114,10 @@ export namespace AstNode {
 	export function findDeepestChild<N extends AstNode>(
 		options: FindRecursivelyOptions<(node: AstNode) => node is N>,
 	): N | undefined
+	export function findDeepestChild(options: FindRecursivelyOptions): AstNode | undefined
 	export function findDeepestChild(
-		options: FindRecursivelyOptions,
-	): AstNode | undefined
-	export function findDeepestChild({
-		node,
-		needle,
-		endInclusive = false,
-		predicate = () => true,
-	}: FindRecursivelyOptions): AstNode | undefined {
+		{ node, needle, endInclusive = false, predicate = () => true }: FindRecursivelyOptions,
+	): AstNode | undefined {
 		let last: AstNode | undefined
 		let head = Range.contains(node, needle, endInclusive) ? node : undefined
 		while (head && predicate(head)) {
@@ -148,15 +133,10 @@ export namespace AstNode {
 	export function findShallowestChild<N extends AstNode>(
 		options: FindRecursivelyOptions<(node: AstNode) => node is N>,
 	): N | undefined
+	export function findShallowestChild(options: FindRecursivelyOptions): AstNode | undefined
 	export function findShallowestChild(
-		options: FindRecursivelyOptions,
-	): AstNode | undefined
-	export function findShallowestChild({
-		node,
-		needle,
-		endInclusive = false,
-		predicate = () => true,
-	}: FindRecursivelyOptions): AstNode | undefined {
+		{ node, needle, endInclusive = false, predicate = () => true }: FindRecursivelyOptions,
+	): AstNode | undefined {
 		let head = Range.contains(node, needle, endInclusive) ? node : undefined
 		while (head && !predicate(head)) {
 			head = findChild(head, needle, endInclusive)
@@ -184,7 +164,4 @@ export namespace AstNode {
 	}
 }
 
-export type Mutable<N> = N extends AstNode ? {
-		-readonly [K in keyof N]: Mutable<N[K]>
-	}
-	: N
+export type Mutable<N> = N extends AstNode ? { -readonly [K in keyof N]: Mutable<N[K]> } : N

--- a/packages/core/src/node/AstNode.ts
+++ b/packages/core/src/node/AstNode.ts
@@ -24,10 +24,10 @@ export namespace AstNode {
 	/* istanbul ignore next */
 	export function is(obj: unknown): obj is AstNode {
 		return (
-			!!obj &&
-			typeof obj === 'object' &&
-			typeof (obj as AstNode).type === 'string' &&
-			Range.is((obj as AstNode).range)
+			!!obj
+			&& typeof obj === 'object'
+			&& typeof (obj as AstNode).type === 'string'
+			&& Range.is((obj as AstNode).range)
 		)
 	}
 

--- a/packages/core/src/node/BooleanNode.ts
+++ b/packages/core/src/node/BooleanNode.ts
@@ -17,9 +17,6 @@ export namespace BooleanNode {
 	}
 
 	export function mock(range: RangeLike): BooleanNode {
-		return {
-			type: 'boolean',
-			range: Range.get(range),
-		}
+		return { type: 'boolean', range: Range.get(range) }
 	}
 }

--- a/packages/core/src/node/CommentNode.ts
+++ b/packages/core/src/node/CommentNode.ts
@@ -1,8 +1,4 @@
-import type {
-	DeepReadonly,
-	InheritReadonly,
-	ReadWrite,
-} from '../common/index.js'
+import type { DeepReadonly, InheritReadonly, ReadWrite } from '../common/index.js'
 import type { AstNode } from './AstNode.js'
 
 export interface CommentNode extends AstNode {

--- a/packages/core/src/node/FloatNode.ts
+++ b/packages/core/src/node/FloatNode.ts
@@ -16,10 +16,6 @@ export namespace FloatNode {
 	}
 
 	export function mock(range: RangeLike): FloatNode {
-		return {
-			type: 'float',
-			range: Range.get(range),
-			value: 0,
-		}
+		return { type: 'float', range: Range.get(range), value: 0 }
 	}
 }

--- a/packages/core/src/node/IntegerNode.ts
+++ b/packages/core/src/node/IntegerNode.ts
@@ -15,10 +15,6 @@ export namespace IntegerNode {
 	}
 
 	export function mock(range: RangeLike): IntegerNode {
-		return {
-			type: 'integer',
-			range: Range.get(range),
-			value: 0,
-		}
+		return { type: 'integer', range: Range.get(range), value: 0 }
 	}
 }

--- a/packages/core/src/node/ListNode.ts
+++ b/packages/core/src/node/ListNode.ts
@@ -12,9 +12,7 @@ export interface ItemNode<V extends AstNode> extends AstNode {
 	readonly sep?: Range
 }
 export namespace ItemNode {
-	export function is<V extends AstNode>(
-		node: object | undefined,
-	): node is ItemNode<V> {
+	export function is<V extends AstNode>(node: object | undefined): node is ItemNode<V> {
 		return (node as ItemNode<V> | undefined)?.type === 'item'
 	}
 }

--- a/packages/core/src/node/LiteralNode.ts
+++ b/packages/core/src/node/LiteralNode.ts
@@ -22,15 +22,7 @@ export namespace LiteralNode {
 		return (obj as LiteralNode | undefined)?.type === 'literal'
 	}
 
-	export function mock(
-		range: RangeLike,
-		options: LiteralOptions,
-	): LiteralNode {
-		return {
-			type: 'literal',
-			range: Range.get(range),
-			options,
-			value: '',
-		}
+	export function mock(range: RangeLike, options: LiteralOptions): LiteralNode {
+		return { type: 'literal', range: Range.get(range), options, value: '' }
 	}
 }

--- a/packages/core/src/node/LongNode.ts
+++ b/packages/core/src/node/LongNode.ts
@@ -15,10 +15,6 @@ export namespace LongNode {
 	}
 
 	export function mock(range: RangeLike): LongNode {
-		return {
-			type: 'long',
-			range: Range.get(range),
-			value: 0n,
-		}
+		return { type: 'long', range: Range.get(range), value: 0n }
 	}
 }

--- a/packages/core/src/node/RecordNode.ts
+++ b/packages/core/src/node/RecordNode.ts
@@ -1,21 +1,15 @@
 import type { Range } from '../source/index.js'
 import type { AstNode } from './AstNode.js'
 
-export interface RecordBaseNode<K extends AstNode, V extends AstNode>
-	extends AstNode
-{
+export interface RecordBaseNode<K extends AstNode, V extends AstNode> extends AstNode {
 	readonly children: PairNode<K, V>[]
 }
 
-export interface RecordNode<K extends AstNode, V extends AstNode>
-	extends RecordBaseNode<K, V>
-{
+export interface RecordNode<K extends AstNode, V extends AstNode> extends RecordBaseNode<K, V> {
 	type: 'record'
 }
 
-export interface PairNode<K extends AstNode, V extends AstNode>
-	extends AstNode
-{
+export interface PairNode<K extends AstNode, V extends AstNode> extends AstNode {
 	readonly type: 'pair'
 	readonly children?: [K, V] | [K] | [V]
 	readonly key?: K

--- a/packages/core/src/node/ResourceLocationNode.ts
+++ b/packages/core/src/node/ResourceLocationNode.ts
@@ -17,26 +17,17 @@ export type ResourceLocationOptions =
 		usageType?: SymbolUsageType
 		namespacePathSep?: ':' | '.'
 	}
-	& (
-		| {
-			category: ResourceLocationCategory
-			pool?: undefined
-			allowTag?: false
-			allowUnknown?: false
-		}
-		| {
-			category: TaggableResourceLocationCategory
-			pool?: undefined
-			allowTag?: boolean
-			allowUnknown?: false
-		}
-		| {
-			category?: undefined
-			pool: string[]
-			allowTag?: false
-			allowUnknown?: boolean
-		}
-	)
+	& ({
+		category: ResourceLocationCategory
+		pool?: undefined
+		allowTag?: false
+		allowUnknown?: false
+	} | {
+		category: TaggableResourceLocationCategory
+		pool?: undefined
+		allowTag?: boolean
+		allowUnknown?: false
+	} | { category?: undefined; pool: string[]; allowTag?: false; allowUnknown?: boolean })
 
 export interface ResourceLocationBaseNode extends AstNode, Partial<ResourceLocation> {
 	readonly options: ResourceLocationOptions
@@ -62,20 +53,11 @@ export namespace ResourceLocationNode {
 
 	/* istanbul ignore next */
 	export function is(obj: AstNode | undefined): obj is ResourceLocationNode {
-		return (
-			(obj as ResourceLocationNode | undefined)?.type === 'resource_location'
-		)
+		return ((obj as ResourceLocationNode | undefined)?.type === 'resource_location')
 	}
 
-	export function mock(
-		range: RangeLike,
-		options: ResourceLocationOptions,
-	): ResourceLocationNode {
-		return {
-			type: 'resource_location',
-			range: Range.get(range),
-			options,
-		}
+	export function mock(range: RangeLike, options: ResourceLocationOptions): ResourceLocationNode {
+		return { type: 'resource_location', range: Range.get(range), options }
 	}
 
 	export function toString(
@@ -107,9 +89,7 @@ export namespace ResourceLocationNode {
 		switch (type) {
 			case 'origin':
 				// Use `node.namespace !== undefined`, so that empty namespaces can be correctly restored to string.
-				id = node.namespace !== undefined
-					? `${node.namespace}${NamespacePathSep}${path}`
-					: path
+				id = node.namespace !== undefined ? `${node.namespace}${NamespacePathSep}${path}` : path
 				break
 			case 'full':
 				// Use `node.namespace` before `||`, so that both undefined and empty value can result in the default namespace.

--- a/packages/core/src/node/ResourceLocationNode.ts
+++ b/packages/core/src/node/ResourceLocationNode.ts
@@ -38,9 +38,7 @@ export type ResourceLocationOptions =
 		}
 	)
 
-export interface ResourceLocationBaseNode
-	extends AstNode, Partial<ResourceLocation>
-{
+export interface ResourceLocationBaseNode extends AstNode, Partial<ResourceLocation> {
 	readonly options: ResourceLocationOptions
 }
 
@@ -116,9 +114,7 @@ export namespace ResourceLocationNode {
 			case 'full':
 				// Use `node.namespace` before `||`, so that both undefined and empty value can result in the default namespace.
 				// Use `||` instead of `??`, so that empty namespaces can be converted to the default namespace.
-				id = `${
-					node.namespace || DefaultNamespace
-				}${NamespacePathSep}${path}`
+				id = `${node.namespace || DefaultNamespace}${NamespacePathSep}${path}`
 				break
 			case 'short':
 				// Use `node.namespace` before `&&` for the same reason stated above.

--- a/packages/core/src/node/Sequence.ts
+++ b/packages/core/src/node/Sequence.ts
@@ -21,9 +21,7 @@ export interface SequenceUtil<CN extends AstNode = AstNode> {
 }
 
 export namespace SequenceUtil {
-	export function is<CN extends AstNode>(
-		obj: object | undefined,
-	): obj is SequenceUtil<CN> {
+	export function is<CN extends AstNode>(obj: object | undefined): obj is SequenceUtil<CN> {
 		return !!obj && (obj as SequenceUtil)[SequenceUtilDiscriminator]
 	}
 }

--- a/packages/core/src/node/StringNode.ts
+++ b/packages/core/src/node/StringNode.ts
@@ -8,10 +8,7 @@ export const EscapeChars = ['"', "'", '\\', 'b', 'f', 'n', 'r', 't'] as const
 export type EscapeChar = (typeof EscapeChars)[number]
 export namespace EscapeChar {
 	/* istanbul ignore next */
-	export function is(
-		expected: EscapeChar[] | undefined,
-		c: string,
-	): c is EscapeChar {
+	export function is(expected: EscapeChar[] | undefined, c: string): c is EscapeChar {
 		return expected ? expected.includes(c as any) : false
 	}
 }
@@ -57,26 +54,15 @@ export interface StringOptions {
 	 * the string can contain. Otherwise set this to `false`.
 	 */
 	unquotable?:
-		| {
-			allowEmpty?: boolean
-			allowList?: Set<string>
-			blockList?: Set<string>
-		}
+		| { allowEmpty?: boolean; allowList?: Set<string>; blockList?: Set<string> }
 		| false
 	/**
 	 * An optional object describing the content of the string.
 	 */
-	value?: {
-		parser: Parser
-		type: AstNode['type']
-	}
+	value?: { parser: Parser; type: AstNode['type'] }
 }
 
-export type QuoteTypeConfig =
-	| 'always double'
-	| 'always single'
-	| 'prefer double'
-	| 'prefer single'
+export type QuoteTypeConfig = 'always double' | 'always single' | 'prefer double' | 'prefer single'
 
 export interface StringBaseNode extends AstNode {
 	readonly options: StringOptions
@@ -100,10 +86,7 @@ export namespace StringNode {
 			range,
 			options,
 			value: '',
-			valueMap: [{
-				inner: Range.create(0),
-				outer: Range.create(range.start),
-			}],
+			valueMap: [{ inner: Range.create(0), outer: Range.create(range.start) }],
 		}
 	}
 }

--- a/packages/core/src/node/SymbolNode.ts
+++ b/packages/core/src/node/SymbolNode.ts
@@ -25,11 +25,6 @@ export namespace SymbolNode {
 	}
 
 	export function mock(range: RangeLike, options: SymbolOptions): SymbolNode {
-		return {
-			type: 'symbol',
-			range: Range.get(range),
-			options,
-			value: '',
-		}
+		return { type: 'symbol', range: Range.get(range), options, value: '' }
 	}
 }

--- a/packages/core/src/parser/comment.ts
+++ b/packages/core/src/parser/comment.ts
@@ -13,17 +13,10 @@ interface Options {
 /**
  * `Failure` when three isn't a comment.
  */
-export function comment({
-	singleLinePrefixes,
-	includesEol,
-}: Options): Parser<CommentNode> {
+export function comment({ singleLinePrefixes, includesEol }: Options): Parser<CommentNode> {
 	return (src: Source, _ctx: ParserContext): Result<CommentNode> => {
 		const start = src.cursor
-		const ans: CommentNode = {
-			type: 'comment',
-			range: Range.create(start),
-			comment: '',
-		}
+		const ans: CommentNode = { type: 'comment', range: Range.create(start), comment: '' }
 
 		for (const prefix of singleLinePrefixes) {
 			if (src.peek(prefix.length) === prefix) {

--- a/packages/core/src/parser/error.ts
+++ b/packages/core/src/parser/error.ts
@@ -16,10 +16,7 @@ export const error: InfallibleParser<ErrorNode | undefined> = (
 	if (!src.canRead()) {
 		return undefined
 	}
-	const ans: ErrorNode = {
-		type: 'error',
-		range: Range.create(src, () => src.skipRemaining()),
-	}
+	const ans: ErrorNode = { type: 'error', range: Range.create(src, () => src.skipRemaining()) }
 	ctx.err.report(localize('error.unparseable-content'), ans)
 	return ans
 }

--- a/packages/core/src/parser/file.ts
+++ b/packages/core/src/parser/file.ts
@@ -24,9 +24,7 @@ export function file(): InfallibleParser<FileNode<AstNode>> {
 
 		src.skipWhitespace()
 
-		const parser = ctx.meta.getParserForLanguageId<AstNode>(
-			ctx.doc.languageId,
-		)
+		const parser = ctx.meta.getParserForLanguageId<AstNode>(ctx.doc.languageId)
 		const result = parser(src, ctx)
 		if (result && result !== Failure) {
 			ans.children.push(result)

--- a/packages/core/src/parser/float.ts
+++ b/packages/core/src/parser/float.ts
@@ -20,12 +20,7 @@ interface OptionsBase {
 	 *
 	 * Defaults to a function that marks an `Error` at the range of the node.
 	 */
-	onOutOfRange?: (
-		ans: FloatNode,
-		src: Source,
-		ctx: ParserContext,
-		options: Options,
-	) => void
+	onOutOfRange?: (ans: FloatNode, src: Source, ctx: ParserContext, options: Options) => void
 }
 
 interface FallibleOptions extends OptionsBase {
@@ -46,10 +41,7 @@ const fallbackOnOutOfRange = (
 	options: Options,
 ) => {
 	ctx.err.report(
-		localize(
-			'expected',
-			localize('float.between', options.min ?? '-∞', options.max ?? '+∞'),
-		),
+		localize('expected', localize('float.between', options.min ?? '-∞', options.max ?? '+∞')),
 		ans,
 		ErrorSeverity.Error,
 	)
@@ -59,11 +51,7 @@ export function float(options: InfallibleOptions): InfallibleParser<FloatNode>
 export function float(options: FallibleOptions): Parser<FloatNode>
 export function float(options: Options): Parser<FloatNode> {
 	return (src: Source, ctx: ParserContext): Result<FloatNode> => {
-		const ans: FloatNode = {
-			type: 'float',
-			range: Range.create(src),
-			value: 0,
-		}
+		const ans: FloatNode = { type: 'float', range: Range.create(src), value: 0 }
 
 		if (src.peek() === '-' || src.peek() === '+') {
 			src.skip()
@@ -100,8 +88,7 @@ export function float(options: Options): Parser<FloatNode> {
 		} else if (!options.pattern.test(raw)) {
 			ctx.err.report(localize('parser.float.illegal', options.pattern), ans)
 		} else if (
-			(options.min && ans.value < options.min)
-			|| (options.max && ans.value > options.max)
+			(options.min && ans.value < options.min) || (options.max && ans.value > options.max)
 		) {
 			const onOutOfRange = options.onOutOfRange ?? fallbackOnOutOfRange
 			onOutOfRange(ans, src, ctx, options)

--- a/packages/core/src/parser/float.ts
+++ b/packages/core/src/parser/float.ts
@@ -100,8 +100,8 @@ export function float(options: Options): Parser<FloatNode> {
 		} else if (!options.pattern.test(raw)) {
 			ctx.err.report(localize('parser.float.illegal', options.pattern), ans)
 		} else if (
-			(options.min && ans.value < options.min) ||
-			(options.max && ans.value > options.max)
+			(options.min && ans.value < options.min)
+			|| (options.max && ans.value > options.max)
 		) {
 			const onOutOfRange = options.onOutOfRange ?? fallbackOnOutOfRange
 			onOutOfRange(ans, src, ctx, options)

--- a/packages/core/src/parser/integer.ts
+++ b/packages/core/src/parser/integer.ts
@@ -20,12 +20,7 @@ interface OptionsBase {
 	 *
 	 * Defaults to a function that marks an `Error` at the range of the node.
 	 */
-	onOutOfRange?: (
-		ans: IntegerNode,
-		src: Source,
-		ctx: ParserContext,
-		options: Options,
-	) => void
+	onOutOfRange?: (ans: IntegerNode, src: Source, ctx: ParserContext, options: Options) => void
 }
 
 interface FallibleOptions extends OptionsBase {
@@ -46,26 +41,17 @@ const fallbackOnOutOfRange = (
 	options: Options,
 ) => {
 	ctx.err.report(
-		localize(
-			'expected',
-			localize('integer.between', options.min ?? '-∞', options.max ?? '+∞'),
-		),
+		localize('expected', localize('integer.between', options.min ?? '-∞', options.max ?? '+∞')),
 		ans,
 		ErrorSeverity.Error,
 	)
 }
 
-export function integer(
-	options: InfallibleOptions,
-): InfallibleParser<IntegerNode>
+export function integer(options: InfallibleOptions): InfallibleParser<IntegerNode>
 export function integer(options: FallibleOptions): Parser<IntegerNode>
 export function integer(options: Options): Parser<IntegerNode> {
 	return (src: Source, ctx: ParserContext): Result<IntegerNode> => {
-		const ans: IntegerNode = {
-			type: 'integer',
-			range: Range.create(src),
-			value: 0,
-		}
+		const ans: IntegerNode = { type: 'integer', range: Range.create(src), value: 0 }
 
 		if (src.peek() === '-' || src.peek() === '+') {
 			src.skip()
@@ -89,10 +75,7 @@ export function integer(options: Options): Parser<IntegerNode> {
 			}
 			ctx.err.report(localize('expected', localize('integer')), ans)
 		} else if (!options.pattern.test(raw) || isOnlySign) {
-			ctx.err.report(
-				localize('parser.integer.illegal', options.pattern),
-				ans,
-			)
+			ctx.err.report(localize('parser.integer.illegal', options.pattern), ans)
 		} else if (
 			(options.min !== undefined && ans.value < options.min)
 			|| (options.max !== undefined && ans.value > options.max)

--- a/packages/core/src/parser/integer.ts
+++ b/packages/core/src/parser/integer.ts
@@ -94,8 +94,8 @@ export function integer(options: Options): Parser<IntegerNode> {
 				ans,
 			)
 		} else if (
-			(options.min !== undefined && ans.value < options.min) ||
-			(options.max !== undefined && ans.value > options.max)
+			(options.min !== undefined && ans.value < options.min)
+			|| (options.max !== undefined && ans.value > options.max)
 		) {
 			const onOutOfRange = options.onOutOfRange ?? fallbackOnOutOfRange
 			onOutOfRange(ans, src, ctx, options)

--- a/packages/core/src/parser/list.ts
+++ b/packages/core/src/parser/list.ts
@@ -16,19 +16,11 @@ export interface Options<V extends AstNode> {
 	end: string
 }
 
-export function list<V extends AstNode>({
-	start,
-	value,
-	sep,
-	trailingSep,
-	end,
-}: Options<V>): InfallibleParser<ListNode<V>> {
+export function list<V extends AstNode>(
+	{ start, value, sep, trailingSep, end }: Options<V>,
+): InfallibleParser<ListNode<V>> {
 	return (src: Source, ctx: ParserContext): ListNode<V> => {
-		const ans: ListNode<V> = {
-			type: 'list',
-			range: Range.create(src),
-			children: [],
-		}
+		const ans: ListNode<V> = { type: 'list', range: Range.create(src), children: [] }
 
 		if (src.trySkip(start)) {
 			src.skipWhitespace()
@@ -37,7 +29,9 @@ export function list<V extends AstNode>({
 			let hasValueSep = false
 			while (src.canRead() && src.peek(end.length) !== end) {
 				const itemStart = src.cursor
-				let valueNode: V | undefined
+				let valueNode:
+					| V
+					| undefined
 
 				// Item sep of the last item.
 				if (requiresValueSep && !hasValueSep) {
@@ -46,18 +40,11 @@ export function list<V extends AstNode>({
 
 				// Value.
 				src.skipWhitespace()
-				const { result, endCursor, updateSrcAndCtx } = attempt(
-					value,
-					src,
-					ctx,
-				)
+				const { result, endCursor, updateSrcAndCtx } = attempt(value, src, ctx)
 				if (result === Failure || endCursor === src.cursor) {
 					ctx.err.report(
 						localize('expected', localize('parser.list.value')),
-						Range.create(
-							src,
-							() => src.skipUntilOrEnd(sep, end, '\r', '\n'),
-						),
+						Range.create(src, () => src.skipUntilOrEnd(sep, end, '\r', '\n')),
 					)
 				} else {
 					updateSrcAndCtx()

--- a/packages/core/src/parser/literal.ts
+++ b/packages/core/src/parser/literal.ts
@@ -7,17 +7,10 @@ import type { InfallibleParser } from './Parser.js'
 
 export function literal(...pool: string[]): InfallibleParser<LiteralNode>
 export function literal(options: LiteralOptions): InfallibleParser<LiteralNode>
-export function literal(
-	...param: [LiteralOptions] | string[]
-): InfallibleParser<LiteralNode> {
+export function literal(...param: [LiteralOptions] | string[]): InfallibleParser<LiteralNode> {
 	const options = getOptions(param)
 	return (src: Source, ctx: ParserContext): LiteralNode => {
-		const ans: LiteralNode = {
-			type: 'literal',
-			range: Range.create(src),
-			options,
-			value: '',
-		}
+		const ans: LiteralNode = { type: 'literal', range: Range.create(src), options, value: '' }
 
 		for (const expected of options.pool) {
 			if (src.trySkip(expected)) {
@@ -38,9 +31,7 @@ function getOptions(param: string[] | [LiteralOptions]): LiteralOptions {
 	if (typeof param[0] === 'object') {
 		ans = param[0]
 	} else {
-		ans = {
-			pool: param as string[],
-		}
+		ans = { pool: param as string[] }
 	}
 	// Sort the pool from longest to shortest.
 	ans.pool = ans.pool.sort((a, b) => b.length - a.length)

--- a/packages/core/src/parser/long.ts
+++ b/packages/core/src/parser/long.ts
@@ -20,12 +20,7 @@ interface OptionsBase {
 	 *
 	 * Defaults to a function that marks an `Error` at the range of the node.
 	 */
-	onOutOfRange?: (
-		ans: LongNode,
-		src: Source,
-		ctx: ParserContext,
-		options: Options,
-	) => void
+	onOutOfRange?: (ans: LongNode, src: Source, ctx: ParserContext, options: Options) => void
 }
 
 interface FallibleOptions extends OptionsBase {
@@ -46,10 +41,7 @@ const fallbackOnOutOfRange = (
 	options: Options,
 ) => {
 	ctx.err.report(
-		localize(
-			'expected',
-			localize('long.between', options.min ?? '-∞', options.max ?? '+∞'),
-		),
+		localize('expected', localize('long.between', options.min ?? '-∞', options.max ?? '+∞')),
 		ans,
 		ErrorSeverity.Error,
 	)
@@ -59,11 +51,7 @@ export function long(options: InfallibleOptions): InfallibleParser<LongNode>
 export function long(options: FallibleOptions): Parser<LongNode>
 export function long(options: Options): Parser<LongNode> {
 	return (src: Source, ctx: ParserContext): Result<LongNode> => {
-		const ans: LongNode = {
-			type: 'long',
-			range: Range.create(src),
-			value: 0n,
-		}
+		const ans: LongNode = { type: 'long', range: Range.create(src), value: 0n }
 
 		if (src.peek() === '-' || src.peek() === '+') {
 			src.skip()
@@ -92,8 +80,7 @@ export function long(options: Options): Parser<LongNode> {
 		} else if (!options.pattern.test(raw) || isOnlySign) {
 			ctx.err.report(localize('parser.long.illegal', options.pattern), ans)
 		} else if (
-			(options.min && ans.value < options.min)
-			|| (options.max && ans.value > options.max)
+			(options.min && ans.value < options.min) || (options.max && ans.value > options.max)
 		) {
 			const onOutOfRange = options.onOutOfRange ?? fallbackOnOutOfRange
 			onOutOfRange(ans, src, ctx, options)

--- a/packages/core/src/parser/long.ts
+++ b/packages/core/src/parser/long.ts
@@ -92,8 +92,8 @@ export function long(options: Options): Parser<LongNode> {
 		} else if (!options.pattern.test(raw) || isOnlySign) {
 			ctx.err.report(localize('parser.long.illegal', options.pattern), ans)
 		} else if (
-			(options.min && ans.value < options.min) ||
-			(options.max && ans.value > options.max)
+			(options.min && ans.value < options.min)
+			|| (options.max && ans.value > options.max)
 		) {
 			const onOutOfRange = options.onOutOfRange ?? fallbackOnOutOfRange
 			onOutOfRange(ans, src, ctx, options)

--- a/packages/core/src/parser/record.ts
+++ b/packages/core/src/parser/record.ts
@@ -76,8 +76,7 @@ export function record<K extends AstNode, V extends AstNode>({
 						localize('expected', localize('parser.record.key')),
 						Range.create(
 							src,
-							() =>
-								src.skipUntilOrEnd(pair.sep, pair.end, end, '\r', '\n'),
+							() => src.skipUntilOrEnd(pair.sep, pair.end, end, '\r', '\n'),
 						),
 					)
 				} else {
@@ -116,8 +115,7 @@ export function record<K extends AstNode, V extends AstNode>({
 						localize('expected', localize('parser.record.value')),
 						Range.create(
 							src,
-							() =>
-								src.skipUntilOrEnd(pair.sep, pair.end, end, '\r', '\n'),
+							() => src.skipUntilOrEnd(pair.sep, pair.end, end, '\r', '\n'),
 						),
 					)
 				} else {

--- a/packages/core/src/parser/record.ts
+++ b/packages/core/src/parser/record.ts
@@ -66,9 +66,9 @@ export function record<K extends AstNode, V extends AstNode>({
 					endCursor: keyEnd,
 				} = attempt(pair.key, src, ctx)
 				if (
-					keyResult === Failure ||
-					(keyEnd - keyStart === 0 &&
-						![pair.sep, pair.end, end, '\r', '\n', '\t', ' '].includes(
+					keyResult === Failure
+					|| (keyEnd - keyStart === 0
+						&& ![pair.sep, pair.end, end, '\r', '\n', '\t', ' '].includes(
 							src.peek(),
 						))
 				) {
@@ -106,9 +106,9 @@ export function record<K extends AstNode, V extends AstNode>({
 					endCursor: valueEnd,
 				} = attempt(valueParser, src, ctx)
 				if (
-					valueResult === Failure ||
-					(valueEnd - valueStart === 0 &&
-						![pair.sep, pair.end, end, '\r', '\n', '\t', ' '].includes(
+					valueResult === Failure
+					|| (valueEnd - valueStart === 0
+						&& ![pair.sep, pair.end, end, '\r', '\n', '\t', ' '].includes(
 							src.peek(),
 						))
 				) {

--- a/packages/core/src/parser/resourceLocation.ts
+++ b/packages/core/src/parser/resourceLocation.ts
@@ -88,14 +88,9 @@ export function resourceLocation(
 		ans.range.end = src.cursor
 
 		if (raw.length === 0) {
-			ctx.err.report(
-				localize('expected', localize('resource-location')),
-				ans,
-			)
+			ctx.err.report(localize('expected', localize('resource-location')), ans)
 		} else {
-			const sepIndex = raw.indexOf(
-				options.namespacePathSep ?? ResourceLocation.NamespacePathSep,
-			)
+			const sepIndex = raw.indexOf(options.namespacePathSep ?? ResourceLocation.NamespacePathSep)
 			if (sepIndex >= 0) {
 				ans.namespace = raw.slice(0, sepIndex)
 			}
@@ -121,17 +116,11 @@ export function resourceLocation(
 			}
 
 			if (ans.isTag && !options.allowTag) {
-				ctx.err.report(
-					localize('parser.resource-location.tag-disallowed'),
-					ans,
-				)
+				ctx.err.report(localize('parser.resource-location.tag-disallowed'), ans)
 			}
 
 			if (!ans.namespace && options.isPredicate) {
-				ctx.err.report(
-					localize('parser.resource-location.namespace-expected'),
-					ans,
-				)
+				ctx.err.report(localize('parser.resource-location.namespace-expected'), ans)
 			}
 		}
 

--- a/packages/core/src/parser/resourceLocation.ts
+++ b/packages/core/src/parser/resourceLocation.ts
@@ -1,9 +1,6 @@
 import { arrayToMessage, localize } from '@spyglassmc/locales'
 import { ResourceLocation } from '../common/index.js'
-import type {
-	ResourceLocationNode,
-	ResourceLocationOptions,
-} from '../node/index.js'
+import type { ResourceLocationNode, ResourceLocationOptions } from '../node/index.js'
 import type { ParserContext } from '../service/index.js'
 import type { Source } from '../source/index.js'
 import { Range } from '../source/index.js'
@@ -109,12 +106,8 @@ export function resourceLocation(
 			/* istanbul ignore next */
 			const illegalChars = [
 				...new Set([
-					...[...(ans.namespace ?? [])].filter((c) =>
-						!LegalResourceLocationCharacters.has(c)
-					),
-					...[...rawPath].filter((c) =>
-						c !== '/' && !LegalResourceLocationCharacters.has(c)
-					),
+					...[...(ans.namespace ?? [])].filter((c) => !LegalResourceLocationCharacters.has(c)),
+					...[...rawPath].filter((c) => c !== '/' && !LegalResourceLocationCharacters.has(c)),
 				]),
 			]
 			if (illegalChars.length) {

--- a/packages/core/src/parser/string.ts
+++ b/packages/core/src/parser/string.ts
@@ -20,9 +20,7 @@ export function string(options: StringOptions): InfallibleParser<StringNode> {
 		}
 		let start = src.cursor
 
-		if (
-			options.quotes?.length && (src.peek() === '"' || src.peek() === "'")
-		) {
+		if (options.quotes?.length && (src.peek() === '"' || src.peek() === "'")) {
 			const currentQuote = src.read() as Quote
 			const contentStart = src.cursor
 			while (src.canRead() && src.peek() !== currentQuote) {
@@ -37,10 +35,7 @@ export function string(options: StringOptions): InfallibleParser<StringNode> {
 						|| EscapeChar.is(options.escapable.characters, c2)
 					) {
 						ans.valueMap.push({
-							inner: Range.create(
-								ans.value.length,
-								ans.value.length + 1,
-							),
+							inner: Range.create(ans.value.length, ans.value.length + 1),
 							outer: Range.create(cStart, src),
 						})
 						ans.value += EscapeTable.get(c2)
@@ -49,10 +44,7 @@ export function string(options: StringOptions): InfallibleParser<StringNode> {
 						if (/^[0-9a-f]{4}$/i.test(hex)) {
 							src.skip(4)
 							ans.valueMap.push({
-								inner: Range.create(
-									ans.value.length,
-									ans.value.length + 1,
-								),
+								inner: Range.create(ans.value.length, ans.value.length + 1),
 								outer: Range.create(cStart, src),
 							})
 							ans.value += String.fromCharCode(parseInt(hex, 16))
@@ -62,10 +54,7 @@ export function string(options: StringOptions): InfallibleParser<StringNode> {
 								Range.create(src, src.getCharRange(3).end),
 							)
 							ans.valueMap.push({
-								inner: Range.create(
-									ans.value.length,
-									ans.value.length + 1,
-								),
+								inner: Range.create(ans.value.length, ans.value.length + 1),
 								outer: Range.create(cStart, src),
 							})
 							ans.value += c2
@@ -73,18 +62,12 @@ export function string(options: StringOptions): InfallibleParser<StringNode> {
 					} else {
 						if (!options.escapable.allowUnknown) {
 							ctx.err.report(
-								localize(
-									'parser.string.illegal-escape',
-									localeQuote(c2),
-								),
+								localize('parser.string.illegal-escape', localeQuote(c2)),
 								src.getCharRange(-1),
 							)
 						}
 						ans.valueMap.push({
-							inner: Range.create(
-								ans.value.length,
-								ans.value.length + 1,
-							),
+							inner: Range.create(ans.value.length, ans.value.length + 1),
 							outer: Range.create(cStart, src),
 						})
 						ans.value += c2
@@ -100,18 +83,12 @@ export function string(options: StringOptions): InfallibleParser<StringNode> {
 			}
 
 			if (!options.quotes.includes(currentQuote)) {
-				ctx.err.report(
-					localize('parser.string.illegal-quote', options.quotes),
-					ans,
-				)
+				ctx.err.report(localize('parser.string.illegal-quote', options.quotes), ans)
 			}
 
 			start = contentStart
 		} else if (options.unquotable) {
-			while (
-				src.canRead()
-				&& isAllowedCharacter(src.peek(), options.unquotable)
-			) {
+			while (src.canRead() && isAllowedCharacter(src.peek(), options.unquotable)) {
 				ans.value += src.read()
 			}
 			if (!ans.value && !options.unquotable.allowEmpty) {
@@ -121,18 +98,10 @@ export function string(options: StringOptions): InfallibleParser<StringNode> {
 			ctx.err.report(localize('expected', options.quotes!), src)
 		}
 
-		ans.valueMap.unshift({
-			inner: Range.create(0),
-			outer: Range.create(start),
-		})
+		ans.valueMap.unshift({ inner: Range.create(0), outer: Range.create(start) })
 
 		if (options.value?.parser) {
-			const valueResult = parseStringValue(
-				options.value.parser,
-				ans.value,
-				ans.valueMap,
-				ctx,
-			)
+			const valueResult = parseStringValue(options.value.parser, ans.value, ans.valueMap, ctx)
 			/* istanbul ignore else */
 			if (valueResult !== Failure) {
 				ans.children = [valueResult]
@@ -154,12 +123,7 @@ export function parseStringValue<T extends Returnable>(
 	const valueSrc = new Source(value, map)
 	const valueCtx = {
 		...ctx,
-		doc: TextDocument.create(
-			ctx.doc.uri,
-			ctx.doc.languageId,
-			ctx.doc.version,
-			value,
-		),
+		doc: TextDocument.create(ctx.doc.uri, ctx.doc.languageId, ctx.doc.version, value),
 	}
 	// TODO: Mark trailing string as errors.
 	return parser(valueSrc, valueCtx)
@@ -235,9 +199,7 @@ export const BrigadierUnquotableCharacters = Object.freeze(
 		'-',
 	] as const,
 )
-export const BrigadierUnquotableCharacterSet = new Set(
-	BrigadierUnquotableCharacters,
-)
+export const BrigadierUnquotableCharacterSet = new Set(BrigadierUnquotableCharacters)
 export const BrigadierUnquotablePattern = /^[0-9A-Za-z_\.\+\-]*$/
 export const BrigadierUnquotableOption = {
 	allowEmpty: true,

--- a/packages/core/src/parser/string.ts
+++ b/packages/core/src/parser/string.ts
@@ -32,9 +32,9 @@ export function string(options: StringOptions): InfallibleParser<StringNode> {
 					src.skip()
 					const c2 = src.read()
 					if (
-						c2 === '\\' ||
-						c2 === currentQuote ||
-						EscapeChar.is(options.escapable.characters, c2)
+						c2 === '\\'
+						|| c2 === currentQuote
+						|| EscapeChar.is(options.escapable.characters, c2)
 					) {
 						ans.valueMap.push({
 							inner: Range.create(
@@ -109,8 +109,8 @@ export function string(options: StringOptions): InfallibleParser<StringNode> {
 			start = contentStart
 		} else if (options.unquotable) {
 			while (
-				src.canRead() &&
-				isAllowedCharacter(src.peek(), options.unquotable)
+				src.canRead()
+				&& isAllowedCharacter(src.peek(), options.unquotable)
 			) {
 				ans.value += src.read()
 			}

--- a/packages/core/src/parser/symbol.ts
+++ b/packages/core/src/parser/symbol.ts
@@ -13,9 +13,7 @@ import type { InfallibleParser } from './Parser.js'
 export function symbol(category: AllCategory): InfallibleParser<SymbolNode>
 export function symbol(category: string): InfallibleParser<SymbolNode>
 export function symbol(options: SymbolOptions): InfallibleParser<SymbolNode>
-export function symbol(
-	param: string | SymbolOptions,
-): InfallibleParser<SymbolNode> {
+export function symbol(param: string | SymbolOptions): InfallibleParser<SymbolNode> {
 	const options = getOptions(param)
 
 	return (src: Source, _ctx: ParserContext): SymbolNode => {

--- a/packages/core/src/parser/util.ts
+++ b/packages/core/src/parser/util.ts
@@ -246,8 +246,8 @@ export function any(
 				.filter(({ attempt }) => attempt.result !== Failure)
 				.sort(
 					(a, b) =>
-						b.attempt.endCursor - a.attempt.endCursor ||
-						a.attempt.errorAmount - b.attempt.errorAmount,
+						b.attempt.endCursor - a.attempt.endCursor
+						|| a.attempt.errorAmount - b.attempt.errorAmount,
 				)
 		if (results.length === 0) {
 			if (out) {
@@ -375,10 +375,10 @@ export function select(cases: readonly Case[]): Parser<Returnable> {
 	return (src: Source, ctx: ParserContext): Result<Returnable> => {
 		for (const { predicate, prefix, parser, regex } of cases) {
 			if (
-				predicate?.(src) ??
-					(prefix !== undefined ? src.tryPeek(prefix) : undefined) ??
-					(regex && src.matchPattern(regex)) ??
-					true
+				predicate?.(src)
+					?? (prefix !== undefined ? src.tryPeek(prefix) : undefined)
+					?? (regex && src.matchPattern(regex))
+					?? true
 			) {
 				const callableParser = typeof parser === 'object'
 					? parser.get()

--- a/packages/core/src/parser/util.ts
+++ b/packages/core/src/parser/util.ts
@@ -8,8 +8,7 @@ import { IndexMap, Range, Source } from '../source/index.js'
 import type { InfallibleParser, Parser, Result, Returnable } from './Parser.js'
 import { Failure } from './Parser.js'
 
-type ExtractNodeType<P extends Parser<Returnable>> = P extends Parser<infer V>
-	? V
+type ExtractNodeType<P extends Parser<Returnable>> = P extends Parser<infer V> ? V
 	: never
 /**
  * @template PA Parser array.
@@ -24,9 +23,7 @@ export interface AttemptResult<N extends Returnable = AstNode> {
 	endCursor: number
 	errorAmount: number
 }
-interface InfallibleAttemptResult<N extends Returnable = AstNode>
-	extends AttemptResult<N>
-{
+interface InfallibleAttemptResult<N extends Returnable = AstNode> extends AttemptResult<N> {
 	result: N
 }
 
@@ -237,18 +234,17 @@ export function any(
 	out?: AnyOutObject,
 ): Parser<Returnable> {
 	return (src: Source, ctx: ParserContext): Result<Returnable> => {
-		const results: { attempt: AttemptResult<Returnable>; index: number }[] =
-			parsers
-				.map((parser, i) => ({
-					attempt: attempt(parser, src, ctx),
-					index: i,
-				}))
-				.filter(({ attempt }) => attempt.result !== Failure)
-				.sort(
-					(a, b) =>
-						b.attempt.endCursor - a.attempt.endCursor
-						|| a.attempt.errorAmount - b.attempt.errorAmount,
-				)
+		const results: { attempt: AttemptResult<Returnable>; index: number }[] = parsers
+			.map((parser, i) => ({
+				attempt: attempt(parser, src, ctx),
+				index: i,
+			}))
+			.filter(({ attempt }) => attempt.result !== Failure)
+			.sort(
+				(a, b) =>
+					b.attempt.endCursor - a.attempt.endCursor
+					|| a.attempt.errorAmount - b.attempt.errorAmount,
+			)
 		if (results.length === 0) {
 			if (out) {
 				out.index = -1

--- a/packages/core/src/processor/ColorInfoProvider.ts
+++ b/packages/core/src/processor/ColorInfoProvider.ts
@@ -36,12 +36,7 @@ export namespace Color {
 	 * @param b A decimal within [0.0, 1.0].
 	 * @param a A decimal within [0.0, 1.0].
 	 */
-	export function fromDecRGBA(
-		r: number,
-		g: number,
-		b: number,
-		a: number,
-	): Color {
+	export function fromDecRGBA(r: number, g: number, b: number, a: number): Color {
 		return [r, g, b, a]
 	}
 
@@ -60,12 +55,7 @@ export namespace Color {
 	 * @param b An integer within [0, 255].
 	 * @param a An integer within [0, 255].
 	 */
-	export function fromIntRGBA(
-		r: number,
-		g: number,
-		b: number,
-		a: number,
-	): Color {
+	export function fromIntRGBA(r: number, g: number, b: number, a: number): Color {
 		return fromDecRGBA(r / 255, g / 255, b / 255, a / 255)
 	}
 
@@ -125,17 +115,9 @@ export enum ColorFormat {
 	CompositeInt,
 }
 
-export type FormattableColor = {
-	value: Color
-	format: ColorFormat[]
-	range?: Range
-}
+export type FormattableColor = { value: Color; format: ColorFormat[]; range?: Range }
 
-export type ColorPresentation = {
-	label: string
-	text: string
-	range: Range
-}
+export type ColorPresentation = { label: string; text: string; range: Range }
 export namespace ColorPresentation {
 	export function fromColorFormat(
 		format: ColorFormat,
@@ -143,11 +125,7 @@ export namespace ColorPresentation {
 		range: Range,
 	): ColorPresentation {
 		const presentation = colorPresentation(format, color)
-		return {
-			label: presentation,
-			text: presentation,
-			range,
-		}
+		return { label: presentation, text: presentation, range }
 	}
 
 	function colorPresentation(format: ColorFormat, color: Color): string {
@@ -156,43 +134,26 @@ export namespace ColorPresentation {
 			case ColorFormat.DecRGBA:
 				return color.map((c) => round(c)).join(' ')
 			case ColorFormat.DecRGB:
-				return color
-					.slice(0, 3)
-					.map((c) => round(c))
-					.join(' ')
+				return color.slice(0, 3).map((c) => round(c)).join(' ')
 			case ColorFormat.IntRGBA:
 				return color.map((c) => Math.round(c * 255)).join(' ')
 			case ColorFormat.IntRGB:
-				return color
-					.slice(0, 3)
-					.map((c) => Math.round(c * 255))
-					.join(' ')
+				return color.slice(0, 3).map((c) => Math.round(c * 255)).join(' ')
 			case ColorFormat.HexRGBA:
 				return `#${
 					Math.round(
-						(((color[0] * 255) << 24)
-							+ ((color[1] * 255) << 16)
-							+ color[2] * 255)
+						(((color[0] * 255) << 24) + ((color[1] * 255) << 16) + color[2] * 255)
 							<< (8 + color[3] * 255),
-					)
-						.toString(16)
-						.padStart(8, '0')
+					).toString(16).padStart(8, '0')
 				}`
 			case ColorFormat.HexRGB:
 				return `#${
-					Math.round(
-						((color[0] * 255) << 16) + ((color[1] * 255) << 8)
-							+ color[2] * 255,
-					)
-						.toString(16)
-						.padStart(6, '0')
+					Math.round(((color[0] * 255) << 16) + ((color[1] * 255) << 8) + color[2] * 255)
+						.toString(16).padStart(6, '0')
 				}`
 			case ColorFormat.CompositeInt:
 				return `${
-					Math.round(
-						((color[0] * 255) << 16) + ((color[1] * 255) << 8)
-							+ color[2] * 255,
-					)
+					Math.round(((color[0] * 255) << 16) + ((color[1] * 255) << 8) + color[2] * 255)
 				}`
 		}
 	}

--- a/packages/core/src/processor/ColorInfoProvider.ts
+++ b/packages/core/src/processor/ColorInfoProvider.ts
@@ -170,10 +170,10 @@ export namespace ColorPresentation {
 			case ColorFormat.HexRGBA:
 				return `#${
 					Math.round(
-						(((color[0] * 255) << 24) +
-							((color[1] * 255) << 16) +
-							color[2] * 255) <<
-							(8 + color[3] * 255),
+						(((color[0] * 255) << 24)
+							+ ((color[1] * 255) << 16)
+							+ color[2] * 255)
+							<< (8 + color[3] * 255),
 					)
 						.toString(16)
 						.padStart(8, '0')
@@ -181,8 +181,8 @@ export namespace ColorPresentation {
 			case ColorFormat.HexRGB:
 				return `#${
 					Math.round(
-						((color[0] * 255) << 16) + ((color[1] * 255) << 8) +
-							color[2] * 255,
+						((color[0] * 255) << 16) + ((color[1] * 255) << 8)
+							+ color[2] * 255,
 					)
 						.toString(16)
 						.padStart(6, '0')
@@ -190,8 +190,8 @@ export namespace ColorPresentation {
 			case ColorFormat.CompositeInt:
 				return `${
 					Math.round(
-						((color[0] * 255) << 16) + ((color[1] * 255) << 8) +
-							color[2] * 255,
+						((color[0] * 255) << 16) + ((color[1] * 255) << 8)
+							+ color[2] * 255,
 					)
 				}`
 		}

--- a/packages/core/src/processor/binder/Binder.ts
+++ b/packages/core/src/processor/binder/Binder.ts
@@ -8,9 +8,7 @@ export type Binder<N extends AstNode> = SyncBinder<N> | AsyncBinder<N>
 export interface SyncBinderInitializer<N extends AstNode> {
 	(node: N, ctx: BinderContext): void
 }
-export interface SyncBinder<N extends AstNode>
-	extends SyncBinderInitializer<N>
-{
+export interface SyncBinder<N extends AstNode> extends SyncBinderInitializer<N> {
 	[IsAsync]?: never
 }
 export namespace SyncBinder {
@@ -27,9 +25,7 @@ export namespace SyncBinder {
 interface AsyncBinderInitializer<N extends AstNode> {
 	(node: N, ctx: BinderContext): Promise<void>
 }
-export interface AsyncBinder<N extends AstNode>
-	extends AsyncBinderInitializer<N>
-{
+export interface AsyncBinder<N extends AstNode> extends AsyncBinderInitializer<N> {
 	[IsAsync]: true
 }
 export namespace AsyncBinder {

--- a/packages/core/src/processor/binder/Binder.ts
+++ b/packages/core/src/processor/binder/Binder.ts
@@ -12,9 +12,7 @@ export interface SyncBinder<N extends AstNode> extends SyncBinderInitializer<N> 
 	[IsAsync]?: never
 }
 export namespace SyncBinder {
-	export function create<N extends AstNode>(
-		binder: SyncBinderInitializer<N>,
-	): SyncBinder<N> {
+	export function create<N extends AstNode>(binder: SyncBinderInitializer<N>): SyncBinder<N> {
 		return binder
 	}
 	export function is(binder: Binder<any>): binder is SyncBinder<any> {
@@ -29,9 +27,7 @@ export interface AsyncBinder<N extends AstNode> extends AsyncBinderInitializer<N
 	[IsAsync]: true
 }
 export namespace AsyncBinder {
-	export function create<N extends AstNode>(
-		binder: AsyncBinderInitializer<N>,
-	): AsyncBinder<N> {
+	export function create<N extends AstNode>(binder: AsyncBinderInitializer<N>): AsyncBinder<N> {
 		return Object.assign(binder, { [IsAsync]: true as const })
 	}
 	export function is(binder: Binder<any>): binder is AsyncBinder<any> {

--- a/packages/core/src/processor/binder/builtin.ts
+++ b/packages/core/src/processor/binder/builtin.ts
@@ -66,8 +66,7 @@ type ExtractBinder<B extends Binder<never>> = B extends Binder<
 	: never
 export function any<Binders extends Binder<never>[]>(
 	binders: Binders,
-): Binders extends SyncBinder<never>[]
-	? SyncBinder<ExtractBinder<Binders[number]>>
+): Binders extends SyncBinder<never>[] ? SyncBinder<ExtractBinder<Binders[number]>>
 	: AsyncBinder<ExtractBinder<Binders[number]>>
 export function any<N extends AstNode>(binders: Binder<N>[]): Binder<N> {
 	if (binders.length === 0) {

--- a/packages/core/src/processor/checker/Checker.ts
+++ b/packages/core/src/processor/checker/Checker.ts
@@ -1,18 +1,9 @@
 import type { AstNode } from '../../node/index.js'
 import type { CheckerContext } from '../../service/index.js'
 
-export type Checker<N extends AstNode> = (
-	node: N,
-	ctx: CheckerContext,
-) => PromiseLike<void> | void
-export type SyncChecker<N extends AstNode> = (
-	node: N,
-	ctx: CheckerContext,
-) => void
-export type AsyncChecker<N extends AstNode> = (
-	node: N,
-	ctx: CheckerContext,
-) => PromiseLike<void>
+export type Checker<N extends AstNode> = (node: N, ctx: CheckerContext) => PromiseLike<void> | void
+export type SyncChecker<N extends AstNode> = (node: N, ctx: CheckerContext) => void
+export type AsyncChecker<N extends AstNode> = (node: N, ctx: CheckerContext) => PromiseLike<void>
 
 /* istanbul ignore next */
 export const FallbackChecker: Checker<any> = () => Promise.resolve()

--- a/packages/core/src/processor/checker/builtin.ts
+++ b/packages/core/src/processor/checker/builtin.ts
@@ -56,8 +56,8 @@ export function any<N extends AstNode>(checkers: Checker<N>[]): Checker<N> {
 			.map((checker) => attempt(checker, node, ctx))
 			.sort(
 				(a, b) =>
-					a.errorAmount - b.errorAmount ||
-					a.totalErrorSpan - b.totalErrorSpan,
+					a.errorAmount - b.errorAmount
+					|| a.totalErrorSpan - b.totalErrorSpan,
 			)
 		attempts[0].updateNodeAndCtx()
 	}

--- a/packages/core/src/processor/checker/builtin.ts
+++ b/packages/core/src/processor/checker/builtin.ts
@@ -1,10 +1,5 @@
 import { StateProxy } from '../../common/index.js'
-import type {
-	AstNode,
-	ResourceLocationNode,
-	SymbolBaseNode,
-	SymbolNode,
-} from '../../node/index.js'
+import type { AstNode, ResourceLocationNode, SymbolBaseNode, SymbolNode } from '../../node/index.js'
 import type { CheckerContext, MetaRegistry } from '../../service/index.js'
 import { ErrorReporter } from '../../service/index.js'
 import { traversePreOrder } from '../util.js'

--- a/packages/core/src/processor/checker/builtin.ts
+++ b/packages/core/src/processor/checker/builtin.ts
@@ -27,9 +27,10 @@ export function attempt<N extends AstNode>(
 
 	StateProxy.undoChanges(node as StateProxy<N>)
 
-	const totalErrorSpan = tempCtx.err.errors
-		.map((e) => e.range.end - e.range.start)
-		.reduce((a, b) => a + b, 0)
+	const totalErrorSpan = tempCtx.err.errors.map((e) => e.range.end - e.range.start).reduce(
+		(a, b) => a + b,
+		0,
+	)
 
 	return {
 		errorAmount: tempCtx.err.errors.length,
@@ -47,13 +48,9 @@ export function any<N extends AstNode>(checkers: Checker<N>[]): Checker<N> {
 		throw new Error('Expected at least one checker')
 	}
 	return (node, ctx) => {
-		const attempts = checkers
-			.map((checker) => attempt(checker, node, ctx))
-			.sort(
-				(a, b) =>
-					a.errorAmount - b.errorAmount
-					|| a.totalErrorSpan - b.totalErrorSpan,
-			)
+		const attempts = checkers.map((checker) => attempt(checker, node, ctx)).sort((a, b) =>
+			a.errorAmount - b.errorAmount || a.totalErrorSpan - b.totalErrorSpan
+		)
 		attempts[0].updateNodeAndCtx()
 	}
 }
@@ -107,9 +104,6 @@ export const symbol: Checker<SymbolBaseNode> = (_node, _ctx) => {
 }
 
 export function registerCheckers(meta: MetaRegistry) {
-	meta.registerChecker<ResourceLocationNode>(
-		'resource_location',
-		resourceLocation,
-	)
+	meta.registerChecker<ResourceLocationNode>('resource_location', resourceLocation)
 	meta.registerChecker<SymbolNode>('symbol', symbol)
 }

--- a/packages/core/src/processor/colorizer/Colorizer.ts
+++ b/packages/core/src/processor/colorizer/Colorizer.ts
@@ -21,11 +21,7 @@ export namespace ColorToken {
 		type: ColorTokenType,
 		modifiers?: ColorTokenModifier[],
 	): ColorToken {
-		return {
-			range: Range.get(range),
-			type,
-			modifiers,
-		}
+		return { range: Range.get(range), type, modifiers }
 	}
 
 	/**
@@ -39,31 +35,16 @@ export namespace ColorToken {
 		modifiers?: ColorTokenModifier[],
 	): ColorToken[] {
 		const ans: ColorToken[] = []
-		let nextStart = Math.min(
-			targetRange.start,
-			tokens[0]?.range.start ?? Infinity,
-		)
+		let nextStart = Math.min(targetRange.start, tokens[0]?.range.start ?? Infinity)
 		for (const t of tokens) {
 			if (t.range.start > nextStart) {
-				ans.push(
-					ColorToken.create(
-						Range.create(nextStart, t.range.start),
-						type,
-						modifiers,
-					),
-				)
+				ans.push(ColorToken.create(Range.create(nextStart, t.range.start), type, modifiers))
 			}
 			ans.push(t)
 			nextStart = t.range.end
 		}
 		if (nextStart < targetRange.end) {
-			ans.push(
-				ColorToken.create(
-					Range.create(nextStart, targetRange.end),
-					type,
-					modifiers,
-				),
-			)
+			ans.push(ColorToken.create(Range.create(nextStart, targetRange.end), type, modifiers))
 		}
 		return ans
 	}

--- a/packages/core/src/processor/colorizer/builtin.ts
+++ b/packages/core/src/processor/colorizer/builtin.ts
@@ -29,8 +29,8 @@ export const fallback: Colorizer = (node, ctx) => {
 	traversePreOrder(
 		node as AstNode,
 		(node) =>
-			!ctx.meta.hasColorizer(node.type) &&
-			(!ctx.range || Range.intersects(node.range, ctx.range)),
+			!ctx.meta.hasColorizer(node.type)
+			&& (!ctx.range || Range.intersects(node.range, ctx.range)),
 		(node) => ctx.meta.hasColorizer(node.type),
 		(node) => {
 			const colorizer = ctx.meta.getColorizer(node.type)

--- a/packages/core/src/processor/colorizer/builtin.ts
+++ b/packages/core/src/processor/colorizer/builtin.ts
@@ -62,10 +62,7 @@ export const number: Colorizer = (node) => {
 	return [ColorToken.create(node, 'number')]
 }
 
-export const resourceLocation: Colorizer<ResourceLocationBaseNode> = (
-	node,
-	_ctx,
-) => {
+export const resourceLocation: Colorizer<ResourceLocationBaseNode> = (node, _ctx) => {
 	let type: ColorTokenType
 	switch (node.options.category) {
 		case 'function':
@@ -84,11 +81,7 @@ export const string: Colorizer<StringBaseNode> = (node, ctx) => {
 		const colorizer = ctx.meta.getColorizer(node.children[0].type)
 		const result = colorizer(node.children[0], ctx)
 		// TODO: Fill the gap between the last token and the ending quote with errors.
-		return ColorToken.fillGap(
-			result,
-			node.range,
-			node.options.colorTokenType ?? 'string',
-		)
+		return ColorToken.fillGap(result, node.range, node.options.colorTokenType ?? 'string')
 	} else {
 		return [ColorToken.create(node, node.options.colorTokenType ?? 'string')]
 	}
@@ -107,10 +100,7 @@ export function registerColorizers(meta: MetaRegistry) {
 	meta.registerColorizer<IntegerNode>('integer', number)
 	meta.registerColorizer<LongNode>('long', number)
 	meta.registerColorizer<LiteralNode>('literal', literal)
-	meta.registerColorizer<ResourceLocationNode>(
-		'resource_location',
-		resourceLocation,
-	)
+	meta.registerColorizer<ResourceLocationNode>('resource_location', resourceLocation)
 	meta.registerColorizer<StringNode>('string', string)
 	meta.registerColorizer<SymbolNode>('symbol', symbol)
 }

--- a/packages/core/src/processor/completer/Completer.ts
+++ b/packages/core/src/processor/completer/Completer.ts
@@ -106,16 +106,10 @@ export class InsertTextBuilder {
 		if (defaultValues.length === 0) {
 			this.#ans += `$\{${this.#nextPlaceholder}}`
 		} else if (defaultValues.length === 1) {
-			this.#ans += `$\{${this.#nextPlaceholder}:${
-				CompletionItem.escape(
-					defaultValues[0],
-				)
-			}}`
+			this.#ans += `$\{${this.#nextPlaceholder}:${CompletionItem.escape(defaultValues[0])}}`
 		} else {
 			this.#ans += `$\{${this.#nextPlaceholder}|${
-				defaultValues
-					.map((v) => v.replace(/([\\$},|])/g, '\\$1'))
-					.join(',')
+				defaultValues.map((v) => v.replace(/([\\$},|])/g, '\\$1')).join(',')
 			}|}`
 		}
 		this.#nextPlaceholder += 1

--- a/packages/core/src/processor/completer/builtin.ts
+++ b/packages/core/src/processor/completer/builtin.ts
@@ -70,19 +70,12 @@ export const literal: Completer<LiteralBaseNode> = (node) => {
 		['resourceLocation', CompletionKind.File],
 		['variable', CompletionKind.Variable],
 	]).get(node.options.colorTokenType ?? 'keyword') ?? CompletionKind.Keyword
-	return (
-		node.options.pool.map((v) => CompletionItem.create(v, node, { kind }))
-			?? []
-	)
+	return (node.options.pool.map((v) => CompletionItem.create(v, node, { kind })) ?? [])
 }
 
 export const noop: Completer<any> = () => []
 
-interface RecordOptions<
-	K extends AstNode,
-	V extends AstNode,
-	N extends RecordBaseNode<K, V>,
-> {
+interface RecordOptions<K extends AstNode, V extends AstNode, N extends RecordBaseNode<K, V>> {
 	key: (
 		record: DeepReadonly<N>,
 		pair: DeepReadonly<PairNode<K, V>> | undefined,
@@ -99,45 +92,31 @@ interface RecordOptions<
 		range: RangeLike,
 	) => CompletionItem[]
 }
-export function record<
-	K extends AstNode,
-	V extends AstNode,
-	N extends RecordBaseNode<K, V>,
->(o: RecordOptions<K, V, N>): Completer<N> {
+export function record<K extends AstNode, V extends AstNode, N extends RecordBaseNode<K, V>>(
+	o: RecordOptions<K, V, N>,
+): Completer<N> {
 	return (node, ctx) => {
 		if (!Range.contains(Range.translate(node, 1, -1), ctx.offset, true)) {
 			return []
 		}
 
 		const completeKeys = (pair: DeepReadonly<PairNode<K, V>> | undefined) =>
-			o.key(
-				node,
-				pair,
-				ctx,
-				pair?.key ?? ctx.offset,
-				false,
-				false,
-				existingKeys,
-			)
+			o.key(node, pair, ctx, pair?.key ?? ctx.offset, false, false, existingKeys)
 		const completePairs = (pair: DeepReadonly<PairNode<K, V>> | undefined) =>
-			o.key(
-				node,
-				pair,
-				ctx,
-				pair ?? ctx.offset,
-				true,
-				hasNextPair || !!pair?.end,
-				existingKeys,
-			)
-		const existingKeys = node.children
-			.filter(
-				(n): n is DeepReadonly<Omit<PairNode<K, V>, 'key'> & { key: K }> => !!n.key,
-			)
-			.map((n) => n.key as DeepReadonly<K>)
-		const index = binarySearch(node.children, ctx.offset, (n, o) =>
-			n.end
-				? Range.compareOffset(Range.translate(n, 0, -1), o, true)
-				: Range.compareOffset(n.range, o, true))
+			o.key(node, pair, ctx, pair ?? ctx.offset, true, hasNextPair || !!pair?.end, existingKeys)
+		const existingKeys = node.children.filter((
+			n,
+		): n is DeepReadonly<Omit<PairNode<K, V>, 'key'> & { key: K }> => !!n.key).map((n) =>
+			n.key as DeepReadonly<K>
+		)
+		const index = binarySearch(
+			node.children,
+			ctx.offset,
+			(n, o) =>
+				n.end
+					? Range.compareOffset(Range.translate(n, 0, -1), o, true)
+					: Range.compareOffset(n.range, o, true),
+		)
 		const pair = index >= 0 ? node.children[index] : undefined
 		const hasNextPair = !!node.children.find((n) => n.range.start > ctx.offset)
 		if (!pair) {
@@ -148,10 +127,7 @@ export function record<
 		if (!key && !sep && !value) {
 			return completePairs(undefined)
 		}
-		if (
-			(key && Range.contains(key, ctx.offset, true))
-			|| (sep && ctx.offset <= sep.start)
-		) {
+		if ((key && Range.contains(key, ctx.offset, true)) || (sep && ctx.offset <= sep.start)) {
 			// Selected key.
 			if (!value || Range.isEmpty(value.range)) {
 				return completePairs(pair)
@@ -174,20 +150,12 @@ export function record<
 	}
 }
 
-export const resourceLocation: Completer<ResourceLocationNode> = (
-	node,
-	ctx,
-) => {
-	const config = LinterConfigValue.destruct(
-		ctx.config.lint.idOmitDefaultNamespace,
-	)
+export const resourceLocation: Completer<ResourceLocationNode> = (node, ctx) => {
+	const config = LinterConfigValue.destruct(ctx.config.lint.idOmitDefaultNamespace)
 
-	const includeEmptyNamespace = !node.options.isPredicate
-		&& node.namespace === ''
-	const includeDefaultNamespace = node.options.isPredicate
-		|| config?.ruleValue !== true
-	const excludeDefaultNamespace = !node.options.isPredicate
-		&& config?.ruleValue !== false
+	const includeEmptyNamespace = !node.options.isPredicate && node.namespace === ''
+	const includeDefaultNamespace = node.options.isPredicate || config?.ruleValue !== true
+	const excludeDefaultNamespace = !node.options.isPredicate && config?.ruleValue !== false
 
 	const getPool = (category: string) => {
 		const symbols = ctx.symbols.getVisibleSymbols(category, ctx.doc.uri)
@@ -229,8 +197,8 @@ export const resourceLocation: Completer<ResourceLocationNode> = (
 		: [
 			...getPool(node.options.category!),
 			...(node.options.allowTag
-				? getPool(`tag/${node.options.category}` as TagFileCategory).map(
-					(v) => `${ResourceLocation.TagPrefix}${v}`,
+				? getPool(`tag/${node.options.category}` as TagFileCategory).map((v) =>
+					`${ResourceLocation.TagPrefix}${v}`
 				)
 				: []),
 		]
@@ -258,11 +226,8 @@ export const string: Completer<StringBaseNode> = (node, ctx) => {
 
 export const symbol: Completer<SymbolBaseNode> = (node, ctx) => {
 	return Object.keys(
-		ctx.symbols.query(
-			ctx.doc,
-			node.options.category,
-			...(node.options.parentPath ?? []),
-		).visibleMembers,
+		ctx.symbols.query(ctx.doc, node.options.category, ...(node.options.parentPath ?? []))
+			.visibleMembers,
 	).map((v) => CompletionItem.create(v, node, { kind: CompletionKind.Variable }))
 }
 
@@ -273,10 +238,7 @@ export function registerCompleters(meta: MetaRegistry) {
 	meta.registerCompleter<IntegerNode>('integer', noop)
 	meta.registerCompleter<LongNode>('long', noop)
 	meta.registerCompleter<LiteralNode>('literal', literal)
-	meta.registerCompleter<ResourceLocationNode>(
-		'resource_location',
-		resourceLocation,
-	)
+	meta.registerCompleter<ResourceLocationNode>('resource_location', resourceLocation)
 	meta.registerCompleter<StringNode>('string', string)
 	meta.registerCompleter<SymbolNode>('symbol', symbol)
 }

--- a/packages/core/src/processor/completer/builtin.ts
+++ b/packages/core/src/processor/completer/builtin.ts
@@ -131,8 +131,7 @@ export function record<
 			)
 		const existingKeys = node.children
 			.filter(
-				(n): n is DeepReadonly<Omit<PairNode<K, V>, 'key'> & { key: K }> =>
-					!!n.key,
+				(n): n is DeepReadonly<Omit<PairNode<K, V>, 'key'> & { key: K }> => !!n.key,
 			)
 			.map((n) => n.key as DeepReadonly<K>)
 		const index = binarySearch(node.children, ctx.offset, (n, o) =>
@@ -140,9 +139,7 @@ export function record<
 				? Range.compareOffset(Range.translate(n, 0, -1), o, true)
 				: Range.compareOffset(n.range, o, true))
 		const pair = index >= 0 ? node.children[index] : undefined
-		const hasNextPair = !!node.children.find((n) =>
-			n.range.start > ctx.offset
-		)
+		const hasNextPair = !!node.children.find((n) => n.range.start > ctx.offset)
 		if (!pair) {
 			return completePairs(undefined)
 		}
@@ -218,15 +215,11 @@ export const resourceLocation: Completer<ResourceLocationNode> = (
 				? defaultNsIds.map((id) => id.slice(defaultNsPrefix.length))
 				: []),
 			...(includeEmptyNamespace
-				? defaultNsIds.map((id) =>
-					id.slice(ResourceLocation.DefaultNamespace.length)
-				)
+				? defaultNsIds.map((id) => id.slice(ResourceLocation.DefaultNamespace.length))
 				: []),
 		]
 		if (node.options.namespacePathSep === '.') {
-			return ans.map((v) =>
-				v.replace(ResourceLocation.NamespacePathSep, '.')
-			)
+			return ans.map((v) => v.replace(ResourceLocation.NamespacePathSep, '.'))
 		}
 		return ans
 	}
@@ -242,9 +235,7 @@ export const resourceLocation: Completer<ResourceLocationNode> = (
 				: []),
 		]
 
-	return pool.map((v) =>
-		CompletionItem.create(v, node, { kind: CompletionKind.Function })
-	)
+	return pool.map((v) => CompletionItem.create(v, node, { kind: CompletionKind.Function }))
 }
 
 export const string: Completer<StringBaseNode> = (node, ctx) => {
@@ -272,9 +263,7 @@ export const symbol: Completer<SymbolBaseNode> = (node, ctx) => {
 			node.options.category,
 			...(node.options.parentPath ?? []),
 		).visibleMembers,
-	).map((v) =>
-		CompletionItem.create(v, node, { kind: CompletionKind.Variable })
-	)
+	).map((v) => CompletionItem.create(v, node, { kind: CompletionKind.Variable }))
 }
 
 export function registerCompleters(meta: MetaRegistry) {

--- a/packages/core/src/processor/completer/builtin.ts
+++ b/packages/core/src/processor/completer/builtin.ts
@@ -71,8 +71,8 @@ export const literal: Completer<LiteralBaseNode> = (node) => {
 		['variable', CompletionKind.Variable],
 	]).get(node.options.colorTokenType ?? 'keyword') ?? CompletionKind.Keyword
 	return (
-		node.options.pool.map((v) => CompletionItem.create(v, node, { kind })) ??
-			[]
+		node.options.pool.map((v) => CompletionItem.create(v, node, { kind }))
+			?? []
 	)
 }
 
@@ -152,8 +152,8 @@ export function record<
 			return completePairs(undefined)
 		}
 		if (
-			(key && Range.contains(key, ctx.offset, true)) ||
-			(sep && ctx.offset <= sep.start)
+			(key && Range.contains(key, ctx.offset, true))
+			|| (sep && ctx.offset <= sep.start)
 		) {
 			// Selected key.
 			if (!value || Range.isEmpty(value.range)) {
@@ -165,9 +165,9 @@ export function record<
 			return o.value(node, pair, ctx, ctx.offset)
 		}
 		if (
-			(value && Range.contains(value, ctx.offset, true)) ||
-			(sep && ctx.offset >= sep.end) ||
-			(key && ctx.offset > key.range.end)
+			(value && Range.contains(value, ctx.offset, true))
+			|| (sep && ctx.offset >= sep.end)
+			|| (key && ctx.offset > key.range.end)
 		) {
 			// Selected value.
 			return o.value(node, pair, ctx, value ?? ctx.offset)
@@ -185,12 +185,12 @@ export const resourceLocation: Completer<ResourceLocationNode> = (
 		ctx.config.lint.idOmitDefaultNamespace,
 	)
 
-	const includeEmptyNamespace = !node.options.isPredicate &&
-		node.namespace === ''
-	const includeDefaultNamespace = node.options.isPredicate ||
-		config?.ruleValue !== true
-	const excludeDefaultNamespace = !node.options.isPredicate &&
-		config?.ruleValue !== false
+	const includeEmptyNamespace = !node.options.isPredicate
+		&& node.namespace === ''
+	const includeDefaultNamespace = node.options.isPredicate
+		|| config?.ruleValue !== true
+	const excludeDefaultNamespace = !node.options.isPredicate
+		&& config?.ruleValue !== false
 
 	const getPool = (category: string) => {
 		const symbols = ctx.symbols.getVisibleSymbols(category, ctx.doc.uri)

--- a/packages/core/src/processor/formatter/Formatter.ts
+++ b/packages/core/src/processor/formatter/Formatter.ts
@@ -7,20 +7,12 @@ export type Formatter<N extends AstNode = AstNode> = (
 	ctx: FormatterContext,
 ) => string
 
-export function formatterContextIndentation(
-	ctx: FormatterContext,
-	additionalLevels = 0,
-): string {
+export function formatterContextIndentation(ctx: FormatterContext, additionalLevels = 0): string {
 	const total = ctx.indentLevel + additionalLevels
-	return ctx.insertSpaces
-		? ' '.repeat(total * ctx.tabSize)
-		: '\t'.repeat(total)
+	return ctx.insertSpaces ? ' '.repeat(total * ctx.tabSize) : '\t'.repeat(total)
 }
 
-export function indentFormatter(
-	ctx: FormatterContext,
-	additionalLevels = 1,
-): FormatterContext {
+export function indentFormatter(ctx: FormatterContext, additionalLevels = 1): FormatterContext {
 	return {
 		...ctx,
 		indentLevel: ctx.indentLevel + additionalLevels,

--- a/packages/core/src/processor/formatter/builtin.ts
+++ b/packages/core/src/processor/formatter/builtin.ts
@@ -23,11 +23,9 @@ export const fallback: Formatter = (node) => {
 }
 
 export const file: Formatter<FileNode<AstNode>> = (node, ctx) => {
-	return node.children
-		.map((child) => {
-			return ctx.meta.getFormatter(child.type)(child, ctx)
-		})
-		.join('')
+	return node.children.map((child) => {
+		return ctx.meta.getFormatter(child.type)(child, ctx)
+	}).join('')
 }
 
 export const boolean: Formatter<BooleanBaseNode> = (node) => {
@@ -71,9 +69,6 @@ export function registerFormatters(meta: MetaRegistry) {
 	meta.registerFormatter<IntegerNode>('integer', integer)
 	meta.registerFormatter<LongNode>('long', long)
 	meta.registerFormatter<LiteralNode>('literal', literal)
-	meta.registerFormatter<ResourceLocationNode>(
-		'resource_location',
-		resourceLocation,
-	)
+	meta.registerFormatter<ResourceLocationNode>('resource_location', resourceLocation)
 	meta.registerFormatter<StringNode>('string', string)
 }

--- a/packages/core/src/processor/linter/Linter.ts
+++ b/packages/core/src/processor/linter/Linter.ts
@@ -2,7 +2,4 @@ import type { StateProxy } from '../../index.js'
 import type { AstNode } from '../../node/index.js'
 import type { LinterContext } from '../../service/index.js'
 
-export type Linter<N extends AstNode> = (
-	node: StateProxy<N>,
-	ctx: LinterContext,
-) => void
+export type Linter<N extends AstNode> = (node: StateProxy<N>, ctx: LinterContext) => void

--- a/packages/core/src/processor/linter/builtin.ts
+++ b/packages/core/src/processor/linter/builtin.ts
@@ -16,9 +16,7 @@ export const noop: Linter<AstNode> = () => {}
 export function nameConvention(key: string): Linter<AstNode> {
 	return (node, ctx) => {
 		if (typeof (node as any)[key] !== 'string') {
-			throw new Error(
-				`Trying to access property "${key}" of node type "${node.type}"`,
-			)
+			throw new Error(`Trying to access property "${key}" of node type "${node.type}"`)
 		}
 		const name: string = (node as any)[key]
 
@@ -47,9 +45,7 @@ export function nameConvention(key: string): Linter<AstNode> {
 export const quote: Linter<StringBaseNode> = (node, ctx) => {
 	const config = ctx.ruleValue as QuoteConfig
 	const mustValueBeQuoted = node.options.unquotable
-		? [...node.value].some(
-			(c) => !isAllowedCharacter(c, node.options.unquotable as any),
-		)
+		? [...node.value].some((c) => !isAllowedCharacter(c, node.options.unquotable as any))
 		: true
 	const isQuoteRequired = config.always || mustValueBeQuoted
 	const isQuoteProhibited = config.always === false && !mustValueBeQuoted
@@ -75,26 +71,13 @@ export namespace configValidator {
 
 	function wrapError(name: string, msg: string): string {
 		return `[Invalid Linter Config] [${name}] ${
-			localize(
-				'linter-config-validator.wrapper',
-				msg,
-				getDocLink(name),
-			)
+			localize('linter-config-validator.wrapper', msg, getDocLink(name))
 		}`
 	}
 
-	export function nameConvention(
-		name: string,
-		val: unknown,
-		logger: Logger,
-	): boolean {
+	export function nameConvention(name: string, val: unknown, logger: Logger): boolean {
 		if (typeof val !== 'string') {
-			logger.error(
-				wrapError(
-					name,
-					localize('linter-config-validator.name-convention.type'),
-				),
-			)
+			logger.error(wrapError(name, localize('linter-config-validator.name-convention.type')))
 			return false
 		}
 
@@ -115,11 +98,7 @@ export namespace configValidator {
 		return true
 	}
 
-	export function symbolLinterConfig(
-		_name: string,
-		value: unknown,
-		_logger: Logger,
-	): boolean {
+	export function symbolLinterConfig(_name: string, value: unknown, _logger: Logger): boolean {
 		return SymbolLinterConfig.is(value)
 	}
 }

--- a/packages/core/src/processor/linter/builtin.ts
+++ b/packages/core/src/processor/linter/builtin.ts
@@ -148,7 +148,6 @@ export function registerLinters(meta: MetaRegistry) {
 	meta.registerLinter('undeclaredSymbol', {
 		configValidator: configValidator.symbolLinterConfig,
 		linter: undeclaredSymbol,
-		nodePredicate: (n) =>
-			n.symbol && !McdocCategories.includes(n.symbol.category as any),
+		nodePredicate: (n) => n.symbol && !McdocCategories.includes(n.symbol.category as any),
 	})
 }

--- a/packages/core/src/processor/linter/builtin/undeclaredSymbol.ts
+++ b/packages/core/src/processor/linter/builtin/undeclaredSymbol.ts
@@ -3,10 +3,7 @@ import type { DeepReadonly } from '../../../common/index.js'
 import { Arrayable, ResourceLocation } from '../../../common/index.js'
 import type { AstNode } from '../../../node/index.js'
 import type { LinterContext } from '../../../service/index.js'
-import {
-	LinterSeverity,
-	SymbolLinterConfig as Config,
-} from '../../../service/index.js'
+import { LinterSeverity, SymbolLinterConfig as Config } from '../../../service/index.js'
 import type { Symbol } from '../../../symbol/index.js'
 import { SymbolUtil, SymbolVisibility } from '../../../symbol/index.js'
 import type { Linter } from '../Linter.js'

--- a/packages/core/src/processor/linter/builtin/undeclaredSymbol.ts
+++ b/packages/core/src/processor/linter/builtin/undeclaredSymbol.ts
@@ -64,21 +64,21 @@ function getAction(
 			return (
 				(condition.category
 					? Arrayable.toArray(condition.category).includes(symbol.category)
-					: true) &&
-				(condition.namespace
+					: true)
+				&& (condition.namespace
 					? Arrayable.toArray(condition.namespace).includes(namespace)
-					: true) &&
-				(condition.excludeNamespace
+					: true)
+				&& (condition.excludeNamespace
 					? !Arrayable.toArray(condition.excludeNamespace).includes(
 						namespace,
 					)
-					: true) &&
-				(condition.pattern
+					: true)
+				&& (condition.pattern
 					? Arrayable.toArray(condition.pattern).some((p) =>
 						new RegExp(p).test(symbol.identifier)
 					)
-					: true) &&
-				(condition.excludePattern
+					: true)
+				&& (condition.excludePattern
 					? !Arrayable.toArray(condition.excludePattern).some((p) =>
 						new RegExp(p).test(symbol.identifier)
 					)

--- a/packages/core/src/processor/linter/builtin/undeclaredSymbol.ts
+++ b/packages/core/src/processor/linter/builtin/undeclaredSymbol.ts
@@ -14,16 +14,10 @@ export const undeclaredSymbol: Linter<AstNode> = (node, ctx) => {
 	}
 	const action = getAction(ctx.ruleValue as Config, node.symbol, ctx)
 	if (Config.Action.isDeclare(action)) {
-		ctx.symbols
-			.query(
-				{ doc: ctx.doc, node },
-				node.symbol.category,
-				...node.symbol.path,
-			)
-			.amend({
-				data: { visibility: getVisibility(action.declare) },
-				usage: { type: 'declaration', node },
-			})
+		ctx.symbols.query({ doc: ctx.doc, node }, node.symbol.category, ...node.symbol.path).amend({
+			data: { visibility: getVisibility(action.declare) },
+			usage: { type: 'declaration', node },
+		})
 	}
 	if (Config.Action.isReport(action)) {
 		const severityOverride = action.report === 'inherit'
@@ -58,17 +52,14 @@ function getAction(
 				0,
 				resourceLocation.indexOf(ResourceLocation.NamespacePathSep),
 			)
-			return (
-				(condition.category
-					? Arrayable.toArray(condition.category).includes(symbol.category)
-					: true)
+			return ((condition.category
+				? Arrayable.toArray(condition.category).includes(symbol.category)
+				: true)
 				&& (condition.namespace
 					? Arrayable.toArray(condition.namespace).includes(namespace)
 					: true)
 				&& (condition.excludeNamespace
-					? !Arrayable.toArray(condition.excludeNamespace).includes(
-						namespace,
-					)
+					? !Arrayable.toArray(condition.excludeNamespace).includes(namespace)
 					: true)
 				&& (condition.pattern
 					? Arrayable.toArray(condition.pattern).some((p) =>
@@ -79,8 +70,7 @@ function getAction(
 					? !Arrayable.toArray(condition.excludePattern).some((p) =>
 						new RegExp(p).test(symbol.identifier)
 					)
-					: true)
-			)
+					: true))
 		}
 		try {
 			return Arrayable.toArray(conditions).some(testSingleCondition)
@@ -94,9 +84,7 @@ function getAction(
 		}
 	}
 
-	function evaluateComplexes(
-		complexes: Arrayable<Config.Complex>,
-	): Config.Action | undefined {
+	function evaluateComplexes(complexes: Arrayable<Config.Complex>): Config.Action | undefined {
 		for (const complex of Arrayable.toArray(complexes)) {
 			if (complex.if && !test(complex.if)) {
 				continue

--- a/packages/core/src/service/CacheService.ts
+++ b/packages/core/src/service/CacheService.ts
@@ -196,8 +196,8 @@ export class CacheService {
 				}
 			} catch (e) {
 				if (
-					this.project.externals.error.isKind(e, 'ENOENT') ||
-					this.project.externals.error.isKind(e, 'EISDIR')
+					this.project.externals.error.isKind(e, 'ENOENT')
+					|| this.project.externals.error.isKind(e, 'EISDIR')
 				) {
 					ans.removedFiles.push(uri)
 				} else {
@@ -255,8 +255,8 @@ export class CacheService {
 
 	async hasFileChangedSinceCache(doc: TextDocument): Promise<boolean> {
 		return (
-			this.checksums.files[doc.uri] !==
-				(await this.project.externals.crypto.getSha1(doc.getText()))
+			this.checksums.files[doc.uri]
+				!== (await this.project.externals.crypto.getSha1(doc.getText()))
 		)
 	}
 

--- a/packages/core/src/service/CacheService.ts
+++ b/packages/core/src/service/CacheService.ts
@@ -23,11 +23,7 @@ interface Checksums {
 }
 namespace Checksums {
 	export function create(): Checksums {
-		return {
-			files: {},
-			roots: {},
-			symbolRegistrars: {},
-		}
+		return { files: {}, roots: {}, symbolRegistrars: {} }
 	}
 }
 
@@ -68,18 +64,16 @@ export class CacheService {
 	 * @param cacheRoot File path to the directory where cache files by Spyglass should be stored.
 	 * @param project
 	 */
-	constructor(
-		private readonly cacheRoot: RootUriString,
-		private readonly project: Project,
-	) {
+	constructor(private readonly cacheRoot: RootUriString, private readonly project: Project) {
 		this.project.on('documentUpdated', async ({ doc }) => {
 			if (!this.#hasValidatedFiles) {
 				return
 			}
 			try {
 				// TODO: Don't update this for every single change.
-				this.checksums.files[doc.uri] = await this.project.externals.crypto
-					.getSha1(doc.getText())
+				this.checksums.files[doc.uri] = await this.project.externals.crypto.getSha1(
+					doc.getText(),
+				)
 			} catch (e) {
 				if (!this.project.externals.error.isKind(e, 'EISDIR')) {
 					this.project.logger.error(`[CacheService#hash-file] ${doc.uri}`)
@@ -110,7 +104,9 @@ export class CacheService {
 		})
 	}
 
-	#cacheFilePath: string | undefined
+	#cacheFilePath:
+		| string
+		| undefined
 	/**
 	 * @throws
 	 *
@@ -118,9 +114,7 @@ export class CacheService {
 	 */
 	private async getCacheFileUri(): Promise<string> {
 		return (this.#cacheFilePath ??= new Uri(
-			`symbols/${await this.project.externals.crypto.getSha1(
-				this.project.projectRoot,
-			)}.json.gz`,
+			`symbols/${await this.project.externals.crypto.getSha1(this.project.projectRoot)}.json.gz`,
 			this.cacheRoot,
 		).toString())
 	}
@@ -131,13 +125,9 @@ export class CacheService {
 		let filePath: string | undefined
 		try {
 			filePath = await this.getCacheFileUri()
-			this.project.logger.info(
-				`[CacheService#load] symbolCachePath = “${filePath}”`,
-			)
-			const cache = (await fileUtil.readGzippedJson(
-				this.project.externals,
-				filePath,
-			)) as CacheFile
+			this.project.logger.info(`[CacheService#load] symbolCachePath = “${filePath}”`)
+			const cache =
+				(await fileUtil.readGzippedJson(this.project.externals, filePath)) as CacheFile
 			__profiler.task('Read File')
 			if (cache.version === LatestCacheVersion) {
 				this.checksums = cache.checksums
@@ -236,28 +226,19 @@ export class CacheService {
 			}
 			__profiler.task('Unlink Symbols')
 
-			await fileUtil.writeGzippedJson(
-				this.project.externals,
-				filePath,
-				cache,
-			)
+			await fileUtil.writeGzippedJson(this.project.externals, filePath, cache)
 			__profiler.task('Write File').finalize()
 
 			return true
 		} catch (e) {
-			this.project.logger.error(
-				`[CacheService#save] path = “${filePath}”`,
-				e,
-			)
+			this.project.logger.error(`[CacheService#save] path = “${filePath}”`, e)
 		}
 		return false
 	}
 
 	async hasFileChangedSinceCache(doc: TextDocument): Promise<boolean> {
-		return (
-			this.checksums.files[doc.uri]
-				!== (await this.project.externals.crypto.getSha1(doc.getText()))
-		)
+		return (this.checksums.files[doc.uri]
+			!== (await this.project.externals.crypto.getSha1(doc.getText())))
 	}
 
 	reset(): LoadResult {

--- a/packages/core/src/service/Config.ts
+++ b/packages/core/src/service/Config.ts
@@ -71,10 +71,7 @@ export interface EnvConfig {
 	 *
 	 * Custom resources, currently only works for `minecraft:resource` JSON definitions dispatched from mcdoc.
 	 */
-	customResources: [
-		filePath: string,
-		config: CustomResourceConfig,
-	][]
+	customResources: [filePath: string, config: CustomResourceConfig][]
 	feature: {
 		codeActions: boolean
 		colors: boolean
@@ -108,10 +105,7 @@ export interface EnvConfig {
 	 * // TODO: Support file paths relative to the project root.
 	 */
 	mcmetaSummaryOverrides: Partial<
-		Record<
-			'blocks' | 'commands' | 'fluids' | 'registries',
-			{ path: string; replace?: boolean }
-		>
+		Record<'blocks' | 'commands' | 'fluids' | 'registries', { path: string; replace?: boolean }>
 	>
 	permissionLevel: 1 | 2 | 3 | 4
 	plugins: string[]
@@ -120,12 +114,10 @@ export interface EnvConfig {
 export type LinterSeverity = 'hint' | 'information' | 'warning' | 'error'
 export namespace LinterSeverity {
 	export function is(value: unknown): value is LinterSeverity {
-		return (
-			value === 'hint'
+		return (value === 'hint'
 			|| value === 'information'
 			|| value === 'warning'
-			|| value === 'error'
-		)
+			|| value === 'error')
 	}
 	export function toErrorSeverity(value: LinterSeverity): ErrorSeverity {
 		switch (value) {
@@ -154,35 +146,20 @@ type LinterConfigValue<T> = T extends boolean ? null | T | [LinterSeverity, T] |
 export namespace LinterConfigValue {
 	export function destruct(
 		value: LinterConfigValue<boolean | string | number | object>,
-	):
-		| {
-			ruleSeverity: ErrorSeverity
-			ruleValue: boolean | string | number | object
-		}
-		| undefined
-	{
+	): { ruleSeverity: ErrorSeverity; ruleValue: boolean | string | number | object } | undefined {
 		if (value === null || value === undefined) {
 			return undefined
 		}
 
 		if (LinterSeverity.is(value)) {
-			return {
-				ruleSeverity: LinterSeverity.toErrorSeverity(value),
-				ruleValue: true,
-			}
+			return { ruleSeverity: LinterSeverity.toErrorSeverity(value), ruleValue: true }
 		}
 
 		if (Array.isArray(value) && LinterSeverity.is(value[0])) {
-			return {
-				ruleSeverity: LinterSeverity.toErrorSeverity(value[0]),
-				ruleValue: value[1],
-			}
+			return { ruleSeverity: LinterSeverity.toErrorSeverity(value[0]), ruleValue: value[1] }
 		}
 
-		return {
-			ruleSeverity: ErrorSeverity.Warning,
-			ruleValue: value,
-		}
+		return { ruleSeverity: ErrorSeverity.Warning, ruleValue: value }
 	}
 }
 
@@ -251,9 +228,7 @@ export interface SnippetsConfig {
 	[label: string]: string
 }
 
-export type SymbolLinterConfig =
-	| Arrayable<SymbolLinterConfig.Complex>
-	| SymbolLinterConfig.Action
+export type SymbolLinterConfig = Arrayable<SymbolLinterConfig.Complex> | SymbolLinterConfig.Action
 export namespace SymbolLinterConfig {
 	export function is(value: unknown): value is SymbolLinterConfig {
 		return Arrayable.is(value, Complex.is) || Action.is(value)
@@ -273,12 +248,9 @@ export namespace SymbolLinterConfig {
 				return false
 			}
 			const value = v as Complex
-			return (
-				(value.if === undefined || Arrayable.is(value.if, Condition.is))
+			return ((value.if === undefined || Arrayable.is(value.if, Condition.is))
 				&& (value.then === undefined || Action.is(value.then))
-				&& (value.override === undefined
-					|| Arrayable.is(value.override, Complex.is))
-			)
+				&& (value.override === undefined || Arrayable.is(value.override, Complex.is)))
 		}
 	}
 
@@ -295,18 +267,15 @@ export namespace SymbolLinterConfig {
 				return false
 			}
 			const value = v as Condition
-			return (
-				(value.category === undefined
-					|| Arrayable.is(value.category, TypePredicates.isString))
-				&& (value.pattern === undefined
-					|| Arrayable.is(value.pattern, TypePredicates.isString))
+			return ((value.category === undefined
+				|| Arrayable.is(value.category, TypePredicates.isString))
+				&& (value.pattern === undefined || Arrayable.is(value.pattern, TypePredicates.isString))
 				&& (value.excludePattern === undefined
 					|| Arrayable.is(value.excludePattern, TypePredicates.isString))
 				&& (value.namespace === undefined
 					|| Arrayable.is(value.namespace, TypePredicates.isString))
 				&& (value.excludeNamespace === undefined
-					|| Arrayable.is(value.excludeNamespace, TypePredicates.isString))
-			)
+					|| Arrayable.is(value.excludeNamespace, TypePredicates.isString)))
 		}
 	}
 
@@ -318,25 +287,15 @@ export namespace SymbolLinterConfig {
 	}
 	export type Action = DeclareAction | ReportAction
 	export namespace Action {
-		export function isDeclare(
-			value: Action | undefined,
-		): value is DeclareAction {
-			return (
-				value !== undefined
-				&& ['block', 'file', 'public'].includes(
-					(value as DeclareAction).declare,
-				)
-			)
+		export function isDeclare(value: Action | undefined): value is DeclareAction {
+			return (value !== undefined
+				&& ['block', 'file', 'public'].includes((value as DeclareAction).declare))
 		}
-		export function isReport(
-			value: Action | undefined,
-		): value is ReportAction {
-			return (
-				value !== undefined
+		export function isReport(value: Action | undefined): value is ReportAction {
+			return (value !== undefined
 				&& ['inherit', 'hint', 'information', 'warning', 'error'].includes(
 					(value as ReportAction).report,
-				)
-			)
+				))
 		}
 		export function is(v: unknown): v is Action {
 			if (!v || typeof v !== 'object') {
@@ -354,10 +313,7 @@ export namespace SymbolLinterConfig {
 export const VanillaConfig: Config = {
 	env: {
 		dataSource: 'GitHub',
-		dependencies: [
-			'@vanilla-datapack',
-			'@vanilla-mcdoc',
-		],
+		dependencies: ['@vanilla-datapack', '@vanilla-mcdoc'],
 		customResources: [],
 		feature: {
 			codeActions: true,
@@ -443,20 +399,12 @@ export const VanillaConfig: Config = {
 		nbtListLengthCheck: null,
 		nbtTypeCheck: 'loosely',
 
-		undeclaredSymbol: [
-			{
-				if: [
-					{ category: RegistryCategories, namespace: 'minecraft' },
-					{
-						category: [...FileCategories, 'bossbar', 'objective', 'team'],
-					},
-				],
-				then: { report: 'warning' },
-			},
-			{
-				then: { declare: 'block' },
-			},
-		],
+		undeclaredSymbol: [{
+			if: [{ category: RegistryCategories, namespace: 'minecraft' }, {
+				category: [...FileCategories, 'bossbar', 'objective', 'team'],
+			}],
+			then: { report: 'warning' },
+		}, { then: { declare: 'block' } }],
 	},
 	snippet: {
 		executeIfScoreSet:
@@ -470,19 +418,11 @@ type ConfigEvent = { config: Config }
 type ErrorEvent = { error: unknown; uri: string }
 
 export class ConfigService implements ExternalEventEmitter {
-	static readonly ConfigFileNames = Object.freeze(
-		[
-			'spyglass.json',
-			'.spyglassrc.json',
-		] as const,
-	)
+	static readonly ConfigFileNames = Object.freeze(['spyglass.json', '.spyglassrc.json'] as const)
 
 	readonly #eventEmitter: ExternalEventEmitter
 
-	constructor(
-		private readonly project: Project,
-		private readonly defaultConfig = VanillaConfig,
-	) {
+	constructor(private readonly project: Project, private readonly defaultConfig = VanillaConfig) {
 		this.#eventEmitter = new project.externals.event.EventEmitter()
 		const handler = async ({ uri }: { uri: string }) => {
 			if (ConfigService.isConfigFile(uri)) {
@@ -519,9 +459,7 @@ export class ConfigService implements ExternalEventEmitter {
 		for (const name of ConfigService.ConfigFileNames) {
 			const uri = this.project.projectRoot + name
 			try {
-				ans = JSON.parse(
-					bufferToString(await this.project.externals.fs.readFile(uri)),
-				)
+				ans = JSON.parse(bufferToString(await this.project.externals.fs.readFile(uri)))
 			} catch (e) {
 				if (this.project.externals.error.isKind(e, 'ENOENT')) {
 					// File doesn't exist.

--- a/packages/core/src/service/Config.ts
+++ b/packages/core/src/service/Config.ts
@@ -121,10 +121,10 @@ export type LinterSeverity = 'hint' | 'information' | 'warning' | 'error'
 export namespace LinterSeverity {
 	export function is(value: unknown): value is LinterSeverity {
 		return (
-			value === 'hint' ||
-			value === 'information' ||
-			value === 'warning' ||
-			value === 'error'
+			value === 'hint'
+			|| value === 'information'
+			|| value === 'warning'
+			|| value === 'error'
 		)
 	}
 	export function toErrorSeverity(value: LinterSeverity): ErrorSeverity {
@@ -275,10 +275,10 @@ export namespace SymbolLinterConfig {
 			}
 			const value = v as Complex
 			return (
-				(value.if === undefined || Arrayable.is(value.if, Condition.is)) &&
-				(value.then === undefined || Action.is(value.then)) &&
-				(value.override === undefined ||
-					Arrayable.is(value.override, Complex.is))
+				(value.if === undefined || Arrayable.is(value.if, Condition.is))
+				&& (value.then === undefined || Action.is(value.then))
+				&& (value.override === undefined
+					|| Arrayable.is(value.override, Complex.is))
 			)
 		}
 	}
@@ -297,16 +297,16 @@ export namespace SymbolLinterConfig {
 			}
 			const value = v as Condition
 			return (
-				(value.category === undefined ||
-					Arrayable.is(value.category, TypePredicates.isString)) &&
-				(value.pattern === undefined ||
-					Arrayable.is(value.pattern, TypePredicates.isString)) &&
-				(value.excludePattern === undefined ||
-					Arrayable.is(value.excludePattern, TypePredicates.isString)) &&
-				(value.namespace === undefined ||
-					Arrayable.is(value.namespace, TypePredicates.isString)) &&
-				(value.excludeNamespace === undefined ||
-					Arrayable.is(value.excludeNamespace, TypePredicates.isString))
+				(value.category === undefined
+					|| Arrayable.is(value.category, TypePredicates.isString))
+				&& (value.pattern === undefined
+					|| Arrayable.is(value.pattern, TypePredicates.isString))
+				&& (value.excludePattern === undefined
+					|| Arrayable.is(value.excludePattern, TypePredicates.isString))
+				&& (value.namespace === undefined
+					|| Arrayable.is(value.namespace, TypePredicates.isString))
+				&& (value.excludeNamespace === undefined
+					|| Arrayable.is(value.excludeNamespace, TypePredicates.isString))
 			)
 		}
 	}
@@ -323,8 +323,8 @@ export namespace SymbolLinterConfig {
 			value: Action | undefined,
 		): value is DeclareAction {
 			return (
-				value !== undefined &&
-				['block', 'file', 'public'].includes(
+				value !== undefined
+				&& ['block', 'file', 'public'].includes(
 					(value as DeclareAction).declare,
 				)
 			)
@@ -333,8 +333,8 @@ export namespace SymbolLinterConfig {
 			value: Action | undefined,
 		): value is ReportAction {
 			return (
-				value !== undefined &&
-				['inherit', 'hint', 'information', 'warning', 'error'].includes(
+				value !== undefined
+				&& ['inherit', 'hint', 'information', 'warning', 'error'].includes(
 					(value as ReportAction).report,
 				)
 			)

--- a/packages/core/src/service/Config.ts
+++ b/packages/core/src/service/Config.ts
@@ -149,8 +149,7 @@ export type QuoteConfig = {
 	type?: 'double' | 'single'
 }
 
-type LinterConfigValue<T> = T extends boolean
-	? null | T | [LinterSeverity, T] | LinterSeverity
+type LinterConfigValue<T> = T extends boolean ? null | T | [LinterSeverity, T] | LinterSeverity
 	: null | T | [LinterSeverity, T]
 export namespace LinterConfigValue {
 	export function destruct(

--- a/packages/core/src/service/Context.ts
+++ b/packages/core/src/service/Context.ts
@@ -213,9 +213,7 @@ export namespace FormatterContext {
 }
 
 export interface ColorizerContext extends ProcessorWithRangeContext {}
-export interface ColorizerContextOptions
-	extends ProcessorWithRangeContextOptions
-{}
+export interface ColorizerContextOptions extends ProcessorWithRangeContextOptions {}
 export namespace ColorizerContext {
 	export function create(
 		project: ProjectData,
@@ -246,12 +244,8 @@ export namespace CompleterContext {
 	}
 }
 
-export interface SignatureHelpProviderContext
-	extends ProcessorWithOffsetContext
-{}
-export interface SignatureHelpProviderContextOptions
-	extends ProcessorWithOffsetContextOptions
-{}
+export interface SignatureHelpProviderContext extends ProcessorWithOffsetContext {}
+export interface SignatureHelpProviderContextOptions extends ProcessorWithOffsetContextOptions {}
 export namespace SignatureHelpProviderContext {
 	export function create(
 		project: ProjectData,

--- a/packages/core/src/service/Context.ts
+++ b/packages/core/src/service/Context.ts
@@ -48,10 +48,7 @@ interface ParserContextOptions {
 	err?: ErrorReporter
 }
 export namespace ParserContext {
-	export function create(
-		project: ProjectData,
-		opts: ParserContextOptions,
-	): ParserContext {
+	export function create(project: ProjectData, opts: ParserContextOptions): ParserContext {
 		return {
 			...ContextBase.create(project),
 			config: project.config,
@@ -72,10 +69,7 @@ interface ProcessorContextOptions {
 	src?: ReadonlySource
 }
 export namespace ProcessorContext {
-	export function create(
-		project: ProjectData,
-		opts: ProcessorContextOptions,
-	): ProcessorContext {
+	export function create(project: ProjectData, opts: ProcessorContextOptions): ProcessorContext {
 		return {
 			...ContextBase.create(project),
 			config: project.config,
@@ -97,10 +91,7 @@ namespace ProcessorWithRangeContext {
 		project: ProjectData,
 		opts: ProcessorWithRangeContextOptions,
 	): ProcessorWithRangeContext {
-		return {
-			...ProcessorContext.create(project, opts),
-			range: opts.range,
-		}
+		return { ...ProcessorContext.create(project, opts), range: opts.range }
 	}
 }
 
@@ -115,10 +106,7 @@ namespace ProcessorWithOffsetContext {
 		project: ProjectData,
 		opts: ProcessorWithOffsetContextOptions,
 	): ProcessorWithOffsetContext {
-		return {
-			...ProcessorContext.create(project, opts),
-			offset: opts.offset,
-		}
+		return { ...ProcessorContext.create(project, opts), offset: opts.offset }
 	}
 }
 
@@ -130,10 +118,7 @@ interface BinderContextOptions extends ProcessorContextOptions {
 	err?: ErrorReporter
 }
 export namespace BinderContext {
-	export function create(
-		project: ProjectData,
-		opts: BinderContextOptions,
-	): BinderContext {
+	export function create(project: ProjectData, opts: BinderContextOptions): BinderContext {
 		return {
 			...ProcessorContext.create(project, opts),
 			err: opts.err ?? new ErrorReporter(),
@@ -150,10 +135,7 @@ interface CheckerContextOptions extends ProcessorContextOptions {
 	err?: ErrorReporter
 }
 export namespace CheckerContext {
-	export function create(
-		project: ProjectData,
-		opts: CheckerContextOptions,
-	): CheckerContext {
+	export function create(project: ProjectData, opts: CheckerContextOptions): CheckerContext {
 		return {
 			...ProcessorContext.create(project, opts),
 			err: opts.err ?? new ErrorReporter(),
@@ -173,10 +155,7 @@ interface LinterContextOptions extends ProcessorContextOptions {
 	ruleValue: unknown
 }
 export namespace LinterContext {
-	export function create(
-		project: ProjectData,
-		opts: LinterContextOptions,
-	): LinterContext {
+	export function create(project: ProjectData, opts: LinterContextOptions): LinterContext {
 		return {
 			...ProcessorContext.create(project, opts),
 			err: opts.err,
@@ -197,10 +176,7 @@ interface FormatterContextOptions extends ProcessorContextOptions {
 	insertSpaces: boolean
 }
 export namespace FormatterContext {
-	export function create(
-		project: ProjectData,
-		opts: FormatterContextOptions,
-	): FormatterContext {
+	export function create(project: ProjectData, opts: FormatterContextOptions): FormatterContext {
 		return {
 			...ProcessorContext.create(project, opts),
 			...opts,
@@ -215,10 +191,7 @@ export namespace FormatterContext {
 export interface ColorizerContext extends ProcessorWithRangeContext {}
 export interface ColorizerContextOptions extends ProcessorWithRangeContextOptions {}
 export namespace ColorizerContext {
-	export function create(
-		project: ProjectData,
-		opts: ColorizerContextOptions,
-	): ColorizerContext {
+	export function create(project: ProjectData, opts: ColorizerContextOptions): ColorizerContext {
 		return ProcessorWithRangeContext.create(project, opts)
 	}
 }
@@ -232,10 +205,7 @@ interface CompleterContextOptions extends ProcessorContextOptions {
 	triggerCharacter?: string
 }
 export namespace CompleterContext {
-	export function create(
-		project: ProjectData,
-		opts: CompleterContextOptions,
-	): CompleterContext {
+	export function create(project: ProjectData, opts: CompleterContextOptions): CompleterContext {
 		return {
 			...ProcessorContext.create(project, opts),
 			offset: opts.offset,
@@ -261,10 +231,6 @@ export interface UriBinderContext extends ContextBase {
 }
 export namespace UriBinderContext {
 	export function create(project: ProjectData): UriBinderContext {
-		return {
-			...ContextBase.create(project),
-			config: project.config,
-			symbols: project.symbols,
-		}
+		return { ...ContextBase.create(project), config: project.config, symbols: project.symbols }
 	}
 }

--- a/packages/core/src/service/ErrorReporter.ts
+++ b/packages/core/src/service/ErrorReporter.ts
@@ -19,9 +19,7 @@ export class ErrorReporter {
 		if (message.trim() === '') {
 			throw new Error('Tried to report an error with no message')
 		}
-		this.errors.push(
-			LanguageError.create(message, Range.get(range), severity, info),
-		)
+		this.errors.push(LanguageError.create(message, Range.get(range), severity, info))
 	}
 
 	/**

--- a/packages/core/src/service/FileService.ts
+++ b/packages/core/src/service/FileService.ts
@@ -234,8 +234,8 @@ export class FileUriSupporter implements UriProtocolSupporter {
 		for (let { uri } of dependencies) {
 			try {
 				if (
-					fileUtil.isFileUri(uri) &&
-					(await externals.fs.stat(uri)).isDirectory()
+					fileUtil.isFileUri(uri)
+					&& (await externals.fs.stat(uri)).isDirectory()
 				) {
 					uri = fileUtil.ensureEndingSlash(uri)
 					roots.push(uri as RootUriString)
@@ -380,11 +380,11 @@ export class ArchiveUriSupporter implements UriProtocolSupporter {
 		for (const { uri, info } of dependencies) {
 			try {
 				if (
-					uri.startsWith('file:') &&
-					ArchiveUriSupporter.SupportedArchiveExtnames.some((ext) =>
+					uri.startsWith('file:')
+					&& ArchiveUriSupporter.SupportedArchiveExtnames.some((ext) =>
 						uri.endsWith(ext)
-					) &&
-					(await externals.fs.stat(uri)).isFile()
+					)
+					&& (await externals.fs.stat(uri)).isFile()
 				) {
 					const archiveName = fileUtil.basename(uri)
 					if (entries.has(archiveName)) {

--- a/packages/core/src/service/FileService.ts
+++ b/packages/core/src/service/FileService.ts
@@ -41,11 +41,7 @@ export interface FileService extends UriProtocolSupporter {
 	 *
 	 * @throws If `protocol` is already registered, unless `force` is set to `true`.
 	 */
-	register(
-		protocol: Protocol,
-		supporter: UriProtocolSupporter,
-		force?: boolean,
-	): void
+	register(protocol: Protocol, supporter: UriProtocolSupporter, force?: boolean): void
 	/**
 	 * Unregister the supported associated with `protocol`. Nothing happens if the `protocol` isn't supported.
 	 */
@@ -64,10 +60,7 @@ export interface FileService extends UriProtocolSupporter {
 }
 
 export namespace FileService {
-	export function create(
-		externals: Externals,
-		cacheRoot: RootUriString,
-	): FileService {
+	export function create(externals: Externals, cacheRoot: RootUriString): FileService {
 		const virtualUrisRoot = fileUtil.ensureEndingSlash(
 			new Uri('virtual-uris/', cacheRoot).toString(),
 		)
@@ -87,15 +80,9 @@ export class FileServiceImpl implements FileService {
 		private readonly virtualUrisRoot?: RootUriString,
 	) {}
 
-	register(
-		protocol: Protocol,
-		supporter: UriProtocolSupporter,
-		force = false,
-	): void {
+	register(protocol: Protocol, supporter: UriProtocolSupporter, force = false): void {
 		if (!force && this.supporters.has(protocol)) {
-			throw new Error(
-				`The protocol “${protocol}” is already associated with another supporter.`,
-			)
+			throw new Error(`The protocol “${protocol}” is already associated with another supporter.`)
 		}
 		this.supporters.set(protocol, supporter)
 	}
@@ -155,12 +142,9 @@ export class FileServiceImpl implements FileService {
 		try {
 			let mappedUri = this.map.getKey(virtualUri)
 			if (mappedUri === undefined) {
-				mappedUri = `${this.virtualUrisRoot}${await this.externals.crypto
-					.getSha1(virtualUri)}/${
-					fileUtil.basename(
-						virtualUri,
-					)
-				}`
+				mappedUri = `${this.virtualUrisRoot}${await this.externals.crypto.getSha1(
+					virtualUri,
+				)}/${fileUtil.basename(virtualUri)}`
 
 				// Delete old mapped file if it exists. This makes sure the
 				// readonly permission on the file is not removed by it being
@@ -233,10 +217,7 @@ export class FileUriSupporter implements UriProtocolSupporter {
 
 		for (let { uri } of dependencies) {
 			try {
-				if (
-					fileUtil.isFileUri(uri)
-					&& (await externals.fs.stat(uri)).isDirectory()
-				) {
+				if (fileUtil.isFileUri(uri) && (await externals.fs.stat(uri)).isDirectory()) {
 					uri = fileUtil.ensureEndingSlash(uri)
 					roots.push(uri as RootUriString)
 					files.set(uri, await externals.fs.getAllFiles(uri))
@@ -260,12 +241,7 @@ export class FileUriSupporter implements UriProtocolSupporter {
 
 export class ArchiveUriSupporter implements UriProtocolSupporter {
 	public static readonly Protocol = 'archive:'
-	private static readonly SupportedArchiveExtnames = [
-		'.tar',
-		'.tar.bz2',
-		'.tar.gz',
-		'.zip',
-	]
+	private static readonly SupportedArchiveExtnames = ['.tar', '.tar.bz2', '.tar.gz', '.zip']
 
 	readonly protocol = ArchiveUriSupporter.Protocol
 
@@ -278,50 +254,35 @@ export class ArchiveUriSupporter implements UriProtocolSupporter {
 	) {}
 
 	async hash(uri: string): Promise<string> {
-		const { archiveName, pathInArchive } = ArchiveUriSupporter.decodeUri(
-			new Uri(uri),
-		)
+		const { archiveName, pathInArchive } = ArchiveUriSupporter.decodeUri(new Uri(uri))
 		if (!pathInArchive) {
 			// Hash the archive itself.
 			return hashFile(this.externals, archiveName)
 		} else {
 			// Hash the corresponding file.
-			return this.externals.crypto.getSha1(
-				this.getDataInArchive(archiveName, pathInArchive),
-			)
+			return this.externals.crypto.getSha1(this.getDataInArchive(archiveName, pathInArchive))
 		}
 	}
 
 	async readFile(uri: string): Promise<Uint8Array> {
-		const { archiveName, pathInArchive } = ArchiveUriSupporter.decodeUri(
-			new Uri(uri),
-		)
+		const { archiveName, pathInArchive } = ArchiveUriSupporter.decodeUri(new Uri(uri))
 		return this.getDataInArchive(archiveName, pathInArchive)
 	}
 
 	/**
 	 * @throws
 	 */
-	private getDataInArchive(
-		archiveName: string,
-		pathInArchive: string,
-	): Uint8Array {
+	private getDataInArchive(archiveName: string, pathInArchive: string): Uint8Array {
 		const entries = this.entries.get(archiveName)
 		if (!entries) {
-			throw new Error(
-				`Archive “${archiveName}” has not been loaded into the memory`,
-			)
+			throw new Error(`Archive “${archiveName}” has not been loaded into the memory`)
 		}
 		const entry = entries.get(pathInArchive)
 		if (!entry) {
-			throw new Error(
-				`Path “${pathInArchive}” does not exist in archive “${archiveName}”`,
-			)
+			throw new Error(`Path “${pathInArchive}” does not exist in archive “${archiveName}”`)
 		}
 		if (entry.type !== 'file') {
-			throw new Error(
-				`Path “${pathInArchive}” in archive “${archiveName}” is not a file`,
-			)
+			throw new Error(`Path “${pathInArchive}” in archive “${archiveName}” is not a file`)
 		}
 		return entry.data
 	}
@@ -349,23 +310,15 @@ export class ArchiveUriSupporter implements UriProtocolSupporter {
 	/**
 	 * @throws When `uri` has the wrong protocol or hostname.
 	 */
-	private static decodeUri(uri: Uri): {
-		archiveName: string
-		pathInArchive: string
-	} {
+	private static decodeUri(uri: Uri): { archiveName: string; pathInArchive: string } {
 		if (uri.protocol !== ArchiveUriSupporter.Protocol) {
-			throw new Error(
-				`Expected protocol “${ArchiveUriSupporter.Protocol}” in “${uri}”`,
-			)
+			throw new Error(`Expected protocol “${ArchiveUriSupporter.Protocol}” in “${uri}”`)
 		}
 		const path = uri.pathname
 		if (!path) {
 			throw new Error(`Missing path in archive uri “${uri.toString()}”`)
 		}
-		return {
-			archiveName: uri.host,
-			pathInArchive: path.charAt(0) === '/' ? path.slice(1) : path,
-		}
+		return { archiveName: uri.host, pathInArchive: path.charAt(0) === '/' ? path.slice(1) : path }
 	}
 
 	static async create(
@@ -384,29 +337,17 @@ export class ArchiveUriSupporter implements UriProtocolSupporter {
 				) {
 					const archiveName = fileUtil.basename(uri)
 					if (entries.has(archiveName)) {
-						throw new Error(
-							`A different URI with ${archiveName} already exists`,
-						)
+						throw new Error(`A different URI with ${archiveName} already exists`)
 					}
 
 					const files = await externals.archive.decompressBall(
 						await externals.fs.readFile(uri),
-						{
-							stripLevel: typeof info?.startDepth === 'number'
-								? info.startDepth
-								: 0,
-						},
+						{ stripLevel: typeof info?.startDepth === 'number' ? info.startDepth : 0 },
 					)
-					entries.set(
-						archiveName,
-						new Map(files.map((f) => [f.path.replace(/\\/g, '/'), f])),
-					)
+					entries.set(archiveName, new Map(files.map((f) => [f.path.replace(/\\/g, '/'), f])))
 				}
 			} catch (e) {
-				logger.error(
-					`[SpyglassUriSupporter#create] Bad dependency “${uri}”`,
-					e,
-				)
+				logger.error(`[SpyglassUriSupporter#create] Bad dependency “${uri}”`, e)
 			}
 		}
 

--- a/packages/core/src/service/FileService.ts
+++ b/packages/core/src/service/FileService.ts
@@ -343,9 +343,7 @@ export class ArchiveUriSupporter implements UriProtocolSupporter {
 	private static getUri(archiveName: string): RootUriString
 	private static getUri(archiveName: string, pathInArchive: string): string
 	private static getUri(archiveName: string, pathInArchive = '') {
-		return `${ArchiveUriSupporter.Protocol}//${archiveName}/${
-			pathInArchive.replace(/\\/g, '/')
-		}`
+		return `${ArchiveUriSupporter.Protocol}//${archiveName}/${pathInArchive.replace(/\\/g, '/')}`
 	}
 
 	/**
@@ -381,9 +379,7 @@ export class ArchiveUriSupporter implements UriProtocolSupporter {
 			try {
 				if (
 					uri.startsWith('file:')
-					&& ArchiveUriSupporter.SupportedArchiveExtnames.some((ext) =>
-						uri.endsWith(ext)
-					)
+					&& ArchiveUriSupporter.SupportedArchiveExtnames.some((ext) => uri.endsWith(ext))
 					&& (await externals.fs.stat(uri)).isFile()
 				) {
 					const archiveName = fileUtil.basename(uri)

--- a/packages/core/src/service/Hover.ts
+++ b/packages/core/src/service/Hover.ts
@@ -8,9 +8,6 @@ export interface Hover {
 export namespace Hover {
 	/* istanbul ignore next */
 	export function create(range: RangeLike, markdown: string): Hover {
-		return {
-			range: Range.get(range),
-			markdown,
-		}
+		return { range: Range.get(range), markdown }
 	}
 }

--- a/packages/core/src/service/MetaRegistry.ts
+++ b/packages/core/src/service/MetaRegistry.ts
@@ -200,8 +200,8 @@ export class MetaRegistry {
 	): boolean {
 		const language = this.#languages.get(languageID)
 		return (
-			!triggerCharacter ||
-			!!language?.triggerCharacters?.includes(triggerCharacter)
+			!triggerCharacter
+			|| !!language?.triggerCharacters?.includes(triggerCharacter)
 		)
 	}
 	public getCompleterForLanguageID(languageID: string): Completer<any> {

--- a/packages/core/src/service/MetaRegistry.ts
+++ b/packages/core/src/service/MetaRegistry.ts
@@ -10,24 +10,13 @@ import type {
 	Completer,
 	InlayHintProvider,
 } from '../processor/index.js'
-import {
-	binder,
-	checker,
-	colorizer,
-	completer,
-	formatter,
-	linter,
-} from '../processor/index.js'
+import { binder, checker, colorizer, completer, formatter, linter } from '../processor/index.js'
 import type { Linter } from '../processor/linter/Linter.js'
 import type { SignatureHelpProvider } from '../processor/SignatureHelpProvider.js'
 import type { DependencyKey, DependencyProvider } from './Dependency.js'
 import type { FileExtension } from './fileUtil.js'
 import type { SymbolRegistrar } from './SymbolRegistrar.js'
-import type {
-	UriBinder,
-	UriSorter,
-	UriSorterRegistration,
-} from './UriProcessor.js'
+import type { UriBinder, UriSorter, UriSorterRegistration } from './UriProcessor.js'
 
 export interface LanguageOptions {
 	/**

--- a/packages/core/src/service/MetaRegistry.ts
+++ b/packages/core/src/service/MetaRegistry.ts
@@ -29,11 +29,7 @@ export interface LanguageOptions {
 }
 
 interface LinterRegistration {
-	configValidator: (
-		ruleName: string,
-		ruleValue: unknown,
-		logger: Logger,
-	) => unknown
+	configValidator: (ruleName: string, ruleValue: unknown, logger: Logger) => unknown
 	linter: Linter<AstNode>
 	nodePredicate: (node: AstNode) => unknown
 }
@@ -112,9 +108,7 @@ export class MetaRegistry {
 	 * An array of characters that trigger a completion request.
 	 */
 	public getTriggerCharacters(): string[] {
-		return Array.from(this.#languages.values()).flatMap(
-			(v) => v.triggerCharacters ?? [],
-		)
+		return Array.from(this.#languages.values()).flatMap((v) => v.triggerCharacters ?? [])
 	}
 
 	/**
@@ -136,10 +130,7 @@ export class MetaRegistry {
 	public getBinder<N extends AstNode>(type: N['type']): Binder<N> {
 		return this.#binders.get(type) ?? binder.fallback
 	}
-	public registerBinder<N extends AstNode>(
-		type: N['type'],
-		binder: Binder<N>,
-	): void {
+	public registerBinder<N extends AstNode>(type: N['type'], binder: Binder<N>): void {
 		this.#binders.set(type, binder)
 	}
 
@@ -149,10 +140,7 @@ export class MetaRegistry {
 	public getChecker<N extends AstNode>(type: N['type']): Checker<N> {
 		return this.#checkers.get(type) ?? checker.fallback
 	}
-	public registerChecker<N extends AstNode>(
-		type: N['type'],
-		checker: Checker<N>,
-	): void {
+	public registerChecker<N extends AstNode>(type: N['type'], checker: Checker<N>): void {
 		this.#checkers.set(type, checker)
 	}
 
@@ -162,10 +150,7 @@ export class MetaRegistry {
 	public getColorizer<N extends AstNode>(type: N['type']): Colorizer<N> {
 		return this.#colorizers.get(type) ?? colorizer.fallback
 	}
-	public registerColorizer<N extends AstNode>(
-		type: N['type'],
-		colorizer: Colorizer<N>,
-	): void {
+	public registerColorizer<N extends AstNode>(type: N['type'], colorizer: Colorizer<N>): void {
 		this.#colorizers.set(type, colorizer)
 	}
 
@@ -175,37 +160,23 @@ export class MetaRegistry {
 	public getCompleter<N extends AstNode>(type: N['type']): Completer<N> {
 		return this.#completers.get(type) ?? completer.fallback
 	}
-	public registerCompleter<N extends AstNode>(
-		type: N['type'],
-		completer: Completer<N>,
-	): void
+	public registerCompleter<N extends AstNode>(type: N['type'], completer: Completer<N>): void
 	public registerCompleter(type: string, completer: Completer<any>): void
 	public registerCompleter(type: string, completer: Completer<any>): void {
 		this.#completers.set(type, completer)
 	}
-	public shouldComplete(
-		languageID: string,
-		triggerCharacter?: string,
-	): boolean {
+	public shouldComplete(languageID: string, triggerCharacter?: string): boolean {
 		const language = this.#languages.get(languageID)
-		return (
-			!triggerCharacter
-			|| !!language?.triggerCharacters?.includes(triggerCharacter)
-		)
+		return (!triggerCharacter || !!language?.triggerCharacters?.includes(triggerCharacter))
 	}
 	public getCompleterForLanguageID(languageID: string): Completer<any> {
 		return this.#languages.get(languageID)?.completer ?? completer.fallback
 	}
 
-	public getDependencyProvider(
-		key: DependencyKey,
-	): DependencyProvider | undefined {
+	public getDependencyProvider(key: DependencyKey): DependencyProvider | undefined {
 		return this.#dependencyProviders.get(key)
 	}
-	public registerDependencyProvider(
-		key: DependencyKey,
-		provider: DependencyProvider,
-	): void {
+	public registerDependencyProvider(key: DependencyKey, provider: DependencyProvider): void {
 		this.#dependencyProviders.set(key, provider)
 	}
 
@@ -215,10 +186,7 @@ export class MetaRegistry {
 	public getFormatter<N extends AstNode>(type: N['type']): Formatter<N> {
 		return this.#formatters.get(type) ?? formatter.fallback
 	}
-	public registerFormatter<N extends AstNode>(
-		type: N['type'],
-		formatter: Formatter<N>,
-	): void {
+	public registerFormatter<N extends AstNode>(type: N['type'], formatter: Formatter<N>): void {
 		this.#formatters.set(type, formatter)
 	}
 
@@ -230,13 +198,8 @@ export class MetaRegistry {
 	}
 
 	public getLinter(ruleName: string): LinterRegistration {
-		return (
-			this.#linters.get(ruleName) ?? {
-				configValidator: () => false,
-				linter: linter.noop,
-				nodePredicate: () => false,
-			}
-		)
+		return (this.#linters.get(ruleName)
+			?? { configValidator: () => false, linter: linter.noop, nodePredicate: () => false })
 	}
 	public registerLinter(ruleName: string, options: LinterRegistration): void {
 		this.#linters.set(ruleName, options)
@@ -259,21 +222,12 @@ export class MetaRegistry {
 		}
 		return ans
 	}
-	public getParserLazily<N extends AstNode>(
-		id: N['type'],
-	): Lazy.UnresolvedLazy<Parser<N>>
-	public getParserLazily<N extends AstNode>(
-		id: string,
-	): Lazy.UnresolvedLazy<Parser<N>>
-	public getParserLazily<N extends AstNode>(
-		id: string,
-	): Lazy.UnresolvedLazy<Parser<N>> {
+	public getParserLazily<N extends AstNode>(id: N['type']): Lazy.UnresolvedLazy<Parser<N>>
+	public getParserLazily<N extends AstNode>(id: string): Lazy.UnresolvedLazy<Parser<N>>
+	public getParserLazily<N extends AstNode>(id: string): Lazy.UnresolvedLazy<Parser<N>> {
 		return Lazy.create(() => this.getParser(id))
 	}
-	public registerParser<N extends AstNode>(
-		id: N['type'],
-		parser: Parser<N>,
-	): void
+	public registerParser<N extends AstNode>(id: N['type'], parser: Parser<N>): void
 	public registerParser(id: string, parser: Parser): void
 	public registerParser(id: string, parser: Parser): void {
 		this.#parsers.set(id, parser)
@@ -282,41 +236,28 @@ export class MetaRegistry {
 	 * @returns The corresponding `Parser` for the language ID.
 	 * @throws If there's no such language in the registry.
 	 */
-	public getParserForLanguageId<N extends AstNode>(
-		languageID: string,
-	): Parser<N> {
+	public getParserForLanguageId<N extends AstNode>(languageID: string): Parser<N> {
 		if (this.#languages.has(languageID)) {
 			return this.#languages.get(languageID)!.parser as Parser<N>
 		}
-		throw new Error(
-			`There is no parser registered for language ID '${languageID}'`,
-		)
+		throw new Error(`There is no parser registered for language ID '${languageID}'`)
 	}
 
-	public registerSignatureHelpProvider(
-		provider: SignatureHelpProvider<any>,
-	): void {
+	public registerSignatureHelpProvider(provider: SignatureHelpProvider<any>): void {
 		this.#signatureHelpProviders.add(provider)
 	}
 	public get signatureHelpProviders(): Set<SignatureHelpProvider<any>> {
 		return this.#signatureHelpProviders
 	}
 
-	public registerSymbolRegistrar(
-		id: string,
-		registrar: SymbolRegistrarRegistration,
-	): void {
+	public registerSymbolRegistrar(id: string, registrar: SymbolRegistrarRegistration): void {
 		this.#symbolRegistrars.set(id, registrar)
 	}
 	public get symbolRegistrars(): Map<string, SymbolRegistrarRegistration> {
 		return this.#symbolRegistrars
 	}
 
-	public registerCustom<T>(
-		group: string,
-		id: string,
-		object: T,
-	): void {
+	public registerCustom<T>(group: string, id: string, object: T): void {
 		let groupRegistry = this.#custom.get(group)
 		if (!groupRegistry) {
 			groupRegistry = new Map()

--- a/packages/core/src/service/Profiler.ts
+++ b/packages/core/src/service/Profiler.ts
@@ -77,19 +77,12 @@ class TopNImpl implements Profiler {
 			} / ${this.#maxTime} ms`,
 		)
 		this.logger.info(
-			`[Profiler: ${this.id}] Top ${
-				Math.min(
-					this.n,
-					this.#topTasks.length,
-				)
-			} task(s):`,
+			`[Profiler: ${this.id}] Top ${Math.min(this.n, this.#topTasks.length)} task(s):`,
 		)
 		for (const [name, time] of this.#topTasks) {
 			this.logger.info(
 				`[Profiler: ${this.id}] ${name}${
-					' '.repeat(
-						longestTaskNameLength - name.length,
-					)
+					' '.repeat(longestTaskNameLength - name.length)
 				} - ${time} ms (${(time / totalDuration) * 100}%)`,
 			)
 		}
@@ -117,10 +110,7 @@ class TotalImpl implements Profiler {
 		const duration = time - this.#lastTime
 		this.#lastTime = time
 		this.#tasks.push([name, duration])
-		this.#longestTaskNameLength = Math.max(
-			this.#longestTaskNameLength,
-			name.length,
-		)
+		this.#longestTaskNameLength = Math.max(this.#longestTaskNameLength, name.length)
 		this.logger.info(`[Profiler: ${this.id}] Done: ${name} in ${duration} ms`)
 		return this
 	}
@@ -128,17 +118,12 @@ class TotalImpl implements Profiler {
 	finalize(): void {
 		this.#finalized = true
 		this.#tasks.push([TotalTaskName, this.#lastTime - this.#startTime])
-		this.#longestTaskNameLength = Math.max(
-			this.#longestTaskNameLength,
-			TotalTaskName.length,
-		)
+		this.#longestTaskNameLength = Math.max(this.#longestTaskNameLength, TotalTaskName.length)
 		this.logger.info(`[Profiler: ${this.id}] == Summary ==`)
 		for (const [name, time] of this.#tasks) {
 			this.logger.info(
 				`[Profiler: ${this.id}] ${name}${
-					' '.repeat(
-						this.#longestTaskNameLength - name.length,
-					)
+					' '.repeat(this.#longestTaskNameLength - name.length)
 				} - ${time} ms`,
 			)
 		}

--- a/packages/core/src/service/Project.ts
+++ b/packages/core/src/service/Project.ts
@@ -1,11 +1,6 @@
 import type { TextDocumentContentChangeEvent } from 'vscode-languageserver-textdocument'
 import { TextDocument } from 'vscode-languageserver-textdocument'
-import type {
-	ExternalEventEmitter,
-	Externals,
-	FsWatcher,
-	IntervalId,
-} from '../common/index.js'
+import type { ExternalEventEmitter, Externals, FsWatcher, IntervalId } from '../common/index.js'
 import {
 	bufferToString,
 	Logger,
@@ -34,11 +29,7 @@ import type { Dependency } from './Dependency.js'
 import { DependencyKey } from './Dependency.js'
 import { Downloader } from './Downloader.js'
 import { LinterErrorReporter } from './ErrorReporter.js'
-import {
-	ArchiveUriSupporter,
-	FileService,
-	FileUriSupporter,
-} from './FileService.js'
+import { ArchiveUriSupporter, FileService, FileUriSupporter } from './FileService.js'
 import type { RootUriString } from './fileUtil.js'
 import { fileUtil } from './fileUtil.js'
 import { MetaRegistry } from './MetaRegistry.js'
@@ -384,9 +375,7 @@ export class Project implements ExternalEventEmitter {
 			// 	return
 			// }
 			this.emit('documentErrored', {
-				errors: FileNode.getErrors(node).map((e) =>
-					LanguageError.withPosRange(e, doc)
-				),
+				errors: FileNode.getErrors(node).map((e) => LanguageError.withPosRange(e, doc)),
 				uri: doc.uri,
 				version: doc.version,
 			})
@@ -448,9 +437,7 @@ export class Project implements ExternalEventEmitter {
 			results.forEach(async (r, i) => {
 				if (r.status === 'rejected') {
 					this.logger.error(
-						`[Project] [callInitializers] [${i}] “${
-							this.#initializers[i].name
-						}”`,
+						`[Project] [callInitializers] [${i}] “${this.#initializers[i].name}”`,
 						r.reason,
 					)
 				} else if (r.value) {
@@ -574,8 +561,7 @@ export class Project implements ExternalEventEmitter {
 			for (
 				const [id, { checksum, registrar }] of this.meta.symbolRegistrars
 			) {
-				const cacheChecksum =
-					this.cacheService.checksums.symbolRegistrars[id]
+				const cacheChecksum = this.cacheService.checksums.symbolRegistrars[id]
 				if (cacheChecksum === undefined || checksum !== cacheChecksum) {
 					this.symbols.clear({ contributor: `symbol_registrar/${id}` })
 					this.symbols.contributeAs(`symbol_registrar/${id}`, () => {

--- a/packages/core/src/service/Project.ts
+++ b/packages/core/src/service/Project.ts
@@ -240,8 +240,8 @@ export class Project implements ExternalEventEmitter {
 		// Identify roots indicated by `pack.mcmeta`.
 		for (const file of this.getTrackedFiles()) {
 			if (
-				file.endsWith(Project.RootSuffix) &&
-				rawRoots.some((r) => file.startsWith(r))
+				file.endsWith(Project.RootSuffix)
+				&& rawRoots.some((r) => file.startsWith(r))
 			) {
 				ans.add(
 					file.slice(0, 1 - Project.RootSuffix.length) as RootUriString,
@@ -350,8 +350,8 @@ export class Project implements ExternalEventEmitter {
 
 		this.cacheService = new CacheService(cacheRoot, this)
 		this.#configService = new ConfigService(this, defaultConfig)
-		this.downloader = downloader ??
-			new Downloader(cacheRoot, externals, logger)
+		this.downloader = downloader
+			?? new Downloader(cacheRoot, externals, logger)
 		this.symbols = new SymbolUtil({}, externals.event.EventEmitter)
 
 		this.#ctx = {}
@@ -901,8 +901,8 @@ export class Project implements ExternalEventEmitter {
 	async ensureBindingStarted(uri: string): Promise<void> {
 		uri = this.normalizeUri(uri)
 		if (
-			this.#symbolUpToDateUris.has(uri) ||
-			this.#bindingInProgressUris.has(uri)
+			this.#symbolUpToDateUris.has(uri)
+			|| this.#bindingInProgressUris.has(uri)
 		) {
 			return
 		}
@@ -1043,17 +1043,17 @@ export class Project implements ExternalEventEmitter {
 
 	private shouldRemove(uri: string): boolean {
 		return (
-			!this.#clientManagedUris.has(uri) &&
-			!this.#dependencyFiles.has(uri) &&
-			!this.#watchedFiles.has(uri)
+			!this.#clientManagedUris.has(uri)
+			&& !this.#dependencyFiles.has(uri)
+			&& !this.#watchedFiles.has(uri)
 		)
 	}
 
 	private isOnlyWatched(uri: string): boolean {
 		return (
-			this.#watchedFiles.has(uri) &&
-			!this.#clientManagedUris.has(uri) &&
-			!this.#dependencyFiles.has(uri)
+			this.#watchedFiles.has(uri)
+			&& !this.#clientManagedUris.has(uri)
+			&& !this.#dependencyFiles.has(uri)
 		)
 	}
 }

--- a/packages/core/src/service/Service.ts
+++ b/packages/core/src/service/Service.ts
@@ -35,21 +35,13 @@ export class Service {
 	readonly profilers: ProfilerFactory
 	readonly project: Project
 
-	constructor({
-		isDebugging = false,
-		logger,
-		profilers = ProfilerFactory.noop(),
-		project,
-	}: Options) {
+	constructor(
+		{ isDebugging = false, logger, profilers = ProfilerFactory.noop(), project }: Options,
+	) {
 		this.isDebugging = isDebugging
 		this.logger = logger
 		this.profilers = profilers
-		this.project = new Project({
-			isDebugging,
-			logger,
-			profilers,
-			...project,
-		})
+		this.project = new Project({ isDebugging, logger, profilers, ...project })
 	}
 
 	private debug(message: string): void {
@@ -58,23 +50,13 @@ export class Service {
 		}
 	}
 
-	colorize(
-		node: FileNode<AstNode>,
-		doc: TextDocument,
-		range?: Range,
-	): readonly ColorToken[] {
+	colorize(node: FileNode<AstNode>, doc: TextDocument, range?: Range): readonly ColorToken[] {
 		try {
 			this.debug(`Colorizing '${doc.uri}' # ${doc.version}`)
 			const colorizer = this.project.meta.getColorizer(node.type)
-			return colorizer(
-				node,
-				ColorizerContext.create(this.project, { doc, range }),
-			)
+			return colorizer(node, ColorizerContext.create(this.project, { doc, range }))
 		} catch (e) {
-			this.logger.error(
-				`[Service] [colorize] Failed for “${doc.uri}” #${doc.version}`,
-				e,
-			)
+			this.logger.error(`[Service] [colorize] Failed for “${doc.uri}” #${doc.version}`, e)
 		}
 		return []
 	}
@@ -89,20 +71,13 @@ export class Service {
 				(node) => node.color,
 				(node) =>
 					ans.push({
-						color: Array.isArray(node.color)
-							? node.color
-							: node.color!.value,
-						range: Array.isArray(node.color)
-							? node.range
-							: node.color!.range ?? node.range,
+						color: Array.isArray(node.color) ? node.color : node.color!.value,
+						range: Array.isArray(node.color) ? node.range : node.color!.range ?? node.range,
 					}),
 			)
 			return ans
 		} catch (e) {
-			this.logger.error(
-				`[Service] [getColorInfo] Failed for “${doc.uri}” #${doc.version}`,
-				e,
-			)
+			this.logger.error(`[Service] [getColorInfo] Failed for “${doc.uri}” #${doc.version}`, e)
 		}
 		return []
 	}
@@ -119,10 +94,7 @@ export class Service {
 					Range.toString(range)
 				}`,
 			)
-			let node = AstNode.findDeepestChild({
-				node: file,
-				needle: range.start,
-			})
+			let node = AstNode.findDeepestChild({ node: file, needle: range.start })
 			while (node) {
 				const nodeColor = node.color
 				if (nodeColor && !Array.isArray(nodeColor)) {
@@ -142,35 +114,18 @@ export class Service {
 		return []
 	}
 
-	complete(
-		node: FileNode<AstNode>,
-		doc: TextDocument,
-		offset: number,
-		triggerCharacter?: string,
-	) {
+	complete(node: FileNode<AstNode>, doc: TextDocument, offset: number, triggerCharacter?: string) {
 		try {
-			this.debug(
-				`Getting completion for '${doc.uri}' # ${doc.version} @ ${offset}`,
-			)
-			const shouldComplete = this.project.meta.shouldComplete(
-				doc.languageId,
-				triggerCharacter,
-			)
+			this.debug(`Getting completion for '${doc.uri}' # ${doc.version} @ ${offset}`)
+			const shouldComplete = this.project.meta.shouldComplete(doc.languageId, triggerCharacter)
 			if (shouldComplete) {
 				return completer.file(
 					node,
-					CompleterContext.create(this.project, {
-						doc,
-						offset,
-						triggerCharacter,
-					}),
+					CompleterContext.create(this.project, { doc, offset, triggerCharacter }),
 				)
 			}
 		} catch (e) {
-			this.logger.error(
-				`[Service] [complete] Failed for “${doc.uri}” #${doc.version}`,
-				e,
-			)
+			this.logger.error(`[Service] [complete] Failed for “${doc.uri}” #${doc.version}`, e)
 		}
 		return []
 	}
@@ -189,46 +144,28 @@ export class Service {
 		// Punctuation should not be treated differently from any other characters, per example:
 		// Hata &ack Sub
 		// ——  Skylinerw, 2022 https://discord.com/channels/154777837382008833/734106483104415856/955521761351454741
-		return [...initialism]
-			.map((c, i) => `${c.toUpperCase()}${secrets[i % secrets.length]}`)
-			.join(' ')
+		return [...initialism].map((c, i) => `${c.toUpperCase()}${secrets[i % secrets.length]}`).join(
+			' ',
+		)
 	}
 
-	format(
-		node: FileNode<AstNode>,
-		doc: TextDocument,
-		tabSize: number,
-		insertSpaces: boolean,
-	) {
+	format(node: FileNode<AstNode>, doc: TextDocument, tabSize: number, insertSpaces: boolean) {
 		try {
 			this.debug(`Formatting '${doc.uri}' # ${doc.version}`)
 			const formatter = this.project.meta.getFormatter(node.type)
 			return formatter(
 				node,
-				FormatterContext.create(this.project, {
-					doc,
-					tabSize,
-					insertSpaces,
-				}),
+				FormatterContext.create(this.project, { doc, tabSize, insertSpaces }),
 			)
 		} catch (e) {
-			this.logger.error(
-				`[Service] [format] Failed for “${doc.uri}” #${doc.version}`,
-				e,
-			)
+			this.logger.error(`[Service] [format] Failed for “${doc.uri}” #${doc.version}`, e)
 			throw e
 		}
 	}
 
-	getHover(
-		file: FileNode<AstNode>,
-		doc: TextDocument,
-		offset: number,
-	): Hover | undefined {
+	getHover(file: FileNode<AstNode>, doc: TextDocument, offset: number): Hover | undefined {
 		try {
-			this.debug(
-				`Getting hover for '${doc.uri}' # ${doc.version} @ ${offset}`,
-			)
+			this.debug(`Getting hover for '${doc.uri}' # ${doc.version} @ ${offset}`)
 			let node = AstNode.findDeepestChild({ node: file, needle: offset })
 			while (node) {
 				const symbol = this.project.symbols.resolveAlias(node.symbol)
@@ -236,8 +173,7 @@ export class Service {
 					const hover =
 						`\`\`\`typescript\n(${symbol.category}${
 							symbol.subcategory ? `/${symbol.subcategory}` : ''
-						}) ${symbol.identifier}\n\`\`\``
-						+ (symbol.desc ? `\n******\n${symbol.desc}` : '')
+						}) ${symbol.identifier}\n\`\`\`` + (symbol.desc ? `\n******\n${symbol.desc}` : '')
 					return Hover.create(node.range, hover)
 				}
 				if (node.hover) {
@@ -246,19 +182,12 @@ export class Service {
 				node = node.parent
 			}
 		} catch (e) {
-			this.logger.error(
-				`[Service] [getHover] Failed for “${doc.uri}” #${doc.version}`,
-				e,
-			)
+			this.logger.error(`[Service] [getHover] Failed for “${doc.uri}” #${doc.version}`, e)
 		}
 		return undefined
 	}
 
-	getInlayHints(
-		node: FileNode<AstNode>,
-		doc: TextDocument,
-		range?: Range,
-	): InlayHint[] {
+	getInlayHints(node: FileNode<AstNode>, doc: TextDocument, range?: Range): InlayHint[] {
 		try {
 			// TODO: `range` argument is not used.
 			this.debug(`Getting inlay hints for '${doc.uri}' # ${doc.version}`)
@@ -269,10 +198,7 @@ export class Service {
 			}
 			return ans
 		} catch (e) {
-			this.logger.error(
-				`[Service] [getInlayHints] Failed for “${doc.uri}” #${doc.version}`,
-				e,
-			)
+			this.logger.error(`[Service] [getInlayHints] Failed for “${doc.uri}” #${doc.version}`, e)
 		}
 		return []
 	}
@@ -283,13 +209,8 @@ export class Service {
 		offset: number,
 	): SignatureHelp | undefined {
 		try {
-			this.debug(
-				`Getting signature help for '${doc.uri}' # ${doc.version} @ ${offset}`,
-			)
-			const ctx = SignatureHelpProviderContext.create(this.project, {
-				doc,
-				offset,
-			})
+			this.debug(`Getting signature help for '${doc.uri}' # ${doc.version} @ ${offset}`)
+			const ctx = SignatureHelpProviderContext.create(this.project, { doc, offset })
 			for (const provider of this.project.meta.signatureHelpProviders) {
 				const result = provider(node, ctx)
 				if (result) {
@@ -345,10 +266,7 @@ export class Service {
 							locations.push({ ...loc, uri: mappedUri })
 						}
 					}
-					return SymbolLocations.create(
-						node.range,
-						locations.length ? locations : undefined,
-					)
+					return SymbolLocations.create(node.range, locations.length ? locations : undefined)
 				}
 				node = node.parent
 			}

--- a/packages/core/src/service/Service.ts
+++ b/packages/core/src/service/Service.ts
@@ -246,8 +246,8 @@ export class Service {
 					const hover =
 						`\`\`\`typescript\n(${symbol.category}${
 							symbol.subcategory ? `/${symbol.subcategory}` : ''
-						}) ${symbol.identifier}\n\`\`\`` +
-						(symbol.desc ? `\n******\n${symbol.desc}` : '')
+						}) ${symbol.identifier}\n\`\`\``
+						+ (symbol.desc ? `\n******\n${symbol.desc}` : '')
 					return Hover.create(node.range, hover)
 				}
 				if (node.hover) {

--- a/packages/core/src/service/Service.ts
+++ b/packages/core/src/service/Service.ts
@@ -2,18 +2,8 @@ import type { TextDocument } from 'vscode-languageserver-textdocument'
 import type { Logger } from '../common/index.js'
 import type { FileNode } from '../node/index.js'
 import { AstNode } from '../node/index.js'
-import type {
-	Color,
-	ColorInfo,
-	ColorToken,
-	InlayHint,
-	SignatureHelp,
-} from '../processor/index.js'
-import {
-	ColorPresentation,
-	completer,
-	traversePreOrder,
-} from '../processor/index.js'
+import type { Color, ColorInfo, ColorToken, InlayHint, SignatureHelp } from '../processor/index.js'
+import { ColorPresentation, completer, traversePreOrder } from '../processor/index.js'
 import { Range } from '../source/index.js'
 import type { SymbolLocation, SymbolUsageType } from '../symbol/index.js'
 import { SymbolUsageTypes } from '../symbol/index.js'

--- a/packages/core/src/service/SymbolLocations.ts
+++ b/packages/core/src/service/SymbolLocations.ts
@@ -18,9 +18,6 @@ export namespace SymbolLocations {
 		range: RangeLike,
 		locations: SymbolLocation[] | undefined,
 	): SymbolLocations {
-		return {
-			range: Range.get(range),
-			locations,
-		}
+		return { range: Range.get(range), locations }
 	}
 }

--- a/packages/core/src/service/SymbolRegistrar.ts
+++ b/packages/core/src/service/SymbolRegistrar.ts
@@ -1,9 +1,5 @@
 import type { SymbolUtil } from '../symbol/index.js'
 
-export type SymbolRegistrar = (
-	this: void,
-	symbols: SymbolUtil,
-	ctx: SymbolRegistrarContext,
-) => void
+export type SymbolRegistrar = (this: void, symbols: SymbolUtil, ctx: SymbolRegistrarContext) => void
 
 export interface SymbolRegistrarContext {}

--- a/packages/core/src/service/UriProcessor.ts
+++ b/packages/core/src/service/UriProcessor.ts
@@ -2,10 +2,5 @@ import type { UriBinderContext } from './Context.js'
 
 export type UriBinder = (uris: readonly string[], ctx: UriBinderContext) => void
 
-export type UriSorterRegistration = (
-	this: void,
-	a: string,
-	b: string,
-	next: UriSorter,
-) => number
+export type UriSorterRegistration = (this: void, a: string, b: string, next: UriSorter) => number
 export type UriSorter = (this: void, a: string, b: string) => number

--- a/packages/core/src/service/fileUtil.ts
+++ b/packages/core/src/service/fileUtil.ts
@@ -29,8 +29,8 @@ export namespace fileUtil {
 			.filter((v) => !!v)
 
 		if (
-			baseComponents.length > targetComponents.length ||
-			baseComponents.some((bc, i) =>
+			baseComponents.length > targetComponents.length
+			|| baseComponents.some((bc, i) =>
 				decodeURIComponent(bc) !== decodeURIComponent(targetComponents[i])
 			)
 		) {
@@ -96,8 +96,8 @@ export namespace fileUtil {
 
 	export function join(fromUri: string, toUri: string): string {
 		return (
-			ensureEndingSlash(fromUri) +
-			(toUri.startsWith('/') ? toUri.slice(1) : toUri)
+			ensureEndingSlash(fromUri)
+			+ (toUri.startsWith('/') ? toUri.slice(1) : toUri)
 		)
 	}
 

--- a/packages/core/src/service/fileUtil.ts
+++ b/packages/core/src/service/fileUtil.ts
@@ -11,10 +11,7 @@ export namespace fileUtil {
 	 *
 	 * @returns The relative URI, or `undefined` if `target` is not under `base`.
 	 */
-	export function getRelativeUriFromBase(
-		target: string,
-		base: string,
-	): string | undefined {
+	export function getRelativeUriFromBase(target: string, base: string): string | undefined {
 		const baseUri = new Uri(base)
 		const targetUri = new Uri(target)
 
@@ -23,10 +20,8 @@ export namespace fileUtil {
 			return undefined
 		}
 
-		const baseComponents = baseUri.pathname.split('/')
-			.filter((v) => !!v)
-		const targetComponents = targetUri.pathname.split('/')
-			.filter((v) => !!v)
+		const baseComponents = baseUri.pathname.split('/').filter((v) => !!v)
+		const targetComponents = targetUri.pathname.split('/').filter((v) => !!v)
 
 		if (
 			baseComponents.length > targetComponents.length
@@ -37,9 +32,7 @@ export namespace fileUtil {
 			return undefined
 		}
 
-		return targetComponents.slice(baseComponents.length).map(
-			encodeURIComponent,
-		).join('/')
+		return targetComponents.slice(baseComponents.length).map(encodeURIComponent).join('/')
 	}
 
 	export function isSubUriOf(uri: string, base: string): boolean {
@@ -79,10 +72,7 @@ export namespace fileUtil {
 	 * getRel(['file:///root/foo/', 'file:///root/'], 'file:///root/foo/bar/qux.json') // -> 'bar/qux.json'
 	 * getRel(['file:///root/foo/', 'file:///root/'], 'file:///outsider.json') // -> undefined
 	 */
-	export function getRel(
-		uri: string,
-		rootUris: readonly RootUriString[],
-	): string | undefined {
+	export function getRel(uri: string, rootUris: readonly RootUriString[]): string | undefined {
 		return getRels(uri, rootUris).next().value
 	}
 
@@ -95,10 +85,7 @@ export namespace fileUtil {
 	}
 
 	export function join(fromUri: string, toUri: string): string {
-		return (
-			ensureEndingSlash(fromUri)
-			+ (toUri.startsWith('/') ? toUri.slice(1) : toUri)
-		)
+		return (ensureEndingSlash(fromUri) + (toUri.startsWith('/') ? toUri.slice(1) : toUri))
 	}
 
 	/**
@@ -125,10 +112,7 @@ export namespace fileUtil {
 	}
 
 	/* istanbul ignore next */
-	export function getParentOfFile(
-		externals: Externals,
-		path: FsLocation,
-	): FsLocation {
+	export function getParentOfFile(externals: Externals, path: FsLocation): FsLocation {
 		return new Uri('.', path)
 	}
 
@@ -176,10 +160,7 @@ export namespace fileUtil {
 		return externals.fs.chmod(path, mode)
 	}
 
-	export async function ensureWritable(
-		externals: Externals,
-		path: FsLocation,
-	): Promise<void> {
+	export async function ensureWritable(externals: Externals, path: FsLocation): Promise<void> {
 		try {
 			await chmod(externals, path, 0o666)
 		} catch (e) {
@@ -189,24 +170,15 @@ export namespace fileUtil {
 		}
 	}
 
-	export async function markReadOnly(
-		externals: Externals,
-		path: FsLocation,
-	): Promise<void> {
+	export async function markReadOnly(externals: Externals, path: FsLocation): Promise<void> {
 		return chmod(externals, path, 0o444)
 	}
 
-	export async function unlink(
-		externals: Externals,
-		path: FsLocation,
-	): Promise<void> {
+	export async function unlink(externals: Externals, path: FsLocation): Promise<void> {
 		return externals.fs.unlink(path)
 	}
 
-	export async function readFile(
-		externals: Externals,
-		path: FsLocation,
-	): Promise<Uint8Array> {
+	export async function readFile(externals: Externals, path: FsLocation): Promise<Uint8Array> {
 		return externals.fs.readFile(path)
 	}
 
@@ -238,10 +210,7 @@ export namespace fileUtil {
 	/**
 	 * @throws
 	 */
-	export async function readJson(
-		externals: Externals,
-		path: FsLocation,
-	): Promise<unknown> {
+	export async function readJson(externals: Externals, path: FsLocation): Promise<unknown> {
 		return JSON.parse(bufferToString(await readFile(externals, path)))
 	}
 
@@ -286,10 +255,7 @@ export namespace fileUtil {
 	/**
 	 * @throws
 	 */
-	export async function readGzippedJson(
-		externals: Externals,
-		path: FsLocation,
-	): Promise<unknown> {
+	export async function readGzippedJson(externals: Externals, path: FsLocation): Promise<unknown> {
 		return JSON.parse(bufferToString(await readGzippedFile(externals, path)))
 	}
 

--- a/packages/core/src/source/IndexMap.ts
+++ b/packages/core/src/source/IndexMap.ts
@@ -32,10 +32,7 @@ export namespace IndexMap {
 	}
 
 	export function toInnerRange(map: IndexMap, outer: Range): Range {
-		return Range.create(
-			toInnerOffset(map, outer.start),
-			toInnerOffset(map, outer.end),
-		)
+		return Range.create(toInnerOffset(map, outer.start), toInnerOffset(map, outer.end))
 	}
 
 	export function toOuterOffset(map: IndexMap, offset: number): number {
@@ -43,16 +40,10 @@ export namespace IndexMap {
 	}
 
 	export function toOuterRange(map: IndexMap, inner: Range): Range {
-		return Range.create(
-			toOuterOffset(map, inner.start),
-			toOuterOffset(map, inner.end),
-		)
+		return Range.create(toOuterOffset(map, inner.start), toOuterOffset(map, inner.end))
 	}
 
 	export function merge(outerMap: IndexMap, innerMap: IndexMap): IndexMap {
-		return innerMap.map((p) => ({
-			inner: p.inner,
-			outer: toOuterRange(outerMap, p.outer),
-		}))
+		return innerMap.map((p) => ({ inner: p.inner, outer: toOuterRange(outerMap, p.outer) }))
 	}
 }

--- a/packages/core/src/source/LanguageError.ts
+++ b/packages/core/src/source/LanguageError.ts
@@ -36,10 +36,7 @@ export namespace LanguageError {
 	/**
 	 * @returns A {@link PosRangeLanguageError}.
 	 */
-	export function withPosRange(
-		error: LanguageError,
-		doc: TextDocument,
-	): PosRangeLanguageError {
+	export function withPosRange(error: LanguageError, doc: TextDocument): PosRangeLanguageError {
 		return {
 			posRange: PositionRange.from(error.range, doc),
 			message: error.message,
@@ -60,8 +57,5 @@ export interface LanguageErrorInfo {
 	codeAction?: string
 	deprecated?: boolean
 	unnecessary?: boolean
-	related?: {
-		location: Location
-		message: string
-	}[]
+	related?: { location: Location; message: string }[]
 }

--- a/packages/core/src/source/Location.ts
+++ b/packages/core/src/source/Location.ts
@@ -9,29 +9,19 @@ export interface Location {
 	posRange: PositionRange
 }
 
-export type LocationLike = Partial<{
-	uri: string
-	range: RangeLike
-	posRange: PositionRange
-}>
+export type LocationLike = Partial<{ uri: string; range: RangeLike; posRange: PositionRange }>
 
 export namespace Location {
 	export function get(partial: LocationLike): Location {
 		return {
 			uri: partial.uri ?? '',
 			range: Range.get(partial.range ?? { start: 0, end: 0 }),
-			posRange: partial.posRange ?? {
-				start: { line: 0, character: 0 },
-				end: { line: 0, character: 0 },
-			},
+			posRange: partial.posRange
+				?? { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },
 		}
 	}
 
 	export function create(doc: TextDocument, range: RangeLike): Location {
-		return Location.get({
-			uri: doc.uri,
-			range,
-			posRange: PositionRange.from(range, doc),
-		})
+		return Location.get({ uri: doc.uri, range, posRange: PositionRange.from(range, doc) })
 	}
 }

--- a/packages/core/src/source/Offset.ts
+++ b/packages/core/src/source/Offset.ts
@@ -1,9 +1,6 @@
 import { ReadonlySource } from './Source.js'
 
-export type OffsetLike =
-	| number
-	| ReadonlySource
-	| ((this: void) => number | ReadonlySource)
+export type OffsetLike = number | ReadonlySource | ((this: void) => number | ReadonlySource)
 
 export namespace Offset {
 	/**

--- a/packages/core/src/source/Position.ts
+++ b/packages/core/src/source/Position.ts
@@ -6,10 +6,7 @@ export interface Position {
 export namespace Position {
 	export function create(line: number, character: number): Position
 	export function create(partial: Partial<Position>): Position
-	export function create(
-		param1: number | Partial<Position>,
-		param2?: number,
-	): Position {
+	export function create(param1: number | Partial<Position>, param2?: number): Position {
 		if (typeof param1 === 'object') {
 			return _createFromPartial(param1)
 		} else {
@@ -37,19 +34,13 @@ export namespace Position {
 	 * { line: Infinity, character: Infinity }
 	 * ```
 	 */
-	export const Infinity = Position.create(
-		Number.POSITIVE_INFINITY,
-		Number.POSITIVE_INFINITY,
-	)
+	export const Infinity = Position.create(Number.POSITIVE_INFINITY, Number.POSITIVE_INFINITY)
 
 	export function toString(pos: Position): string {
 		return `<${pos.line}, ${pos.character}>`
 	}
 
 	export function isBefore(pos1: Position, pos2: Position): boolean {
-		return (
-			pos1.line < pos2.line
-			|| (pos1.line === pos2.line && pos1.character < pos2.character)
-		)
+		return (pos1.line < pos2.line || (pos1.line === pos2.line && pos1.character < pos2.character))
 	}
 }

--- a/packages/core/src/source/Position.ts
+++ b/packages/core/src/source/Position.ts
@@ -48,8 +48,8 @@ export namespace Position {
 
 	export function isBefore(pos1: Position, pos2: Position): boolean {
 		return (
-			pos1.line < pos2.line ||
-			(pos1.line === pos2.line && pos1.character < pos2.character)
+			pos1.line < pos2.line
+			|| (pos1.line === pos2.line && pos1.character < pos2.character)
 		)
 	}
 }

--- a/packages/core/src/source/PositionRange.ts
+++ b/packages/core/src/source/PositionRange.ts
@@ -72,16 +72,10 @@ export namespace PositionRange {
 	 * }
 	 * ```
 	 */
-	export const Full = Object.freeze(
-		PositionRange.create(Position.Beginning, Position.Infinity),
-	)
+	export const Full = Object.freeze(PositionRange.create(Position.Beginning, Position.Infinity))
 
 	export function toString(range: PositionRange): string {
-		return `[${Position.toString(range.start)}, ${
-			Position.toString(
-				range.end,
-			)
-		})`
+		return `[${Position.toString(range.start)}, ${Position.toString(range.end)})`
 	}
 
 	export function contains(range: PositionRange, pos: Position): boolean {
@@ -94,16 +88,11 @@ export namespace PositionRange {
 			return true
 		}
 		// Now `pos` is in the same line as `start` and/or `end`.
-		return (
-			(pos.line === start.line ? pos.character >= start.character : true)
-			&& (pos.line === end.line ? pos.character < end.character : true)
-		)
+		return ((pos.line === start.line ? pos.character >= start.character : true)
+			&& (pos.line === end.line ? pos.character < end.character : true))
 	}
 
 	export function endsBefore(range: PositionRange, pos: Position): boolean {
-		return Position.isBefore(
-			Position.create(range.end.line, range.end.character - 1),
-			pos,
-		)
+		return Position.isBefore(Position.create(range.end.line, range.end.character - 1), pos)
 	}
 }

--- a/packages/core/src/source/PositionRange.ts
+++ b/packages/core/src/source/PositionRange.ts
@@ -95,8 +95,8 @@ export namespace PositionRange {
 		}
 		// Now `pos` is in the same line as `start` and/or `end`.
 		return (
-			(pos.line === start.line ? pos.character >= start.character : true) &&
-			(pos.line === end.line ? pos.character < end.character : true)
+			(pos.line === start.line ? pos.character >= start.character : true)
+			&& (pos.line === end.line ? pos.character < end.character : true)
 		)
 	}
 

--- a/packages/core/src/source/Range.ts
+++ b/packages/core/src/source/Range.ts
@@ -37,29 +37,21 @@ export namespace Range {
 	 */
 	export function create(start: OffsetLike, end?: OffsetLike): Range {
 		start = Offset.get(start)
-		return {
-			start,
-			end: end !== undefined ? Offset.get(end) : start,
-		}
+		return { start, end: end !== undefined ? Offset.get(end) : start }
 	}
 
 	/**
 	 * Creates a range that covers the area between `from.start` and `to.end`.
 	 */
 	export function span(from: RangeLike, to: RangeLike): Range {
-		return {
-			start: Range.get(from).start,
-			end: Range.get(to).end,
-		}
+		return { start: Range.get(from).start, end: Range.get(to).end }
 	}
 
 	export function is(obj: unknown): obj is Range {
-		return (
-			!!obj
+		return (!!obj
 			&& typeof obj === 'object'
 			&& typeof (obj as Range).start === 'number'
-			&& typeof (obj as Range).end === 'number'
-		)
+			&& typeof (obj as Range).end === 'number')
 	}
 
 	/**
@@ -80,23 +72,12 @@ export namespace Range {
 		return `[${range.start}, ${range.end})`
 	}
 
-	export function contains(
-		range: RangeLike,
-		offset: number,
-		endInclusive = false,
-	): boolean {
+	export function contains(range: RangeLike, offset: number, endInclusive = false): boolean {
 		range = get(range)
-		return (
-			range.start <= offset
-			&& (endInclusive ? offset <= range.end : offset < range.end)
-		)
+		return (range.start <= offset && (endInclusive ? offset <= range.end : offset < range.end))
 	}
 
-	export function containsRange(
-		a: RangeLike,
-		b: RangeLike,
-		endInclusive = false,
-	): boolean {
+	export function containsRange(a: RangeLike, b: RangeLike, endInclusive = false): boolean {
 		a = get(a)
 		b = get(b)
 		return contains(a, b.start, endInclusive) && contains(a, b.end, true)
@@ -110,11 +91,7 @@ export namespace Range {
 		return a.start === b.start && a.end === b.end
 	}
 
-	export function endsBefore(
-		range: Range,
-		target: RangeLike,
-		endInclusive = false,
-	): boolean {
+	export function endsBefore(range: Range, target: RangeLike, endInclusive = false): boolean {
 		return endInclusive
 			? range.end < Range.get(target).start
 			: range.end <= Range.get(target).start
@@ -145,11 +122,7 @@ export namespace Range {
 	/**
 	 * @returns Negative when `range` is before `offset`, `0` if it {@link contains} `offset`, and positive if it's after.
 	 */
-	export function compareOffset(
-		range: Range,
-		offset: number,
-		endInclusive = false,
-	): number {
+	export function compareOffset(range: Range, offset: number, endInclusive = false): number {
 		if (endInclusive ? range.end < offset : range.end <= offset) {
 			return -1
 		} else if (range.start > offset) {
@@ -170,10 +143,7 @@ export namespace Range {
 		endOffset = startOffset,
 	): Range {
 		range = get(range)
-		return {
-			start: range.start + startOffset,
-			end: range.end + endOffset,
-		}
+		return { start: range.start + startOffset, end: range.end + endOffset }
 	}
 }
 
@@ -183,10 +153,6 @@ export interface RangeContainer {
 }
 export namespace RangeContainer {
 	export function is(obj: unknown): obj is RangeContainer {
-		return (
-			!!obj
-			&& typeof obj === 'object'
-			&& Range.is((obj as RangeContainer).range)
-		)
+		return (!!obj && typeof obj === 'object' && Range.is((obj as RangeContainer).range))
 	}
 }

--- a/packages/core/src/source/Range.ts
+++ b/packages/core/src/source/Range.ts
@@ -55,10 +55,10 @@ export namespace Range {
 
 	export function is(obj: unknown): obj is Range {
 		return (
-			!!obj &&
-			typeof obj === 'object' &&
-			typeof (obj as Range).start === 'number' &&
-			typeof (obj as Range).end === 'number'
+			!!obj
+			&& typeof obj === 'object'
+			&& typeof (obj as Range).start === 'number'
+			&& typeof (obj as Range).end === 'number'
 		)
 	}
 
@@ -87,8 +87,8 @@ export namespace Range {
 	): boolean {
 		range = get(range)
 		return (
-			range.start <= offset &&
-			(endInclusive ? offset <= range.end : offset < range.end)
+			range.start <= offset
+			&& (endInclusive ? offset <= range.end : offset < range.end)
 		)
 	}
 
@@ -184,9 +184,9 @@ export interface RangeContainer {
 export namespace RangeContainer {
 	export function is(obj: unknown): obj is RangeContainer {
 		return (
-			!!obj &&
-			typeof obj === 'object' &&
-			Range.is((obj as RangeContainer).range)
+			!!obj
+			&& typeof obj === 'object'
+			&& Range.is((obj as RangeContainer).range)
 		)
 	}
 }

--- a/packages/core/src/source/Source.ts
+++ b/packages/core/src/source/Source.ts
@@ -16,10 +16,7 @@ export const Whitespaces = Object.freeze([' ', '\n', '\r', '\t'] as const)
 export class ReadonlySource {
 	public innerCursor = 0
 
-	constructor(
-		public readonly string: string,
-		public readonly indexMap: IndexMap = [],
-	) {}
+	constructor(public readonly string: string, public readonly indexMap: IndexMap = []) {}
 
 	get cursor() {
 		return IndexMap.toOuterOffset(this.indexMap, this.innerCursor)
@@ -48,10 +45,7 @@ export class ReadonlySource {
 	 * @param offset The index to offset from cursor. Defaults to 0
 	 */
 	peek(length = 1, offset = 0) {
-		return this.string.slice(
-			this.innerCursor + offset,
-			this.innerCursor + offset + length,
-		)
+		return this.string.slice(this.innerCursor + offset, this.innerCursor + offset + length)
 	}
 
 	/**
@@ -76,11 +70,7 @@ export class ReadonlySource {
 
 	peekUntil(...terminators: string[]): string {
 		let ans = ''
-		for (
-			let cursor = this.innerCursor;
-			cursor < this.string.length;
-			cursor++
-		) {
+		for (let cursor = this.innerCursor; cursor < this.string.length; cursor++) {
 			const c = this.string.charAt(cursor)
 			if (terminators.includes(c)) {
 				return ans
@@ -109,11 +99,7 @@ export class ReadonlySource {
 	 * @param offset Defaults to 0.
 	 */
 	hasNonSpaceAheadInLine(offset = 0): boolean {
-		for (
-			let cursor = this.innerCursor + offset;
-			cursor < this.string.length;
-			cursor++
-		) {
+		for (let cursor = this.innerCursor + offset; cursor < this.string.length; cursor++) {
 			const c = this.string.charAt(cursor)
 			if (Source.isNewline(c)) {
 				break
@@ -130,9 +116,7 @@ export class ReadonlySource {
 	slice(param0: Range | RangeContainer | number, end?: number): string {
 		if (typeof param0 === 'number') {
 			const innerStart = IndexMap.toInnerOffset(this.indexMap, param0)
-			const innerEnd = end !== undefined
-				? IndexMap.toInnerOffset(this.indexMap, end)
-				: undefined
+			const innerEnd = end !== undefined ? IndexMap.toInnerOffset(this.indexMap, end) : undefined
 			return this.string.slice(innerStart, innerEnd)
 		}
 		const range = IndexMap.toInnerRange(this.indexMap, Range.get(param0))
@@ -146,10 +130,7 @@ export class ReadonlySource {
 }
 
 export class Source extends ReadonlySource {
-	constructor(
-		public override string: string,
-		public override indexMap: IndexMap = [],
-	) {
+	constructor(public override string: string, public override indexMap: IndexMap = []) {
 		super(string, indexMap)
 	}
 

--- a/packages/core/src/symbol/Symbol.ts
+++ b/packages/core/src/symbol/Symbol.ts
@@ -162,8 +162,7 @@ export const TaggableResourceLocationCategories = Object.freeze(
 		...WorldgenFileCategories,
 	] as const,
 )
-export type TaggableResourceLocationCategory =
-	(typeof TaggableResourceLocationCategories)[number]
+export type TaggableResourceLocationCategory = (typeof TaggableResourceLocationCategories)[number]
 export namespace TaggableResourceLocationCategory {
 	export function is(
 		category: string,
@@ -232,8 +231,7 @@ export const ResourceLocationCategories = Object.freeze(
 		...RegistryCategories,
 	] as const,
 )
-export type ResourceLocationCategory =
-	(typeof ResourceLocationCategories)[number]
+export type ResourceLocationCategory = (typeof ResourceLocationCategories)[number]
 export namespace ResourceLocationCategory {
 	export function is(category: string): category is ResourceLocationCategory {
 		return ResourceLocationCategories.includes(
@@ -352,9 +350,7 @@ export namespace SymbolUsageType {
 	}
 }
 
-export interface Symbol
-	extends SymbolMetadata, Partial<Record<SymbolUsageType, SymbolLocation[]>>
-{
+export interface Symbol extends SymbolMetadata, Partial<Record<SymbolUsageType, SymbolLocation[]>> {
 	/**
 	 * The main category of this {@link Symbol}. Symbols in different categories are definitely
 	 * independent with each other. e.g. advancements and functions.
@@ -509,9 +505,7 @@ export interface UnlinkedSymbolMap {
 	[identifier: string]: UnlinkedSymbol
 }
 
-export interface UnlinkedSymbolTable
-	extends Partial<Record<AllCategory, UnlinkedSymbolMap>>
-{
+export interface UnlinkedSymbolTable extends Partial<Record<AllCategory, UnlinkedSymbolMap>> {
 	[category: string]: UnlinkedSymbolMap | undefined
 }
 

--- a/packages/core/src/symbol/Symbol.ts
+++ b/packages/core/src/symbol/Symbol.ts
@@ -7,12 +7,7 @@ import type { RangeLike } from '../source/index.js'
 import { Location, PositionRange, Range } from '../source/index.js'
 
 // #region Mcdoc Categories
-export const McdocCategories = Object.freeze(
-	[
-		'mcdoc',
-		'mcdoc/dispatcher',
-	] as const,
-)
+export const McdocCategories = Object.freeze(['mcdoc', 'mcdoc/dispatcher'] as const)
 export type McdocCategory = (typeof McdocCategories)[number]
 // #endregion
 
@@ -156,17 +151,11 @@ export const WorldgenFileCategories = Object.freeze(
 export type WorldgenFileCategory = (typeof WorldgenFileCategories)[number]
 
 export const TaggableResourceLocationCategories = Object.freeze(
-	[
-		...NormalFileCategories,
-		...RegistryCategories,
-		...WorldgenFileCategories,
-	] as const,
+	[...NormalFileCategories, ...RegistryCategories, ...WorldgenFileCategories] as const,
 )
 export type TaggableResourceLocationCategory = (typeof TaggableResourceLocationCategories)[number]
 export namespace TaggableResourceLocationCategory {
-	export function is(
-		category: string,
-	): category is TaggableResourceLocationCategory {
+	export function is(category: string): category is TaggableResourceLocationCategory {
 		return TaggableResourceLocationCategories.includes(
 			category as TaggableResourceLocationCategory,
 		)
@@ -179,11 +168,7 @@ export const TagFileCategories = Object.freeze(
 export type TagFileCategory = (typeof TagFileCategories)[number]
 
 export const FileCategories = Object.freeze(
-	[
-		...NormalFileCategories,
-		...TagFileCategories,
-		...WorldgenFileCategories,
-	] as const,
+	[...NormalFileCategories, ...TagFileCategories, ...WorldgenFileCategories] as const,
 )
 export type FileCategory = (typeof FileCategories)[number]
 
@@ -202,21 +187,12 @@ export const MiscCategories = Object.freeze(
 )
 export type MiscCategory = (typeof MiscCategories)[number]
 
-export const DatapackCategories = Object.freeze(
-	[
-		...FileCategories,
-		...MiscCategories,
-	] as const,
-)
+export const DatapackCategories = Object.freeze([...FileCategories, ...MiscCategories] as const)
 export type DatapackCategory = (typeof DatapackCategories)[number]
 // #endregion
 
 export const AllCategories = Object.freeze(
-	[
-		...DatapackCategories,
-		...McdocCategories,
-		...RegistryCategories,
-	] as const,
+	[...DatapackCategories, ...McdocCategories, ...RegistryCategories] as const,
 )
 export type AllCategory = (typeof AllCategories)[number]
 
@@ -234,9 +210,7 @@ export const ResourceLocationCategories = Object.freeze(
 export type ResourceLocationCategory = (typeof ResourceLocationCategories)[number]
 export namespace ResourceLocationCategory {
 	export function is(category: string): category is ResourceLocationCategory {
-		return ResourceLocationCategories.includes(
-			category as ResourceLocationCategory,
-		)
+		return ResourceLocationCategories.includes(category as ResourceLocationCategory)
 	}
 }
 
@@ -258,15 +232,9 @@ export interface SymbolPath {
 }
 export namespace SymbolPath {
 	export function fromSymbol(symbol: DeepReadonly<Symbol>): SymbolPath
-	export function fromSymbol(
-		symbol: DeepReadonly<Symbol> | undefined,
-	): SymbolPath | undefined
-	export function fromSymbol(
-		symbol: DeepReadonly<Symbol> | undefined,
-	): SymbolPath | undefined {
-		return symbol
-			? { category: symbol.category, path: symbol.path }
-			: undefined
+	export function fromSymbol(symbol: DeepReadonly<Symbol> | undefined): SymbolPath | undefined
+	export function fromSymbol(symbol: DeepReadonly<Symbol> | undefined): SymbolPath | undefined {
+		return symbol ? { category: symbol.category, path: symbol.path } : undefined
 	}
 
 	/**
@@ -312,10 +280,7 @@ export interface SymbolMetadata {
 	 * A map of symbols that are related to the current symbol. **Only** symbols defined in the global symbol table
 	 * (i.e. visibility is {@link SymbolVisibility.Public} or {@link SymbolVisibility.Restricted}) can be specified in this map.
 	 */
-	relations?: {
-		aliasOf?: SymbolPath
-		[relationship: string]: SymbolPath | undefined
-	}
+	relations?: { aliasOf?: SymbolPath; [relationship: string]: SymbolPath | undefined }
 	/**
 	 * An optional subcategory. Symbols under the same category but having different
 	 * subcategories may be used interchangeablely in certain context. e.g. both
@@ -335,13 +300,7 @@ export interface SymbolMetadata {
 }
 
 export const SymbolUsageTypes = Object.freeze(
-	[
-		'definition',
-		'declaration',
-		'implementation',
-		'reference',
-		'typeDefinition',
-	] as const,
+	['definition', 'declaration', 'implementation', 'reference', 'typeDefinition'] as const,
 )
 export type SymbolUsageType = (typeof SymbolUsageTypes)[number]
 export namespace SymbolUsageType {
@@ -463,10 +422,7 @@ export namespace SymbolLocation {
 		return {
 			...Location.create(doc, range),
 			...(fullRange
-				? {
-					fullRange: Range.get(fullRange),
-					fullPosRange: PositionRange.from(fullRange, doc),
-				}
+				? { fullRange: Range.get(fullRange), fullPosRange: PositionRange.from(fullRange, doc) }
 				: {}),
 			...(contributor ? { contributor } : {}),
 			...(additional ? additional : {}),
@@ -482,16 +438,9 @@ export interface SymbolTable extends Partial<Record<AllCategory, SymbolMap>> {
 	[category: string]: SymbolMap | undefined
 }
 
-export interface UnlinkedSymbol extends
-	Omit<
-		Symbol,
-		| 'category'
-		| 'identifier'
-		| 'members'
-		| 'parentMap'
-		| 'parentSymbol'
-		| 'path'
-	>
+export interface UnlinkedSymbol
+	extends
+		Omit<Symbol, 'category' | 'identifier' | 'members' | 'parentMap' | 'parentSymbol' | 'path'>
 {
 	category?: undefined
 	identifier?: undefined
@@ -543,10 +492,7 @@ export namespace SymbolTable {
 			path: string[],
 		) => {
 			for (const [identifier, childSymbol] of Object.entries(map)) {
-				linkSymbol(childSymbol, map, parentSymbol, category, [
-					...path,
-					identifier,
-				])
+				linkSymbol(childSymbol, map, parentSymbol, category, [...path, identifier])
 			}
 		}
 

--- a/packages/core/src/symbol/SymbolUtil.ts
+++ b/packages/core/src/symbol/SymbolUtil.ts
@@ -578,9 +578,9 @@ export class SymbolUtil implements ExternalEventEmitter {
 				return result
 			}
 			if (
-				!parentSymbol &&
-				!parentMap &&
-				(result.parentSymbol || result.parentMap)
+				!parentSymbol
+				&& !parentMap
+				&& (result.parentSymbol || result.parentMap)
 			) {
 				parentSymbol = result.parentSymbol
 				parentMap = result.parentMap
@@ -647,13 +647,13 @@ export class SymbolUtil implements ExternalEventEmitter {
 				// Visibility changes are only accepted if the change wouldn't result in the
 				// symbol being stored in a different symbol table.
 				const inGlobalTable = (v: SymbolVisibility | undefined) =>
-					v === undefined ||
-					v === SymbolVisibility.Public ||
-					v === SymbolVisibility.Restricted
+					v === undefined
+					|| v === SymbolVisibility.Public
+					|| v === SymbolVisibility.Restricted
 				if (
-					symbol.visibility === addition.visibility ||
-					(inGlobalTable(symbol.visibility) &&
-						inGlobalTable(addition.visibility))
+					symbol.visibility === addition.visibility
+					|| (inGlobalTable(symbol.visibility)
+						&& inGlobalTable(addition.visibility))
 				) {
 					symbol.visibility = addition.visibility
 				} else {
@@ -738,12 +738,12 @@ export class SymbolUtil implements ExternalEventEmitter {
 
 	static isTrimmable(symbol: Symbol): boolean {
 		return (
-			!Object.keys(symbol.members ?? {}).length &&
-			!symbol.declaration?.length &&
-			!symbol.definition?.length &&
-			!symbol.implementation?.length &&
-			!symbol.reference?.length &&
-			!symbol.typeDefinition?.length
+			!Object.keys(symbol.members ?? {}).length
+			&& !symbol.declaration?.length
+			&& !symbol.definition?.length
+			&& !symbol.implementation?.length
+			&& !symbol.reference?.length
+			&& !symbol.typeDefinition?.length
 		)
 	}
 
@@ -787,8 +787,8 @@ export class SymbolUtil implements ExternalEventEmitter {
 		symbol: DeepReadonly<Symbol> | undefined,
 	): symbol is Symbol {
 		return !!(
-			symbol?.definition?.length ||
-			(symbol?.definition?.length && symbol?.implementation?.length)
+			symbol?.definition?.length
+			|| (symbol?.definition?.length && symbol?.implementation?.length)
 		)
 	}
 	/**
@@ -821,9 +821,9 @@ export class SymbolUtil implements ExternalEventEmitter {
 	 */
 	static getDeclaredLocation(symbol: DeepReadonly<Symbol>): SymbolLocation {
 		return (
-			symbol.declaration?.[0] ??
-				symbol.definition?.[0] ??
-				(() => {
+			symbol.declaration?.[0]
+				?? symbol.definition?.[0]
+				?? (() => {
 					throw new Error(
 						`Cannot get declared location of ${
 							JSON.stringify(
@@ -869,9 +869,9 @@ export class SymbolUtil implements ExternalEventEmitter {
 
 	static isVisibilityInGlobal(v: SymbolVisibility | undefined) {
 		return (
-			v === undefined ||
-			v === SymbolVisibility.Public ||
-			v === SymbolVisibility.Restricted
+			v === undefined
+			|| v === SymbolVisibility.Public
+			|| v === SymbolVisibility.Restricted
 		)
 	}
 
@@ -880,9 +880,9 @@ export class SymbolUtil implements ExternalEventEmitter {
 		v2: SymbolVisibility | undefined,
 	) {
 		return (
-			(this.isVisibilityInGlobal(v1) && this.isVisibilityInGlobal(v2)) ||
-			(v1 === SymbolVisibility.Block && v2 === SymbolVisibility.Block) ||
-			(v1 === SymbolVisibility.File && v2 === SymbolVisibility.File)
+			(this.isVisibilityInGlobal(v1) && this.isVisibilityInGlobal(v2))
+			|| (v1 === SymbolVisibility.Block && v2 === SymbolVisibility.Block)
+			|| (v1 === SymbolVisibility.File && v2 === SymbolVisibility.File)
 		)
 	}
 }
@@ -1167,17 +1167,17 @@ export class SymbolQuery {
 			addition: SymbolAddition,
 		): SymbolVisibility => {
 			return (
-				addition.data?.visibility ??
-					this.symbol?.visibility ??
-					SymbolVisibility.Public
+				addition.data?.visibility
+					?? this.symbol?.visibility
+					?? SymbolVisibility.Public
 			)
 		}
 
 		const getMap = (addition: SymbolAddition): SymbolMap => {
 			const additionVisibility = getAdditionVisibility(addition)
 			if (
-				this.#map &&
-				SymbolUtil.areVisibilitiesCompatible(
+				this.#map
+				&& SymbolUtil.areVisibilitiesCompatible(
 					additionVisibility,
 					this.#symbol?.visibility,
 				)
@@ -1273,8 +1273,8 @@ export class SymbolQuery {
 
 		// Treat `usage.range` as `[0, 0)` if this class was constructed with a string URI (instead of a `TextDocument`).
 		if (
-			this.#createdWithUri &&
-			SymbolAdditionUsageWithRange.is(addition.usage)
+			this.#createdWithUri
+			&& SymbolAdditionUsageWithRange.is(addition.usage)
 		) {
 			addition.usage.range = Range.create(0, 0)
 		}
@@ -1381,8 +1381,8 @@ export class SymbolQuery {
 			)
 		}
 
-		const memberDoc = typeof doc === 'string' && doc === this.#doc.uri &&
-				!this.#createdWithUri
+		const memberDoc = typeof doc === 'string' && doc === this.#doc.uri
+				&& !this.#createdWithUri
 			? this.#doc
 			: doc
 		const memberMap = this.#symbol.members
@@ -1492,11 +1492,11 @@ export namespace SymbolFormatter {
 		const ans: string[] = []
 		assertEqual(symbol.path[symbol.path.length - 1], symbol.identifier)
 		ans.push(
-			`SYMBOL ${symbol.path.join('.')}` +
-				` {${symbol.category}${
+			`SYMBOL ${symbol.path.join('.')}`
+				+ ` {${symbol.category}${
 					symbol.subcategory ? ` (${symbol.subcategory})` : ''
-				}}` +
-				` [${
+				}}`
+				+ ` [${
 					stringifyVisibility(
 						symbol.visibility,
 						symbol.visibilityRestriction,

--- a/packages/core/src/symbol/SymbolUtil.ts
+++ b/packages/core/src/symbol/SymbolUtil.ts
@@ -1,9 +1,5 @@
 import { TextDocument } from 'vscode-languageserver-textdocument'
-import type {
-	DeepReadonly,
-	ExternalEventEmitter,
-	Externals,
-} from '../common/index.js'
+import type { DeepReadonly, ExternalEventEmitter, Externals } from '../common/index.js'
 import type { AstNode } from '../node/index.js'
 import type { RangeLike } from '../source/index.js'
 import { Range } from '../source/index.js'
@@ -17,12 +13,7 @@ import type {
 	SymbolTable,
 	SymbolUsageType,
 } from './Symbol.js'
-import {
-	SymbolLocation,
-	SymbolPath,
-	SymbolUsageTypes,
-	SymbolVisibility,
-} from './Symbol.js'
+import { SymbolLocation, SymbolPath, SymbolUsageTypes, SymbolVisibility } from './Symbol.js'
 
 export interface LookupResult {
 	/**
@@ -102,11 +93,10 @@ export class SymbolUtil implements ExternalEventEmitter {
 				this.#trimmableSymbols.delete(SymbolPath.toString(symbol))
 			})
 			.on('symbolLocationCreated', ({ symbol, location }) => {
-				const cache =
-					(this.#cache[location.contributor ?? 'undefined'] ??= Object
-						.create(
-							null,
-						) as never)
+				const cache = (this.#cache[location.contributor ?? 'undefined'] ??= Object
+					.create(
+						null,
+					) as never)
 				const fileSymbols = (cache[location.uri] ??= new Set())
 				const path = SymbolPath.toString(symbol)
 				fileSymbols.add(path)
@@ -1421,8 +1411,7 @@ export class SymbolQuery {
 	): this {
 		return this.onEach(
 			Object.keys(this.visibleMembers),
-			(identifier) =>
-				this.member(identifier, (query) => fn(identifier, query)),
+			(identifier) => this.member(identifier, (query) => fn(identifier, query)),
 		)
 	}
 
@@ -1493,9 +1482,7 @@ export namespace SymbolFormatter {
 		assertEqual(symbol.path[symbol.path.length - 1], symbol.identifier)
 		ans.push(
 			`SYMBOL ${symbol.path.join('.')}`
-				+ ` {${symbol.category}${
-					symbol.subcategory ? ` (${symbol.subcategory})` : ''
-				}}`
+				+ ` {${symbol.category}${symbol.subcategory ? ` (${symbol.subcategory})` : ''}}`
 				+ ` [${
 					stringifyVisibility(
 						symbol.visibility,
@@ -1514,8 +1501,7 @@ export namespace SymbolFormatter {
 				ans.push(
 					`${IndentChar}${type}:\n${
 						symbol[type]!.map(
-							(v) =>
-								`${indent}${IndentChar.repeat(2)}${JSON.stringify(v)}`,
+							(v) => `${indent}${IndentChar.repeat(2)}${JSON.stringify(v)}`,
 						).join(`\n${indent}${IndentChar.repeat(2)}------------\n`)
 					}`,
 				)

--- a/packages/core/test/common/Operations.spec.ts
+++ b/packages/core/test/common/Operations.spec.ts
@@ -3,11 +3,7 @@ import { describe, it } from 'mocha'
 import snapshot from 'snap-shot-it'
 
 describe('Operations', () => {
-	const getTestObj = () => ({
-		foo: 1,
-		bar: 2,
-		baz: 3,
-	})
+	const getTestObj = () => ({ foo: 1, bar: 2, baz: 3 })
 	it('Should redo and undo correctly', () => {
 		const ops = new Operations()
 		const testObj = getTestObj()

--- a/packages/core/test/common/ReadonlyProxy.spec.ts
+++ b/packages/core/test/common/ReadonlyProxy.spec.ts
@@ -6,45 +6,25 @@ import { assertError } from '../utils.js'
 
 describe('ReadonlyProxy', () => {
 	it('Should create a deeply readonly proxy', () => {
-		const testObj = {
-			foo: {
-				baz: {
-					qux: true,
-				},
-				bax: true,
-			},
-			bar: true,
-		}
+		const testObj = { foo: { baz: { qux: true }, bax: true }, bar: true }
 		const proxy = ReadonlyProxy.create(testObj)
 
-		assertError(
-			() => {
-				// @ts-expect-error
-				proxy.bar = false
-			},
-			(e) => snapshot((e as Error).message),
-		)
-		assertError(
-			() => {
-				// @ts-expect-error
-				proxy.foo.bax = false
-			},
-			(e) => snapshot((e as Error).message),
-		)
-		assertError(
-			() => {
-				// @ts-expect-error
-				proxy.foo.baz.qux = false
-			},
-			(e) => snapshot((e as Error).message),
-		)
-		assertError(
-			() => {
-				// @ts-expect-error
-				delete proxy.foo.baz.qux
-			},
-			(e) => snapshot((e as Error).message),
-		)
+		assertError(() => {
+			// @ts-expect-error
+			proxy.bar = false
+		}, (e) => snapshot((e as Error).message))
+		assertError(() => {
+			// @ts-expect-error
+			proxy.foo.bax = false
+		}, (e) => snapshot((e as Error).message))
+		assertError(() => {
+			// @ts-expect-error
+			proxy.foo.baz.qux = false
+		}, (e) => snapshot((e as Error).message))
+		assertError(() => {
+			// @ts-expect-error
+			delete proxy.foo.baz.qux
+		}, (e) => snapshot((e as Error).message))
 		snapshot(testObj)
 		assert.deepStrictEqual(testObj, proxy)
 	})

--- a/packages/core/test/common/StateProxy.spec.ts
+++ b/packages/core/test/common/StateProxy.spec.ts
@@ -4,21 +4,8 @@ import { describe, it } from 'mocha'
 import snapshot from 'snap-shot-it'
 
 const getTestObj = () => ({
-	symbols: {
-		advancement: {
-			foo: {
-				category: 'advancement',
-			},
-		},
-	},
-	node: {
-		type: 'file',
-		children: [
-			{
-				type: 'symbol',
-			},
-		],
-	},
+	symbols: { advancement: { foo: { category: 'advancement' } } },
+	node: { type: 'file', children: [{ type: 'symbol' }] },
 })
 
 describe('StateProxy', () => {
@@ -34,14 +21,8 @@ describe('StateProxy', () => {
 		assert.strictEqual(proxy.symbols, proxy.symbols)
 		assert(StateProxy.is(proxy.symbols), 'proxy.symbols is a StateProxy')
 		assert.strictEqual(proxy.symbols.advancement, proxy.symbols.advancement)
-		assert(
-			StateProxy.is(proxy.symbols.advancement),
-			'proxy.symbols.advancement is a StateProxy',
-		)
-		assert.strictEqual(
-			proxy.symbols.advancement.foo,
-			proxy.symbols.advancement.foo,
-		)
+		assert(StateProxy.is(proxy.symbols.advancement), 'proxy.symbols.advancement is a StateProxy')
+		assert.strictEqual(proxy.symbols.advancement.foo, proxy.symbols.advancement.foo)
 		assert(
 			StateProxy.is(proxy.symbols.advancement.foo),
 			'proxy.symbols.advancement.foo is a StateProxy',
@@ -51,15 +32,9 @@ describe('StateProxy', () => {
 		assert(StateProxy.is(proxy.node), 'proxy.node is a StateProxy')
 		assert.strictEqual(proxy.node.type, 'file')
 		assert.strictEqual(proxy.node.children, proxy.node.children)
-		assert(
-			StateProxy.is(proxy.node.children),
-			'proxy.node.children is a StateProxy',
-		)
+		assert(StateProxy.is(proxy.node.children), 'proxy.node.children is a StateProxy')
 		assert.strictEqual(proxy.node.children[0], proxy.node.children[0])
-		assert(
-			StateProxy.is(proxy.node.children[0]),
-			'proxy.node.children[0] is a StateProxy',
-		)
+		assert(StateProxy.is(proxy.node.children[0]), 'proxy.node.children[0] is a StateProxy')
 		assert.strictEqual(proxy.node.children[0].type, 'symbol')
 	})
 	it('Should return the correct origin', () => {
@@ -76,24 +51,15 @@ describe('StateProxy', () => {
 			testObj.symbols.advancement.foo,
 		)
 		assert.strictEqual(StateProxy.dereference(proxy.node), testObj.node)
-		assert.strictEqual(
-			StateProxy.dereference(proxy.node.children),
-			testObj.node.children,
-		)
-		assert.strictEqual(
-			StateProxy.dereference(proxy.node.children[0]),
-			testObj.node.children[0],
-		)
+		assert.strictEqual(StateProxy.dereference(proxy.node.children), testObj.node.children)
+		assert.strictEqual(StateProxy.dereference(proxy.node.children[0]), testObj.node.children[0])
 	})
 	it('Should undo and redo changes correctly', () => {
 		const testObj = getTestObj() as any
 		const proxy = StateProxy.create(testObj) as StateProxy<any>
 		snapshot(proxy)
 
-		const barSymbol = {
-			category: 'advancement',
-			data: 1,
-		}
+		const barSymbol = { category: 'advancement', data: 1 }
 		proxy.symbols.advancement.bar = barSymbol
 		proxy.node.children[0].symbol = barSymbol
 		proxy.symbols.advancement.bar.data = 42

--- a/packages/core/test/common/util.spec.ts
+++ b/packages/core/test/common/util.spec.ts
@@ -1,10 +1,5 @@
 import { describe } from 'mocha'
-import type {
-	AstNode,
-	CommentNode,
-	DeepReadonly,
-	InheritReadonly,
-} from '../../lib'
+import type { AstNode, CommentNode, DeepReadonly, InheritReadonly } from '../../lib'
 import { assertType, typing } from '../utils.js'
 
 describe('common util', () => {

--- a/packages/core/test/common/util.spec.ts
+++ b/packages/core/test/common/util.spec.ts
@@ -5,10 +5,7 @@ import { assertType, typing } from '../utils.js'
 describe('common util', () => {
 	typing('InheritReadonly', () => {
 		type UndefinedNode = InheritReadonly<CommentNode, undefined>
-		type ReadonlyNode = InheritReadonly<
-			CommentNode,
-			DeepReadonly<AstNode>
-		>
+		type ReadonlyNode = InheritReadonly<CommentNode, DeepReadonly<AstNode>>
 		type ReadWriteNode = InheritReadonly<CommentNode, AstNode>
 		assertType<never>(0 as unknown as UndefinedNode)
 		assertType<DeepReadonly<CommentNode>>(0 as unknown as ReadonlyNode)

--- a/packages/core/test/node/AstNode.spec.ts
+++ b/packages/core/test/node/AstNode.spec.ts
@@ -5,61 +5,31 @@ import { AstNode, Range } from '../../lib/index.js'
 const TestNode: AstNode = {
 	type: 'not_leaf_1',
 	range: Range.create(0, 10),
-	children: [
-		{
-			type: 'leaf_1',
-			range: Range.create(0, 5),
-		},
-		{
-			type: 'not_leaf_2',
-			range: Range.create(5, 10),
-			children: [
-				{
-					type: 'not_leaf_3',
-					range: Range.create(5, 8),
-					children: [
-						{
-							type: 'leaf_2',
-							range: Range.create(5, 6),
-						},
-						{
-							type: 'leaf_3',
-							range: Range.create(6, 8),
-						},
-					],
-				},
-				{
-					type: 'leaf_4',
-					range: Range.create(9, 10),
-				},
-			],
-		},
-	],
+	children: [{ type: 'leaf_1', range: Range.create(0, 5) }, {
+		type: 'not_leaf_2',
+		range: Range.create(5, 10),
+		children: [{
+			type: 'not_leaf_3',
+			range: Range.create(5, 8),
+			children: [{ type: 'leaf_2', range: Range.create(5, 6) }, {
+				type: 'leaf_3',
+				range: Range.create(6, 8),
+			}],
+		}, { type: 'leaf_4', range: Range.create(9, 10) }],
+	}],
 }
 
 const DiscontinuousTestNode: AstNode = {
 	type: 'not_leaf_1',
 	range: Range.create(0, 10),
-	children: [
-		{
-			type: 'not_leaf_2',
-			range: Range.create(0, 6),
-			children: [
-				{
-					type: 'leaf_1',
-					range: Range.create(0, 2),
-				},
-				{
-					type: 'leaf_2',
-					range: Range.create(4, 6),
-				},
-			],
-		},
-		{
-			type: 'not_leaf_4',
-			range: Range.create(9, 10),
-		},
-	],
+	children: [{
+		type: 'not_leaf_2',
+		range: Range.create(0, 6),
+		children: [{ type: 'leaf_1', range: Range.create(0, 2) }, {
+			type: 'leaf_2',
+			range: Range.create(4, 6),
+		}],
+	}, { type: 'not_leaf_4', range: Range.create(9, 10) }],
 }
 
 describe('AstNode', () => {
@@ -68,17 +38,8 @@ describe('AstNode', () => {
 			const suites: number[] = [0, 1, 5, 7, 9, 12]
 			for (const suite of suites) {
 				it(`Should return the node at ${suite}`, () => {
-					const node = AstNode.findDeepestChild({
-						node: TestNode,
-						needle: suite,
-					})
-					snapshot(
-						node
-							? {
-								node: node.type,
-							}
-							: 'undefined',
-					)
+					const node = AstNode.findDeepestChild({ node: TestNode, needle: suite })
+					snapshot(node ? { node: node.type } : 'undefined')
 				})
 			}
 		})
@@ -86,17 +47,8 @@ describe('AstNode', () => {
 			const suites: number[] = [0, 3, 7, 12]
 			for (const suite of suites) {
 				it(`Should return the node at ${suite}`, () => {
-					const node = AstNode.findDeepestChild({
-						node: DiscontinuousTestNode,
-						needle: suite,
-					})
-					snapshot(
-						node
-							? {
-								node: node.type,
-							}
-							: 'undefined',
-					)
+					const node = AstNode.findDeepestChild({ node: DiscontinuousTestNode, needle: suite })
+					snapshot(node ? { node: node.type } : 'undefined')
 				})
 			}
 		})

--- a/packages/core/test/node/ResourceLocationNode.spec.ts
+++ b/packages/core/test/node/ResourceLocationNode.spec.ts
@@ -17,32 +17,12 @@ describe('ResourceLocationNode', () => {
 			{ node: { path: ['foo'] }, type: 'origin', expected: 'foo' },
 			{ node: { path: ['foo'] }, type: 'full', expected: 'minecraft:foo' },
 			{ node: { path: ['foo'] }, type: 'short', expected: 'foo' },
-			{
-				node: { path: ['foo', 'bar'] },
-				type: 'origin',
-				expected: 'foo/bar',
-			},
-			{
-				node: { path: ['foo', 'bar'] },
-				type: 'full',
-				expected: 'minecraft:foo/bar',
-			},
+			{ node: { path: ['foo', 'bar'] }, type: 'origin', expected: 'foo/bar' },
+			{ node: { path: ['foo', 'bar'] }, type: 'full', expected: 'minecraft:foo/bar' },
 			{ node: { path: ['foo', 'bar'] }, type: 'short', expected: 'foo/bar' },
-			{
-				node: { namespace: '', path: ['foo'] },
-				type: undefined,
-				expected: ':foo',
-			},
-			{
-				node: { namespace: '', path: ['foo'] },
-				type: 'full',
-				expected: 'minecraft:foo',
-			},
-			{
-				node: { namespace: '', path: ['foo'] },
-				type: 'short',
-				expected: 'foo',
-			},
+			{ node: { namespace: '', path: ['foo'] }, type: undefined, expected: ':foo' },
+			{ node: { namespace: '', path: ['foo'] }, type: 'full', expected: 'minecraft:foo' },
+			{ node: { namespace: '', path: ['foo'] }, type: 'short', expected: 'foo' },
 			{
 				node: { namespace: 'minecraft', path: ['foo'] },
 				type: 'origin',
@@ -53,41 +33,25 @@ describe('ResourceLocationNode', () => {
 				type: 'full',
 				expected: 'minecraft:foo',
 			},
-			{
-				node: { namespace: 'minecraft', path: ['foo'] },
-				type: 'short',
-				expected: 'foo',
-			},
+			{ node: { namespace: 'minecraft', path: ['foo'] }, type: 'short', expected: 'foo' },
 			{
 				node: { namespace: 'spgoding', path: ['foo'] },
 				type: 'origin',
 				expected: 'spgoding:foo',
 			},
-			{
-				node: { namespace: 'spgoding', path: ['foo'] },
-				type: 'full',
-				expected: 'spgoding:foo',
-			},
+			{ node: { namespace: 'spgoding', path: ['foo'] }, type: 'full', expected: 'spgoding:foo' },
 			{
 				node: { namespace: 'spgoding', path: ['foo'] },
 				type: 'short',
 				expected: 'spgoding:foo',
 			},
-			{
-				node: { isTag: true, path: ['foo', 'bar'] },
-				type: 'origin',
-				expected: 'foo/bar',
-			},
+			{ node: { isTag: true, path: ['foo', 'bar'] }, type: 'origin', expected: 'foo/bar' },
 			{
 				node: { isTag: true, path: ['foo', 'bar'] },
 				type: 'full',
 				expected: 'minecraft:foo/bar',
 			},
-			{
-				node: { isTag: true, path: ['foo', 'bar'] },
-				type: 'short',
-				expected: 'foo/bar',
-			},
+			{ node: { isTag: true, path: ['foo', 'bar'] }, type: 'short', expected: 'foo/bar' },
 			{
 				node: { isTag: true, path: ['foo', 'bar'] },
 				type: 'origin',

--- a/packages/core/test/parser/comment.spec.ts
+++ b/packages/core/test/parser/comment.spec.ts
@@ -7,14 +7,8 @@ describe('comment()', () => {
 	const suites: { prefixes: Set<string>; content: string }[] = [
 		{ prefixes: new Set(['//']), content: '' },
 		{ prefixes: new Set(['//']), content: '// This is a comment.' },
-		{
-			prefixes: new Set(['//']),
-			content: '// This is a comment.\nAnother line here.',
-		},
-		{
-			prefixes: new Set(['//']),
-			content: '# Whoops.\n// The world is burning!',
-		},
+		{ prefixes: new Set(['//']), content: '// This is a comment.\nAnother line here.' },
+		{ prefixes: new Set(['//']), content: '# Whoops.\n// The world is burning!' },
 	]
 	for (const { prefixes, content } of suites) {
 		it(`Parse "${showWhitespaceGlyph(content)}"`, () => {
@@ -22,10 +16,7 @@ describe('comment()', () => {
 			snapshot(testParser(parser, content))
 		})
 		it(`Parse "${showWhitespaceGlyph(content)}" with "includesEol" on`, () => {
-			const parser = comment({
-				singleLinePrefixes: prefixes,
-				includesEol: true,
-			})
+			const parser = comment({ singleLinePrefixes: prefixes, includesEol: true })
 			snapshot(testParser(parser, content))
 		})
 	}

--- a/packages/core/test/parser/error.spec.ts
+++ b/packages/core/test/parser/error.spec.ts
@@ -4,11 +4,9 @@ import { error } from '../../lib/index.js'
 import { showWhitespaceGlyph, testParser } from '../utils.js'
 
 describe('error()', () => {
-	const suites: { content: string }[] = [
-		{ content: '' },
-		{ content: '\t' },
-		{ content: 'whatever\nall errors' },
-	]
+	const suites: { content: string }[] = [{ content: '' }, { content: '\t' }, {
+		content: 'whatever\nall errors',
+	}]
 	for (const { content } of suites) {
 		it(`Parse "${showWhitespaceGlyph(content)}"`, () => {
 			snapshot(testParser(error, content))

--- a/packages/core/test/parser/file.spec.ts
+++ b/packages/core/test/parser/file.spec.ts
@@ -19,12 +19,9 @@ describe('file()', () => {
 			}
 		},
 	})
-	const suites: { content: string }[] = [
-		{ content: '' },
-		{ content: '{test content}' },
-		{ content: '{test content}\n\t' },
-		{ content: '{test content}\nWhoops errors!' },
-	]
+	const suites: { content: string }[] = [{ content: '' }, { content: '{test content}' }, {
+		content: '{test content}\n\t',
+	}, { content: '{test content}\nWhoops errors!' }]
 	for (const { content } of suites) {
 		it(`Parse "${showWhitespaceGlyph(content)}"`, () => {
 			snapshot(

--- a/packages/core/test/parser/float.spec.ts
+++ b/packages/core/test/parser/float.spec.ts
@@ -25,41 +25,30 @@ describe('float()', () => {
 	})
 
 	describe('float(min, max, onOutOfRange)', () => {
-		const options: Options[] = [
-			{ pattern, min: 1 },
-			{ pattern, max: 6 },
-			{
-				pattern,
-				min: 1,
-				max: 6,
-				onOutOfRange: (ans, _src, ctx) => ctx.err.report('Testing MESSAGE', ans),
-			},
-		]
-		const cases: { content: string }[] = [
-			{ content: '0.0' },
-			{ content: '3.0' },
-			{ content: '9.0' },
-		]
+		const options: Options[] = [{ pattern, min: 1 }, { pattern, max: 6 }, {
+			pattern,
+			min: 1,
+			max: 6,
+			onOutOfRange: (ans, _src, ctx) => ctx.err.report('Testing MESSAGE', ans),
+		}]
+		const cases: { content: string }[] = [{ content: '0.0' }, { content: '3.0' }, {
+			content: '9.0',
+		}]
 		for (const option of options) {
-			describe(
-				`float(${option.min}, ${option.max}, ${!!option.onOutOfRange})`,
-				() => {
-					for (const { content } of cases) {
-						it(`Parse "${showWhitespaceGlyph(content)}"`, () => {
-							const parser = float(option as any)
-							snapshot(testParser(parser, content))
-						})
-					}
-				},
-			)
+			describe(`float(${option.min}, ${option.max}, ${!!option.onOutOfRange})`, () => {
+				for (const { content } of cases) {
+					it(`Parse "${showWhitespaceGlyph(content)}"`, () => {
+						const parser = float(option as any)
+						snapshot(testParser(parser, content))
+					})
+				}
+			})
 		}
 	})
 
 	describe('float(failsOnEmpty = true)', () => {
 		const option: Options = { pattern, failsOnEmpty: true }
-		const cases: { content: string }[] = [{ content: '' }, {
-			content: '7e+3',
-		}]
+		const cases: { content: string }[] = [{ content: '' }, { content: '7e+3' }]
 		for (const { content } of cases) {
 			it(`Parse "${showWhitespaceGlyph(content)}"`, () => {
 				const parser = float(option as any)

--- a/packages/core/test/parser/float.spec.ts
+++ b/packages/core/test/parser/float.spec.ts
@@ -32,8 +32,7 @@ describe('float()', () => {
 				pattern,
 				min: 1,
 				max: 6,
-				onOutOfRange: (ans, _src, ctx) =>
-					ctx.err.report('Testing MESSAGE', ans),
+				onOutOfRange: (ans, _src, ctx) => ctx.err.report('Testing MESSAGE', ans),
 			},
 		]
 		const cases: { content: string }[] = [

--- a/packages/core/test/parser/integer.spec.ts
+++ b/packages/core/test/parser/integer.spec.ts
@@ -44,8 +44,7 @@ describe('integer()', () => {
 				pattern,
 				min: 1,
 				max: 6,
-				onOutOfRange: (ans, _src, ctx) =>
-					ctx.err.report('Test message!', ans),
+				onOutOfRange: (ans, _src, ctx) => ctx.err.report('Test message!', ans),
 			},
 		]
 		const cases: { content: string }[] = [

--- a/packages/core/test/parser/integer.spec.ts
+++ b/packages/core/test/parser/integer.spec.ts
@@ -37,33 +37,22 @@ describe('integer()', () => {
 	})
 
 	describe('integer(min, max, onOutOfRange)', () => {
-		const options: Options[] = [
-			{ pattern, min: 1 },
-			{ pattern, max: 6 },
-			{
-				pattern,
-				min: 1,
-				max: 6,
-				onOutOfRange: (ans, _src, ctx) => ctx.err.report('Test message!', ans),
-			},
-		]
-		const cases: { content: string }[] = [
-			{ content: '0' },
-			{ content: '3' },
-			{ content: '9' },
-		]
+		const options: Options[] = [{ pattern, min: 1 }, { pattern, max: 6 }, {
+			pattern,
+			min: 1,
+			max: 6,
+			onOutOfRange: (ans, _src, ctx) => ctx.err.report('Test message!', ans),
+		}]
+		const cases: { content: string }[] = [{ content: '0' }, { content: '3' }, { content: '9' }]
 		for (const option of options) {
-			describe(
-				`integer(${option.min}, ${option.max}, ${!!option.onOutOfRange})`,
-				() => {
-					for (const { content } of cases) {
-						it(`Parse "${showWhitespaceGlyph(content)}"`, () => {
-							const parser = integer(option as any)
-							snapshot(testParser(parser, content))
-						})
-					}
-				},
-			)
+			describe(`integer(${option.min}, ${option.max}, ${!!option.onOutOfRange})`, () => {
+				for (const { content } of cases) {
+					it(`Parse "${showWhitespaceGlyph(content)}"`, () => {
+						const parser = integer(option as any)
+						snapshot(testParser(parser, content))
+					})
+				}
+			})
 		}
 	})
 })

--- a/packages/core/test/parser/list.spec.ts
+++ b/packages/core/test/parser/list.spec.ts
@@ -7,50 +7,26 @@ import { showWhitespaceGlyph, testParser } from '../utils.js'
 
 describe('list()', () => {
 	const quotedString = string({ quotes: ['"'] })
-	const suites: {
-		title: string
-		options: Options<StringNode>
-		contents: string[]
-	}[] = [
-		{
-			title: 'list(no trailing comma)',
-			options: {
-				start: '[',
-				value: quotedString,
-				sep: ',',
-				trailingSep: false,
-				end: ']',
-			},
-			contents: [
-				'',
-				'[',
-				'[ ]',
-				'[ , ]',
-				'[ , "foo" ]',
-				'[ "foo" ]',
-				'[ "foo" , ]',
-				'[ "foo"   "bar" ]',
-				'[ "foo" , "bar" ]',
-				'[ "foo" , "bar" , ]',
-			],
-		},
-		{
-			title: 'list(trailing comma)',
-			options: {
-				start: '[',
-				value: quotedString,
-				sep: ',',
-				trailingSep: true,
-				end: ']',
-			},
-			contents: [
-				'[ "foo" ]',
-				'[ "foo" , ]',
-				'[ "foo" , "bar" ]',
-				'[ "foo" , "bar" , ]',
-			],
-		},
-	]
+	const suites: { title: string; options: Options<StringNode>; contents: string[] }[] = [{
+		title: 'list(no trailing comma)',
+		options: { start: '[', value: quotedString, sep: ',', trailingSep: false, end: ']' },
+		contents: [
+			'',
+			'[',
+			'[ ]',
+			'[ , ]',
+			'[ , "foo" ]',
+			'[ "foo" ]',
+			'[ "foo" , ]',
+			'[ "foo"   "bar" ]',
+			'[ "foo" , "bar" ]',
+			'[ "foo" , "bar" , ]',
+		],
+	}, {
+		title: 'list(trailing comma)',
+		options: { start: '[', value: quotedString, sep: ',', trailingSep: true, end: ']' },
+		contents: ['[ "foo" ]', '[ "foo" , ]', '[ "foo" , "bar" ]', '[ "foo" , "bar" , ]'],
+	}]
 	for (const { title, options, contents } of suites) {
 		describe(title, () => {
 			for (const content of contents) {

--- a/packages/core/test/parser/long.spec.ts
+++ b/packages/core/test/parser/long.spec.ts
@@ -48,8 +48,7 @@ describe('long()', () => {
 				pattern,
 				min: 1n,
 				max: 6n,
-				onOutOfRange: (ans, _src, ctx) =>
-					ctx.err.report('Test message!', ans),
+				onOutOfRange: (ans, _src, ctx) => ctx.err.report('Test message!', ans),
 			},
 		]
 		const cases: { content: string }[] = [

--- a/packages/core/test/parser/long.spec.ts
+++ b/packages/core/test/parser/long.spec.ts
@@ -41,33 +41,22 @@ describe('long()', () => {
 	})
 
 	describe('long(min, max, onOutOfRange)', () => {
-		const options: Options[] = [
-			{ pattern, min: 1n },
-			{ pattern, max: 6n },
-			{
-				pattern,
-				min: 1n,
-				max: 6n,
-				onOutOfRange: (ans, _src, ctx) => ctx.err.report('Test message!', ans),
-			},
-		]
-		const cases: { content: string }[] = [
-			{ content: '0' },
-			{ content: '3' },
-			{ content: '9' },
-		]
+		const options: Options[] = [{ pattern, min: 1n }, { pattern, max: 6n }, {
+			pattern,
+			min: 1n,
+			max: 6n,
+			onOutOfRange: (ans, _src, ctx) => ctx.err.report('Test message!', ans),
+		}]
+		const cases: { content: string }[] = [{ content: '0' }, { content: '3' }, { content: '9' }]
 		for (const option of options) {
-			describe(
-				`long(${option.min}, ${option.max}, ${!!option.onOutOfRange})`,
-				() => {
-					for (const { content } of cases) {
-						it(`Parse "${showWhitespaceGlyph(content)}"`, () => {
-							const parser = long(option as any)
-							snapshot(testParser(parser, content))
-						})
-					}
-				},
-			)
+			describe(`long(${option.min}, ${option.max}, ${!!option.onOutOfRange})`, () => {
+				for (const { content } of cases) {
+					it(`Parse "${showWhitespaceGlyph(content)}"`, () => {
+						const parser = long(option as any)
+						snapshot(testParser(parser, content))
+					})
+				}
+			})
 		}
 	})
 })

--- a/packages/core/test/parser/record.spec.ts
+++ b/packages/core/test/parser/record.spec.ts
@@ -7,12 +7,8 @@ import { showWhitespaceGlyph, testParser } from '../utils.js'
 
 describe('record()', () => {
 	const quotedString = string({ quotes: ['"'] })
-	const suites: {
-		title: string
-		options: Options<StringNode, StringNode>
-		contents: string[]
-	}[] = [
-		{
+	const suites: { title: string; options: Options<StringNode, StringNode>; contents: string[] }[] =
+		[{
 			title: 'record(no trailing comma)',
 			options: {
 				start: '{',
@@ -42,18 +38,11 @@ describe('record()', () => {
 				'{ "foo" : "bar"   "baz" : "qux" }',
 				'{ "foo" : "bar" , "baz" : "qux" , }',
 			],
-		},
-		{
+		}, {
 			title: 'record(trailing comma)',
 			options: {
 				start: '{',
-				pair: {
-					key: quotedString,
-					sep: ':',
-					value: quotedString,
-					end: ',',
-					trailingEnd: true,
-				},
+				pair: { key: quotedString, sep: ':', value: quotedString, end: ',', trailingEnd: true },
 				end: '}',
 			},
 			contents: [
@@ -62,8 +51,7 @@ describe('record()', () => {
 				'{ "foo" : "bar" , "baz" : "qux" }',
 				'{ "foo" : "bar" , "baz" : "qux" , }',
 			],
-		},
-	]
+		}]
 	for (const { title, options, contents } of suites) {
 		describe(title, () => {
 			for (const content of contents) {

--- a/packages/core/test/parser/resourceLocation.spec.ts
+++ b/packages/core/test/parser/resourceLocation.spec.ts
@@ -25,9 +25,7 @@ describe('resourceLocation()', () => {
 	]
 	for (const { content, options } of suites) {
 		it(
-			`Parse "${
-				showWhitespaceGlyph(content)
-			}" with ${options.category}, ${options.allowTag}`,
+			`Parse "${showWhitespaceGlyph(content)}" with ${options.category}, ${options.allowTag}`,
 			() => {
 				const parser = resourceLocation(options)
 				snapshot(testParser(parser, content))

--- a/packages/core/test/parser/resourceLocation.spec.ts
+++ b/packages/core/test/parser/resourceLocation.spec.ts
@@ -15,10 +15,7 @@ describe('resourceLocation()', () => {
 		{ options: { category: 'function' }, content: ':foo/bar' },
 		{ options: { category: 'function' }, content: 'minecraft:foo/bar' },
 		{ options: { category: 'function' }, content: 'spgoding:foo/bar' },
-		{
-			options: { category: 'function' },
-			content: 'foo # can you stop before here?',
-		},
+		{ options: { category: 'function' }, content: 'foo # can you stop before here?' },
 		{ options: { category: 'function' }, content: 'spg/:foo:qux/H/42' },
 		{ options: { category: 'function', allowTag: true }, content: '#tick' },
 		{ options: { category: 'function', allowTag: false }, content: '#tick' },

--- a/packages/core/test/parser/string.spec.ts
+++ b/packages/core/test/parser/string.spec.ts
@@ -5,60 +5,39 @@ import { BrigadierUnquotableCharacterSet, string } from '../../lib/index.js'
 import { showWhitespaceGlyph, testParser } from '../utils.js'
 
 describe('string()', () => {
-	const suites: {
-		title: string
-		options: StringOptions
-		contents: string[]
-	}[] = [
-		{
-			title: 'quoted_string(", ⧵n⧵t)', // We use ⧵ (U+29f5) instead of normal back slash here, due to the snapshots being stupid and not escaping it before exporting.
-			options: { quotes: ['"'], escapable: { characters: ['n', 't'] } },
-			contents: [
-				'',
-				'"foo',
-				'"foo\n',
-				'"foo"',
-				"'foo'",
-				'"foo\\nbar\\t\\"\\\\qux"',
-				'"foo\\u00a7\\abar"',
-			],
+	const suites: { title: string; options: StringOptions; contents: string[] }[] = [{
+		title: 'quoted_string(", ⧵n⧵t)', // We use ⧵ (U+29f5) instead of normal back slash here, due to the snapshots being stupid and not escaping it before exporting.
+		options: { quotes: ['"'], escapable: { characters: ['n', 't'] } },
+		contents: [
+			'',
+			'"foo',
+			'"foo\n',
+			'"foo"',
+			"'foo'",
+			'"foo\\nbar\\t\\"\\\\qux"',
+			'"foo\\u00a7\\abar"',
+		],
+	}, {
+		title: 'quoted_string(", ⧵u⧵?)',
+		options: { quotes: ['"'], escapable: { characters: [], allowUnknown: true, unicode: true } },
+		contents: ['"foo\\u00a7\\abar"', '"\\uggez"'],
+	}, {
+		title: 'quoted_string(", ⧵?)',
+		options: { quotes: ['"'], escapable: { characters: [], allowUnknown: true } },
+		contents: ['"foo\\u00a7\\abar"'],
+	}, {
+		title: 'unquoted_string()',
+		options: { unquotable: { allowList: BrigadierUnquotableCharacterSet } },
+		contents: ['', 'foo', '$$$', '"foo"'],
+	}, {
+		title: 'quoted_string(quoted_string())',
+		options: {
+			quotes: ['"'],
+			escapable: { allowUnknown: true, unicode: true },
+			value: { type: 'string', parser: string({ quotes: ['"'], escapable: {} }) },
 		},
-		{
-			title: 'quoted_string(", ⧵u⧵?)',
-			options: {
-				quotes: ['"'],
-				escapable: { characters: [], allowUnknown: true, unicode: true },
-			},
-			contents: ['"foo\\u00a7\\abar"', '"\\uggez"'],
-		},
-		{
-			title: 'quoted_string(", ⧵?)',
-			options: {
-				quotes: ['"'],
-				escapable: { characters: [], allowUnknown: true },
-			},
-			contents: ['"foo\\u00a7\\abar"'],
-		},
-		{
-			title: 'unquoted_string()',
-			options: {
-				unquotable: { allowList: BrigadierUnquotableCharacterSet },
-			},
-			contents: ['', 'foo', '$$$', '"foo"'],
-		},
-		{
-			title: 'quoted_string(quoted_string())',
-			options: {
-				quotes: ['"'],
-				escapable: { allowUnknown: true, unicode: true },
-				value: {
-					type: 'string',
-					parser: string({ quotes: ['"'], escapable: {} }),
-				},
-			},
-			contents: ['"foo"', '"\\"\\u0066oo\\\\\\\\bar\\""'],
-		},
-	]
+		contents: ['"foo"', '"\\"\\u0066oo\\\\\\\\bar\\""'],
+	}]
 	for (const { title, options, contents } of suites) {
 		describe(title, () => {
 			for (const content of contents) {

--- a/packages/core/test/parser/util.spec.ts
+++ b/packages/core/test/parser/util.spec.ts
@@ -1,13 +1,7 @@
 import assert from 'assert'
 import { describe, it } from 'mocha'
 import snapshot from 'snap-shot-it'
-import type {
-	AstNode,
-	Parser,
-	ParserContext,
-	Result,
-	Source,
-} from '../../lib/index.js'
+import type { AstNode, Parser, ParserContext, Result, Source } from '../../lib/index.js'
 import {
 	any,
 	boolean,

--- a/packages/core/test/parser/util.spec.ts
+++ b/packages/core/test/parser/util.spec.ts
@@ -23,11 +23,7 @@ interface LiteralNode extends AstNode {
  *
  * `Failure` when it does not encounter the `literal`.
  */
-function literal(
-	literal: string,
-	meta?: string,
-	errorAmount = 0,
-): Parser<LiteralNode> {
+function literal(literal: string, meta?: string, errorAmount = 0): Parser<LiteralNode> {
 	return (src: Source, ctx: ParserContext): Result<LiteralNode> => {
 		const ans: LiteralNode = {
 			type: 'literal',
@@ -51,21 +47,9 @@ describe('any()', () => {
 		parsers: [Parser<AstNode>, ...Parser<AstNode>[]]
 		parserToString: string
 	}[] = [
-		{
-			parsers: [literal('foo'), literal('bar')],
-			content: 'foo',
-			parserToString: 'foo | bar',
-		},
-		{
-			parsers: [literal('foo'), literal('bar')],
-			content: 'bar',
-			parserToString: 'foo | bar',
-		},
-		{
-			parsers: [literal('foo'), literal('bar')],
-			content: 'qux',
-			parserToString: 'foo | bar',
-		},
+		{ parsers: [literal('foo'), literal('bar')], content: 'foo', parserToString: 'foo | bar' },
+		{ parsers: [literal('foo'), literal('bar')], content: 'bar', parserToString: 'foo | bar' },
+		{ parsers: [literal('foo'), literal('bar')], content: 'qux', parserToString: 'foo | bar' },
 		{
 			parsers: [literal('foo', 'correct', 1), literal('foo', 'wrong', 1)],
 			content: 'foo',
@@ -83,37 +67,23 @@ describe('any()', () => {
 		},
 	]
 	for (const { content, parsers, parserToString } of suites) {
-		it(
-			`Parse "${
-				showWhitespaceGlyph(
-					content,
-				)
-			}" with "${parserToString}"`,
-			() => {
-				const parser = any(parsers)
-				snapshot(testParser(parser, content))
-			},
-		)
+		it(`Parse "${showWhitespaceGlyph(content)}" with "${parserToString}"`, () => {
+			const parser = any(parsers)
+			snapshot(testParser(parser, content))
+		})
 	}
 })
 
 describe('dumpErrors()', () => {
-	const suites: {
-		name: string
-		parser: Parser<AstNode>
-		content: string
-	}[] = [
-		{
-			name: 'should output errors when not wrapped with `dumpErrors()`',
-			parser: boolean,
-			content: 'bar',
-		},
-		{
-			name: 'should not output errors when wrapped with `dumpErrors()`',
-			parser: dumpErrors(boolean),
-			content: 'bar',
-		},
-	]
+	const suites: { name: string; parser: Parser<AstNode>; content: string }[] = [{
+		name: 'should output errors when not wrapped with `dumpErrors()`',
+		parser: boolean,
+		content: 'bar',
+	}, {
+		name: 'should not output errors when wrapped with `dumpErrors()`',
+		parser: dumpErrors(boolean),
+		content: 'bar',
+	}]
 	for (const { name, content, parser } of suites) {
 		it(name, () => {
 			snapshot(testParser(parser, content))
@@ -122,39 +92,29 @@ describe('dumpErrors()', () => {
 })
 
 describe('concatOnTrailingBackslash()', () => {
-	const parsers: {
-		parser: Parser<AstNode>
-		suites: Array<{
-			content: string
-		}>
-	}[] = [
-		{
-			parser: boolean,
-			suites: [
-				{ content: 'true' },
-				{ content: 'true\n' },
-				{ content: 'tru\\\ne' },
-				{ content: 'tru\\ \ne' },
-				{ content: 'tru\\\n e' },
-				{ content: 'tru\\ \n e' },
-				{ content: 'tru\\ \n \\\n e' },
-				{ content: 'tru\\e \\ \n e' },
-				{ content: 'tru\\\n\ne' },
-				{ content: 'tru\\' },
-				{ content: 'tru\\ \n' },
-				{ content: 'tru\\ \n ' },
-			],
-		},
-	]
+	const parsers: { parser: Parser<AstNode>; suites: Array<{ content: string }> }[] = [{
+		parser: boolean,
+		suites: [
+			{ content: 'true' },
+			{ content: 'true\n' },
+			{ content: 'tru\\\ne' },
+			{ content: 'tru\\ \ne' },
+			{ content: 'tru\\\n e' },
+			{ content: 'tru\\ \n e' },
+			{ content: 'tru\\ \n \\\n e' },
+			{ content: 'tru\\e \\ \n e' },
+			{ content: 'tru\\\n\ne' },
+			{ content: 'tru\\' },
+			{ content: 'tru\\ \n' },
+			{ content: 'tru\\ \n ' },
+		],
+	}]
 	for (const { parser, suites } of parsers) {
 		for (const { content } of suites) {
-			it(
-				`Parse "${showWhitespaceGlyph(content)}"`,
-				() => {
-					const wrappedParser = concatOnTrailingBackslash(parser)
-					snapshot(testParser(wrappedParser, content))
-				},
-			)
+			it(`Parse "${showWhitespaceGlyph(content)}"`, () => {
+				const wrappedParser = concatOnTrailingBackslash(parser)
+				snapshot(testParser(wrappedParser, content))
+			})
 		}
 	}
 })

--- a/packages/core/test/processor/ColorInfoProvider.spec.ts
+++ b/packages/core/test/processor/ColorInfoProvider.spec.ts
@@ -29,12 +29,7 @@ describe('Color', () => {
 			snapshot(Color.fromCompositeInt(0xffaa55))
 		})
 		it('Should return white for negative number', () => {
-			assert.deepStrictEqual(Color.fromCompositeInt(-1), [
-				1.0,
-				1.0,
-				1.0,
-				1.0,
-			])
+			assert.deepStrictEqual(Color.fromCompositeInt(-1), [1.0, 1.0, 1.0, 1.0])
 		})
 	})
 })

--- a/packages/core/test/processor/binder/builtin.spec.ts
+++ b/packages/core/test/processor/binder/builtin.spec.ts
@@ -22,32 +22,20 @@ typing('binder builtin.ts', () => {
 	typing('attempt', () => {
 		const { attempt } = binder
 		assertType<AttemptResult>(attempt(booleanSyncBinder, booleanNode, ctx))
-		assertType<Promise<AttemptResult>>(
-			attempt(booleanAsyncBinder, booleanNode, ctx),
-		)
+		assertType<Promise<AttemptResult>>(attempt(booleanAsyncBinder, booleanNode, ctx))
 	})
 
 	typing('any', () => {
 		const { any } = binder
 		assertType<SyncBinder<BooleanNode>>(any([booleanSyncBinder]))
-		assertType<SyncBinder<BooleanNode>>(
-			any([booleanSyncBinder, booleanSyncBinder]),
-		)
-		assertType<SyncBinder<BooleanNode | StringNode>>(
-			any([booleanSyncBinder, stringSyncBinder]),
-		)
+		assertType<SyncBinder<BooleanNode>>(any([booleanSyncBinder, booleanSyncBinder]))
+		assertType<SyncBinder<BooleanNode | StringNode>>(any([booleanSyncBinder, stringSyncBinder]))
 		assertType<AsyncBinder<BooleanNode>>(any([booleanAsyncBinder]))
-		assertType<AsyncBinder<BooleanNode>>(
-			any([booleanAsyncBinder, booleanAsyncBinder]),
-		)
-		assertType<AsyncBinder<BooleanNode>>(
-			any([booleanAsyncBinder, booleanSyncBinder]),
-		)
+		assertType<AsyncBinder<BooleanNode>>(any([booleanAsyncBinder, booleanAsyncBinder]))
+		assertType<AsyncBinder<BooleanNode>>(any([booleanAsyncBinder, booleanSyncBinder]))
 		assertType<AsyncBinder<BooleanNode | StringNode>>(
 			any([booleanAsyncBinder, stringAsyncBinder]),
 		)
-		assertType<AsyncBinder<BooleanNode | StringNode>>(
-			any([booleanAsyncBinder, stringSyncBinder]),
-		)
+		assertType<AsyncBinder<BooleanNode | StringNode>>(any([booleanAsyncBinder, stringSyncBinder]))
 	})
 })

--- a/packages/core/test/processor/colorizer/Colorizer.spec.ts
+++ b/packages/core/test/processor/colorizer/Colorizer.spec.ts
@@ -5,45 +5,34 @@ import { showWhitespaceGlyph } from '../../utils.js'
 
 describe('ColorToken', () => {
 	describe('fillGap()', () => {
-		const suites: {
-			title: string
-			sourceTokens: ColorToken[]
-			targetRange: Range
-		}[] = [
-			{
-				// 000000000011111111112
-				// 012345678901234567890
-				title: '"/kill @a"',
-				sourceTokens: [
-					ColorToken.create(Range.create(6, 11), 'keyword'),
-					ColorToken.create(Range.create(12, 14), 'literal'),
-				],
-				targetRange: Range.create(5, 15),
-			},
-			{
-				// 000000000011111111112
-				// 012345678901234567890
-				title: '"foo:qux"',
-				sourceTokens: [
-					ColorToken.create(Range.create(6, 13), 'resourceLocation'),
-				],
-				targetRange: Range.create(5, 14),
-			},
-			{
-				// 000000000011111111112
-				// 012345678901234567890
-				title: 'bar',
-				sourceTokens: [ColorToken.create(Range.create(5, 8), 'keyword')],
-				targetRange: Range.create(6, 7),
-			},
-			{
-				// 000000000011111111112
-				// 012345678901234567890
-				title: '',
-				sourceTokens: [],
-				targetRange: Range.create(0, 20),
-			},
-		]
+		const suites: { title: string; sourceTokens: ColorToken[]; targetRange: Range }[] = [{
+			// 000000000011111111112
+			// 012345678901234567890
+			title: '"/kill @a"',
+			sourceTokens: [
+				ColorToken.create(Range.create(6, 11), 'keyword'),
+				ColorToken.create(Range.create(12, 14), 'literal'),
+			],
+			targetRange: Range.create(5, 15),
+		}, {
+			// 000000000011111111112
+			// 012345678901234567890
+			title: '"foo:qux"',
+			sourceTokens: [ColorToken.create(Range.create(6, 13), 'resourceLocation')],
+			targetRange: Range.create(5, 14),
+		}, {
+			// 000000000011111111112
+			// 012345678901234567890
+			title: 'bar',
+			sourceTokens: [ColorToken.create(Range.create(5, 8), 'keyword')],
+			targetRange: Range.create(6, 7),
+		}, {
+			// 000000000011111111112
+			// 012345678901234567890
+			title: '',
+			sourceTokens: [],
+			targetRange: Range.create(0, 20),
+		}]
 		for (const { title, sourceTokens, targetRange } of suites) {
 			it(`Fill for “${showWhitespaceGlyph(title)}”`, () => {
 				snapshot(ColorToken.fillGap(sourceTokens, targetRange, 'string'))

--- a/packages/core/test/processor/util.spec.ts
+++ b/packages/core/test/processor/util.spec.ts
@@ -6,61 +6,31 @@ import { Range, traversePreOrder } from '../../lib/index.js'
 const TestNode: AstNode = {
 	type: 'not_leaf_1',
 	range: Range.create(0, 10),
-	children: [
-		{
-			type: 'leaf_1',
-			range: Range.create(0, 5),
-		},
-		{
-			type: 'not_leaf_2',
-			range: Range.create(5, 10),
-			children: [
-				{
-					type: 'not_leaf_3',
-					range: Range.create(5, 8),
-					children: [
-						{
-							type: 'leaf_2',
-							range: Range.create(5, 6),
-						},
-						{
-							type: 'leaf_3',
-							range: Range.create(6, 8),
-						},
-					],
-				},
-				{
-					type: 'leaf_4',
-					range: Range.create(9, 10),
-				},
-			],
-		},
-	],
+	children: [{ type: 'leaf_1', range: Range.create(0, 5) }, {
+		type: 'not_leaf_2',
+		range: Range.create(5, 10),
+		children: [{
+			type: 'not_leaf_3',
+			range: Range.create(5, 8),
+			children: [{ type: 'leaf_2', range: Range.create(5, 6) }, {
+				type: 'leaf_3',
+				range: Range.create(6, 8),
+			}],
+		}, { type: 'leaf_4', range: Range.create(9, 10) }],
+	}],
 }
 
 const DiscontinuousTestNode: AstNode = {
 	type: 'not_leaf_1',
 	range: Range.create(0, 10),
-	children: [
-		{
-			type: 'not_leaf_2',
-			range: Range.create(0, 6),
-			children: [
-				{
-					type: 'leaf_1',
-					range: Range.create(0, 2),
-				},
-				{
-					type: 'leaf_2',
-					range: Range.create(4, 6),
-				},
-			],
-		},
-		{
-			type: 'not_leaf_4',
-			range: Range.create(9, 10),
-		},
-	],
+	children: [{
+		type: 'not_leaf_2',
+		range: Range.create(0, 6),
+		children: [{ type: 'leaf_1', range: Range.create(0, 2) }, {
+			type: 'leaf_2',
+			range: Range.create(4, 6),
+		}],
+	}, { type: 'not_leaf_4', range: Range.create(9, 10) }],
 }
 
 describe('processor/util.ts', () => {
@@ -70,11 +40,7 @@ describe('processor/util.ts', () => {
 				TestNode,
 				(_) => true,
 				(node) => node.type === 'leaf_1' || node.type === 'not_leaf_3',
-				(node, parents) =>
-					snapshot({
-						node: node.type,
-						parents: parents.map((p) => p.type),
-					}),
+				(node, parents) => snapshot({ node: node.type, parents: parents.map((p) => p.type) }),
 			)
 		})
 	})

--- a/packages/core/test/service/ErrorReporter.spec.ts
+++ b/packages/core/test/service/ErrorReporter.spec.ts
@@ -26,11 +26,7 @@ describe('ErrorReporter', () => {
 			err.report('Error message 2', Range.Beginning, ErrorSeverity.Warning)
 			const tmpErr = new ErrorReporter()
 			tmpErr.report('Error message 3', Range.Beginning)
-			tmpErr.report(
-				'Error message 4',
-				Range.Beginning,
-				ErrorSeverity.Warning,
-			)
+			tmpErr.report('Error message 4', Range.Beginning, ErrorSeverity.Warning)
 			err.absorb(tmpErr)
 			snapshot(err)
 			snapshot(tmpErr)

--- a/packages/core/test/service/fileUtil.spec.ts
+++ b/packages/core/test/service/fileUtil.spec.ts
@@ -4,17 +4,11 @@ import { fileUtil } from '../../lib/index.js'
 
 describe('fileUtil', () => {
 	describe('getRelativeUriFromBase()', () => {
-		const bases: string[] = [
-			'file:///c%3A/Users/admin/',
-			'file:///c:/Users/admin/',
-		]
+		const bases: string[] = ['file:///c%3A/Users/admin/', 'file:///c:/Users/admin/']
 		const suites: { uri: string; expected: string | undefined }[] = [
 			{ uri: 'file:///c%3A/Users/admin/', expected: '' },
 			{ uri: 'file:///c%3A/Users/admin/foo.mcdoc', expected: 'foo.mcdoc' },
-			{
-				uri: 'file:///c%3A/Users/admin/foo/bar.mcdoc',
-				expected: 'foo/bar.mcdoc',
-			},
+			{ uri: 'file:///c%3A/Users/admin/foo/bar.mcdoc', expected: 'foo/bar.mcdoc' },
 			{ uri: 'file:///c:/Users/admin/', expected: '' },
 			{ uri: 'file:///c:/Users/admin/foo.mcdoc', expected: 'foo.mcdoc' },
 			{
@@ -22,19 +16,13 @@ describe('fileUtil', () => {
 				uri: 'file:///c://///Users///admin//foo.mcdoc',
 				expected: 'foo.mcdoc',
 			},
-			{
-				uri: 'file:///c:/Users/admin/foo/bar.mcdoc',
-				expected: 'foo/bar.mcdoc',
-			},
+			{ uri: 'file:///c:/Users/admin/foo/bar.mcdoc', expected: 'foo/bar.mcdoc' },
 			{ uri: 'file:///qux.mcdoc', expected: undefined },
 		]
 		for (const { uri, expected } of suites) {
 			for (const base of bases) {
 				it(`Should return '${expected}' for '${uri}' when base is '${base}'`, () => {
-					assert.strictEqual(
-						fileUtil.getRelativeUriFromBase(uri, base),
-						expected,
-					)
+					assert.strictEqual(fileUtil.getRelativeUriFromBase(uri, base), expected)
 				})
 			}
 		}
@@ -54,11 +42,7 @@ describe('fileUtil', () => {
 		}
 	})
 	describe('getRel()', () => {
-		const rootUris: `${string}/`[] = [
-			'file:///root1/subdir/',
-			'file:///root1/',
-			'file:///root2/',
-		]
+		const rootUris: `${string}/`[] = ['file:///root1/subdir/', 'file:///root1/', 'file:///root2/']
 		const suites: { uri: string; expected: string | undefined }[] = [
 			{ uri: 'file:///root1/subdir/foo.mcdoc', expected: 'foo.mcdoc' },
 			{ uri: 'file:///root1/foo.mcdoc', expected: 'foo.mcdoc' },
@@ -73,10 +57,10 @@ describe('fileUtil', () => {
 		}
 	})
 	describe('ensureEndingSlash()', () => {
-		const suites: { uri: string; expected: string }[] = [
-			{ uri: 'file:///root1/foo', expected: 'file:///root1/foo/' },
-			{ uri: 'file:///root1/foo/', expected: 'file:///root1/foo/' },
-		]
+		const suites: { uri: string; expected: string }[] = [{
+			uri: 'file:///root1/foo',
+			expected: 'file:///root1/foo/',
+		}, { uri: 'file:///root1/foo/', expected: 'file:///root1/foo/' }]
 		for (const { uri, expected } of suites) {
 			it(`Should return '${expected}' for '${uri}'`, () => {
 				assert.strictEqual(fileUtil.ensureEndingSlash(uri), expected)
@@ -84,28 +68,23 @@ describe('fileUtil', () => {
 		}
 	})
 	describe('join()', () => {
-		const suites: { fromUri: string; toUri: string; expected: string }[] = [
-			{
-				fromUri: 'file:///root1/foo',
-				toUri: 'bar.mcdoc',
-				expected: 'file:///root1/foo/bar.mcdoc',
-			},
-			{
-				fromUri: 'file:///root1/foo/',
-				toUri: 'bar.mcdoc',
-				expected: 'file:///root1/foo/bar.mcdoc',
-			},
-			{
-				fromUri: 'file:///root1/foo',
-				toUri: '/bar.mcdoc',
-				expected: 'file:///root1/foo/bar.mcdoc',
-			},
-			{
-				fromUri: 'file:///root1/foo/',
-				toUri: '/bar.mcdoc',
-				expected: 'file:///root1/foo/bar.mcdoc',
-			},
-		]
+		const suites: { fromUri: string; toUri: string; expected: string }[] = [{
+			fromUri: 'file:///root1/foo',
+			toUri: 'bar.mcdoc',
+			expected: 'file:///root1/foo/bar.mcdoc',
+		}, {
+			fromUri: 'file:///root1/foo/',
+			toUri: 'bar.mcdoc',
+			expected: 'file:///root1/foo/bar.mcdoc',
+		}, {
+			fromUri: 'file:///root1/foo',
+			toUri: '/bar.mcdoc',
+			expected: 'file:///root1/foo/bar.mcdoc',
+		}, {
+			fromUri: 'file:///root1/foo/',
+			toUri: '/bar.mcdoc',
+			expected: 'file:///root1/foo/bar.mcdoc',
+		}]
 		for (const { fromUri, toUri, expected } of suites) {
 			it(`Should join '${fromUri}' and '${toUri}' to '${expected}'`, () => {
 				assert.strictEqual(fileUtil.join(fromUri, toUri), expected)
@@ -113,10 +92,10 @@ describe('fileUtil', () => {
 		}
 	})
 	describe('isFileUri()', () => {
-		const suites: { uri: string; expected: boolean }[] = [
-			{ uri: 'file:///root1/foo.mcdoc', expected: true },
-			{ uri: 'spyglassmc:///root1/foo.mcdoc', expected: false },
-		]
+		const suites: { uri: string; expected: boolean }[] = [{
+			uri: 'file:///root1/foo.mcdoc',
+			expected: true,
+		}, { uri: 'spyglassmc:///root1/foo.mcdoc', expected: false }]
 		for (const { uri, expected } of suites) {
 			it(`Should return '${expected}' for '${uri}'`, () => {
 				assert.strictEqual(fileUtil.isFileUri(uri), expected)

--- a/packages/core/test/source/IndexMap.spec.ts
+++ b/packages/core/test/source/IndexMap.spec.ts
@@ -11,11 +11,10 @@ describe('IndexMap', () => {
 		 * Outer      -             "foo\"bar\u00a7qux"
 		 * Inner      - foo"bar§qux
 		 */
-		const map: IndexMap = [
-			{ outer: Range.create(13, 13), inner: Range.create(0, 0) },
-			{ outer: Range.create(16, 18), inner: Range.create(3, 4) },
-			{ outer: Range.create(21, 27), inner: Range.create(7, 8) },
-		]
+		const map: IndexMap = [{ outer: Range.create(13, 13), inner: Range.create(0, 0) }, {
+			outer: Range.create(16, 18),
+			inner: Range.create(3, 4),
+		}, { outer: Range.create(21, 27), inner: Range.create(7, 8) }]
 		const toInnerCases: { input: number; expected: number }[] = [
 			{ input: 13, expected: 0 },
 			{ input: 14, expected: 1 },
@@ -75,14 +74,11 @@ describe('IndexMap', () => {
 			 * Middle     - helloworld::"foo\"bar\u00a7qux"
 			 * Inner      - foo"bar§qux
 			 */
-			const outerMap: IndexMap = [
-				{ inner: Range.create(0, 0), outer: Range.create(8, 8) },
-			]
-			const innerMap: IndexMap = [
-				{ inner: Range.create(0, 0), outer: Range.create(13, 13) },
-				{ inner: Range.create(3, 4), outer: Range.create(16, 18) },
-				{ inner: Range.create(7, 8), outer: Range.create(21, 27) },
-			]
+			const outerMap: IndexMap = [{ inner: Range.create(0, 0), outer: Range.create(8, 8) }]
+			const innerMap: IndexMap = [{ inner: Range.create(0, 0), outer: Range.create(13, 13) }, {
+				inner: Range.create(3, 4),
+				outer: Range.create(16, 18),
+			}, { inner: Range.create(7, 8), outer: Range.create(21, 27) }]
 			const mergedMap = IndexMap.merge(outerMap, innerMap)
 			snapshot(mergedMap)
 		})
@@ -103,11 +99,10 @@ describe('IndexMap', () => {
 				{ inner: Range.create(20, 21), outer: Range.create(32, 34) },
 				{ inner: Range.create(21, 22), outer: Range.create(34, 36) },
 			]
-			const innerMap: IndexMap = [
-				{ inner: Range.create(0, 0), outer: Range.create(11, 11) },
-				{ inner: Range.create(4, 5), outer: Range.create(15, 17) },
-				{ inner: Range.create(7, 8), outer: Range.create(19, 21) },
-			]
+			const innerMap: IndexMap = [{ inner: Range.create(0, 0), outer: Range.create(11, 11) }, {
+				inner: Range.create(4, 5),
+				outer: Range.create(15, 17),
+			}, { inner: Range.create(7, 8), outer: Range.create(19, 21) }]
 			const mergedMap = IndexMap.merge(outerMap, innerMap)
 			snapshot(mergedMap)
 		})
@@ -121,41 +116,25 @@ describe('IndexMap', () => {
 			 * Outer      - foo\"bar\u00a7qux
 			 * Inner      - foo"bar§qux
 			 */
-			const indexMap = [
-				{ inner: Range.create(3, 4), outer: Range.create(3, 5) },
-				{ inner: Range.create(7, 8), outer: Range.create(8, 14) },
-			]
+			const indexMap = [{ inner: Range.create(3, 4), outer: Range.create(3, 5) }, {
+				inner: Range.create(7, 8),
+				outer: Range.create(8, 14),
+			}]
 			const toInnerCases = [
-				{
-					input: Range.create(0, 1),
-					expected: Range.create(0, 1),
-					name: '`f` -> `f`',
-				},
-				{
-					input: Range.create(3, 5),
-					expected: Range.create(3, 4),
-					name: '`\\"` -> `"`',
-				},
+				{ input: Range.create(0, 1), expected: Range.create(0, 1), name: '`f` -> `f`' },
+				{ input: Range.create(3, 5), expected: Range.create(3, 4), name: '`\\"` -> `"`' },
 				{ // (shifted left)
 					input: Range.create(7, 8),
 					expected: Range.create(6, 7),
 					name: '`r` -> `r`',
 				},
-				{
-					input: Range.create(8, 14),
-					expected: Range.create(7, 8),
-					name: '`\\u00a7` -> `§`',
-				},
+				{ input: Range.create(8, 14), expected: Range.create(7, 8), name: '`\\u00a7` -> `§`' },
 				{
 					input: Range.create(7, 14),
 					expected: Range.create(6, 8),
 					name: '`r\\u00a7` -> `r§`',
 				},
-				{
-					input: Range.create(7, 12),
-					expected: Range.create(6, 7),
-					name: '`r\\u00` -> `r`',
-				},
+				{ input: Range.create(7, 12), expected: Range.create(6, 7), name: '`r\\u00` -> `r`' },
 				{
 					input: Range.create(7, 15),
 					expected: Range.create(6, 9),
@@ -163,26 +142,14 @@ describe('IndexMap', () => {
 				},
 			]
 			const toOuterCases = [
-				{
-					input: Range.create(0, 1),
-					expected: Range.create(0, 1),
-					name: '`f` -> `f`',
-				},
-				{
-					input: Range.create(3, 4),
-					expected: Range.create(3, 5),
-					name: '`"` -> `"`',
-				},
+				{ input: Range.create(0, 1), expected: Range.create(0, 1), name: '`f` -> `f`' },
+				{ input: Range.create(3, 4), expected: Range.create(3, 5), name: '`"` -> `"`' },
 				{ // (shifted right)
 					input: Range.create(6, 7),
 					expected: Range.create(7, 8),
 					name: '`r` -> `r`',
 				},
-				{
-					input: Range.create(7, 8),
-					expected: Range.create(8, 14),
-					name: '`§` -> `\\u00a7`',
-				},
+				{ input: Range.create(7, 8), expected: Range.create(8, 14), name: '`§` -> `\\u00a7`' },
 				{
 					input: Range.create(6, 8),
 					expected: Range.create(7, 14),

--- a/packages/core/test/source/LanguageError.spec.ts
+++ b/packages/core/test/source/LanguageError.spec.ts
@@ -6,22 +6,11 @@ describe('LanguageError', () => {
 	describe('create()', () => {
 		it('Should create correctly', () => {
 			snapshot(LanguageError.create('Error message', Range.Beginning))
+			snapshot(LanguageError.create('Error message', Range.Beginning, ErrorSeverity.Warning))
 			snapshot(
-				LanguageError.create(
-					'Error message',
-					Range.Beginning,
-					ErrorSeverity.Warning,
-				),
-			)
-			snapshot(
-				LanguageError.create(
-					'Error message',
-					Range.Beginning,
-					ErrorSeverity.Warning,
-					{
-						deprecated: true,
-					},
-				),
+				LanguageError.create('Error message', Range.Beginning, ErrorSeverity.Warning, {
+					deprecated: true,
+				}),
 			)
 		})
 	})

--- a/packages/core/test/source/Location.spec.ts
+++ b/packages/core/test/source/Location.spec.ts
@@ -10,12 +10,7 @@ describe('Location', () => {
 			snapshot(Location.get({}))
 			snapshot(Location.get({ uri: 'file:///home/spgoding/test' }))
 			snapshot(Location.get({ range: Range.create(1, 2) }))
-			snapshot(
-				Location.get({
-					uri: 'file:///home/spgoding/test',
-					range: Range.create(1, 2),
-				}),
-			)
+			snapshot(Location.get({ uri: 'file:///home/spgoding/test', range: Range.create(1, 2) }))
 			snapshot(
 				Location.get({
 					uri: 'file:///home/spgoding/test',
@@ -29,20 +24,12 @@ describe('Location', () => {
 			const result = Location.get(incoming)
 			incoming.range = Range.create(9, 9)
 
-			assert.deepStrictEqual(
-				result,
-				Location.get({ range: Range.create(1, 2) }),
-			)
+			assert.deepStrictEqual(result, Location.get({ range: Range.create(1, 2) }))
 		})
 	})
 	describe('create()', () => {
 		it('Should create correctly', () => {
-			const doc = TextDocument.create(
-				'file:///home/spgoding/test',
-				'mcdoc',
-				0,
-				'01234567890',
-			)
+			const doc = TextDocument.create('file:///home/spgoding/test', 'mcdoc', 0, '01234567890')
 			snapshot(Location.create(doc, Range.create(5, 6)))
 			snapshot(Location.create(doc, { range: Range.create(7, 8) }))
 			snapshot(Location.create(doc, 9))

--- a/packages/core/test/source/Position.spec.ts
+++ b/packages/core/test/source/Position.spec.ts
@@ -26,41 +26,28 @@ describe('Position', () => {
 			assert.strictEqual(Position.toString(Position.Beginning), '<0, 0>')
 		})
 		it('Should work for Infinity', () => {
-			assert.strictEqual(
-				Position.toString(Position.Infinity),
-				'<Infinity, Infinity>',
-			)
+			assert.strictEqual(Position.toString(Position.Infinity), '<Infinity, Infinity>')
 		})
 	})
 	describe('isBefore()', () => {
 		const pos2 = Position.create(4, 2)
-		const suites: { name: string; pos1: Position; expected: boolean }[] = [
-			{
-				name: 'positions before the line',
-				pos1: Position.create(3, 5),
-				expected: true,
-			},
-			{
-				name: 'positions within the line and before the character',
-				pos1: Position.create(4, 1),
-				expected: true,
-			},
-			{
-				name: 'positions within the line and at the character',
-				pos1: Position.create(4, 2),
-				expected: false,
-			},
-			{
-				name: 'positions within the line and after the character',
-				pos1: Position.create(4, 3),
-				expected: false,
-			},
-			{
-				name: 'positions after the line',
-				pos1: Position.create(5, 1),
-				expected: false,
-			},
-		]
+		const suites: { name: string; pos1: Position; expected: boolean }[] = [{
+			name: 'positions before the line',
+			pos1: Position.create(3, 5),
+			expected: true,
+		}, {
+			name: 'positions within the line and before the character',
+			pos1: Position.create(4, 1),
+			expected: true,
+		}, {
+			name: 'positions within the line and at the character',
+			pos1: Position.create(4, 2),
+			expected: false,
+		}, {
+			name: 'positions within the line and after the character',
+			pos1: Position.create(4, 3),
+			expected: false,
+		}, { name: 'positions after the line', pos1: Position.create(5, 1), expected: false }]
 		for (const { name, pos1, expected } of suites) {
 			it(`Should return ${expected} for ${name}`, () => {
 				const actual = Position.isBefore(pos1, pos2)

--- a/packages/core/test/source/PositionRange.spec.ts
+++ b/packages/core/test/source/PositionRange.spec.ts
@@ -7,17 +7,12 @@ describe('PositionRange', () => {
 	describe('create()', () => {
 		it('Should create correctly', () => {
 			snapshot(PositionRange.create(1, 2, 3, 4))
-			snapshot(
-				PositionRange.create(Position.create(1, 2), Position.create(3, 4)),
-			)
+			snapshot(PositionRange.create(Position.create(1, 2), Position.create(3, 4)))
 			snapshot(PositionRange.create({}))
 			snapshot(PositionRange.create({ start: Position.create(1, 2) }))
 			snapshot(PositionRange.create({ end: Position.create(3, 4) }))
 			snapshot(
-				PositionRange.create({
-					start: Position.create(1, 2),
-					end: Position.create(3, 4),
-				}),
+				PositionRange.create({ start: Position.create(1, 2), end: Position.create(3, 4) }),
 			)
 		})
 		it('Should create a new object from the passed-in Range', () => {
@@ -31,10 +26,7 @@ describe('PositionRange', () => {
 	})
 	describe('toString()', () => {
 		it('Should work for regular numbers', () => {
-			assert.strictEqual(
-				PositionRange.toString(PositionRange.Beginning),
-				'[<0, 0>, <0, 1>)',
-			)
+			assert.strictEqual(PositionRange.toString(PositionRange.Beginning), '[<0, 0>, <0, 1>)')
 		})
 		it('Should work for Infinity', () => {
 			assert.strictEqual(
@@ -45,37 +37,27 @@ describe('PositionRange', () => {
 	})
 	describe('endsBefore()', () => {
 		const pos = Position.create(4, 2)
-		const suites: {
-			name: string
-			range: PositionRange
-			expected: boolean
-		}[] = [
-			{
-				name: 'ranges ending before the line',
-				range: PositionRange.create(0, 0, 3, 5),
-				expected: true,
-			},
-			{
-				name: 'ranges ending within the line and before the character',
-				range: PositionRange.create(0, 0, 4, 1),
-				expected: true,
-			},
-			{
-				name: 'ranges ending within the line and at the character',
-				range: PositionRange.create(0, 0, 4, 2),
-				expected: true,
-			},
-			{
-				name: 'ranges ending within the line and after the character',
-				range: PositionRange.create(0, 0, 4, 3),
-				expected: false,
-			},
-			{
-				name: 'ranges ending after the line',
-				range: PositionRange.create(0, 0, 5, 1),
-				expected: false,
-			},
-		]
+		const suites: { name: string; range: PositionRange; expected: boolean }[] = [{
+			name: 'ranges ending before the line',
+			range: PositionRange.create(0, 0, 3, 5),
+			expected: true,
+		}, {
+			name: 'ranges ending within the line and before the character',
+			range: PositionRange.create(0, 0, 4, 1),
+			expected: true,
+		}, {
+			name: 'ranges ending within the line and at the character',
+			range: PositionRange.create(0, 0, 4, 2),
+			expected: true,
+		}, {
+			name: 'ranges ending within the line and after the character',
+			range: PositionRange.create(0, 0, 4, 3),
+			expected: false,
+		}, {
+			name: 'ranges ending after the line',
+			range: PositionRange.create(0, 0, 5, 1),
+			expected: false,
+		}]
 		for (const { name, range, expected } of suites) {
 			it(`Should return ${expected} for ${name}`, () => {
 				const actual = PositionRange.endsBefore(range, pos)
@@ -84,41 +66,37 @@ describe('PositionRange', () => {
 		}
 	})
 	describe('contains()', () => {
-		const suites = [
-			{
-				range: PositionRange.create(1, 2, 1, 4),
-				cases: [
-					{ pos: Position.create(0, 3), expected: false },
-					{ pos: Position.create(1, 1), expected: false },
-					{ pos: Position.create(1, 2), expected: true },
-					{ pos: Position.create(1, 3), expected: true },
-					{ pos: Position.create(1, 4), expected: false },
-					{ pos: Position.create(2, 3), expected: false },
-				],
-			},
-			{
-				range: PositionRange.create(1, 2, 3, 4),
-				cases: [
-					{ pos: Position.create(0, 3), expected: false },
-					{ pos: Position.create(1, 1), expected: false },
-					{ pos: Position.create(1, 2), expected: true },
-					{ pos: Position.create(1, 3), expected: true },
-					{ pos: Position.create(1, 4), expected: true },
-					{ pos: Position.create(1, 5), expected: true },
-					{ pos: Position.create(2, Infinity), expected: true },
-					{ pos: Position.create(3, 1), expected: true },
-					{ pos: Position.create(3, 2), expected: true },
-					{ pos: Position.create(3, 3), expected: true },
-					{ pos: Position.create(3, 4), expected: false },
-					{ pos: Position.create(3, 5), expected: false },
-					{ pos: Position.create(4, 3), expected: false },
-				],
-			},
-			{
-				range: PositionRange.Full,
-				cases: [{ pos: Position.create(4, 2), expected: true }],
-			},
-		] as const
+		const suites = [{
+			range: PositionRange.create(1, 2, 1, 4),
+			cases: [
+				{ pos: Position.create(0, 3), expected: false },
+				{ pos: Position.create(1, 1), expected: false },
+				{ pos: Position.create(1, 2), expected: true },
+				{ pos: Position.create(1, 3), expected: true },
+				{ pos: Position.create(1, 4), expected: false },
+				{ pos: Position.create(2, 3), expected: false },
+			],
+		}, {
+			range: PositionRange.create(1, 2, 3, 4),
+			cases: [
+				{ pos: Position.create(0, 3), expected: false },
+				{ pos: Position.create(1, 1), expected: false },
+				{ pos: Position.create(1, 2), expected: true },
+				{ pos: Position.create(1, 3), expected: true },
+				{ pos: Position.create(1, 4), expected: true },
+				{ pos: Position.create(1, 5), expected: true },
+				{ pos: Position.create(2, Infinity), expected: true },
+				{ pos: Position.create(3, 1), expected: true },
+				{ pos: Position.create(3, 2), expected: true },
+				{ pos: Position.create(3, 3), expected: true },
+				{ pos: Position.create(3, 4), expected: false },
+				{ pos: Position.create(3, 5), expected: false },
+				{ pos: Position.create(4, 3), expected: false },
+			],
+		}, {
+			range: PositionRange.Full,
+			cases: [{ pos: Position.create(4, 2), expected: true }],
+		}] as const
 		for (const { range, cases } of suites) {
 			describe(`range ${PositionRange.toString(range)}`, () => {
 				for (const { pos, expected } of cases) {

--- a/packages/core/test/source/Range.spec.ts
+++ b/packages/core/test/source/Range.spec.ts
@@ -79,21 +79,9 @@ describe('Range', () => {
 	describe('endsBefore()', () => {
 		const offset = 2
 		const suites: { name: string; range: Range; expected: boolean }[] = [
-			{
-				name: 'ranges ending before the offset',
-				range: Range.create(0, 1),
-				expected: true,
-			},
-			{
-				name: 'ranges ending at the offset',
-				range: Range.create(0, 2),
-				expected: true,
-			},
-			{
-				name: 'ranges ending after the offset',
-				range: Range.create(0, 3),
-				expected: false,
-			},
+			{ name: 'ranges ending before the offset', range: Range.create(0, 1), expected: true },
+			{ name: 'ranges ending at the offset', range: Range.create(0, 2), expected: true },
+			{ name: 'ranges ending after the offset', range: Range.create(0, 3), expected: false },
 		]
 		for (const { name, range, expected } of suites) {
 			it(`Should return ${expected} for ${name}`, () => {
@@ -110,31 +98,20 @@ describe('Range', () => {
 		})
 	})
 	describe('contains()', () => {
-		const suites = [
-			{
-				range: Range.create(1, 2),
-				cases: [
-					{ offset: 0, expected: false },
-					{ offset: 1, expected: true },
-					{ offset: 2, expected: false },
-					{ offset: 3, expected: false },
-				],
-			},
-			{
-				endInclusive: true,
-				range: Range.create(1, 2),
-				cases: [
-					{ offset: 0, expected: false },
-					{ offset: 1, expected: true },
-					{ offset: 2, expected: true },
-					{ offset: 3, expected: false },
-				],
-			},
-			{
-				range: Range.Full,
-				cases: [{ offset: 4, expected: true }],
-			},
-		] as {
+		const suites = [{
+			range: Range.create(1, 2),
+			cases: [{ offset: 0, expected: false }, { offset: 1, expected: true }, {
+				offset: 2,
+				expected: false,
+			}, { offset: 3, expected: false }],
+		}, {
+			endInclusive: true,
+			range: Range.create(1, 2),
+			cases: [{ offset: 0, expected: false }, { offset: 1, expected: true }, {
+				offset: 2,
+				expected: true,
+			}, { offset: 3, expected: false }],
+		}, { range: Range.Full, cases: [{ offset: 4, expected: true }] }] as {
 			range: Range
 			cases: { offset: number; expected: boolean }[]
 			endInclusive?: boolean
@@ -151,29 +128,23 @@ describe('Range', () => {
 		}
 	})
 	describe('intersects()', () => {
-		const suites = [
-			{
-				baseRange: Range.create(1, 3),
-				cases: [
-					{ range: Range.create(0, 1), expected: false },
-					{ range: Range.create(1, 1), expected: true },
-					{ range: Range.create(0, 2), expected: true },
-					{ range: Range.create(1, 2), expected: true },
-					{ range: Range.create(2, 2), expected: true },
-					{ range: Range.create(1, 3), expected: true },
-					{ range: Range.create(2, 3), expected: true },
-					{ range: Range.create(3, 3), expected: false },
-					{ range: Range.create(1, 4), expected: true },
-					{ range: Range.create(2, 4), expected: true },
-					{ range: Range.create(3, 4), expected: false },
-					{ range: Range.create(4, 4), expected: false },
-				],
-			},
-			{
-				baseRange: Range.Full,
-				cases: [{ range: Range.create(4, 4), expected: true }],
-			},
-		] as const
+		const suites = [{
+			baseRange: Range.create(1, 3),
+			cases: [
+				{ range: Range.create(0, 1), expected: false },
+				{ range: Range.create(1, 1), expected: true },
+				{ range: Range.create(0, 2), expected: true },
+				{ range: Range.create(1, 2), expected: true },
+				{ range: Range.create(2, 2), expected: true },
+				{ range: Range.create(1, 3), expected: true },
+				{ range: Range.create(2, 3), expected: true },
+				{ range: Range.create(3, 3), expected: false },
+				{ range: Range.create(1, 4), expected: true },
+				{ range: Range.create(2, 4), expected: true },
+				{ range: Range.create(3, 4), expected: false },
+				{ range: Range.create(4, 4), expected: false },
+			],
+		}, { baseRange: Range.Full, cases: [{ range: Range.create(4, 4), expected: true }] }] as const
 		for (const { baseRange, cases } of suites) {
 			describe(`intersects ${Range.toString(baseRange)}`, () => {
 				for (const { range, expected } of cases) {
@@ -219,16 +190,10 @@ describe('RangeContainer', () => {
 			assert.strictEqual(RangeContainer.is({ start: 1, end: 1 }), false)
 		})
 		it('Should return false for keys with wrong type', () => {
-			assert.strictEqual(
-				RangeContainer.is({ range: { start: undefined, end: 1 } }),
-				false,
-			)
+			assert.strictEqual(RangeContainer.is({ range: { start: undefined, end: 1 } }), false)
 		})
 		it('Should return true for range container', () => {
-			assert.strictEqual(
-				RangeContainer.is({ range: { start: 1, end: 1 } }),
-				true,
-			)
+			assert.strictEqual(RangeContainer.is({ range: { start: 1, end: 1 } }), true)
 		})
 	})
 })

--- a/packages/core/test/source/Source.spec.ts
+++ b/packages/core/test/source/Source.spec.ts
@@ -14,18 +14,13 @@ describe('Source', () => {
 		 */
 		const indexMapSuite = {
 			string: 'foo"bar§qux', // from: foo\"bar\u00a7qux
-			indexMap: [
-				{ inner: Range.create(3, 4), outer: Range.create(3, 5) },
-				{ inner: Range.create(7, 8), outer: Range.create(8, 14) },
-			],
+			indexMap: [{ inner: Range.create(3, 4), outer: Range.create(3, 5) }, {
+				inner: Range.create(7, 8),
+				outer: Range.create(8, 14),
+			}],
 		}
 
-		const suites: {
-			string: string
-			cursor: number
-			expected: Range
-			indexMap?: IndexMap
-		}[] = [
+		const suites: { string: string; cursor: number; expected: Range; indexMap?: IndexMap }[] = [
 			{ string: 'foo', cursor: 0, expected: Range.create(0, 1) },
 			{ string: 'foo', cursor: 1, expected: Range.create(1, 2) },
 			{ string: 'foo', cursor: 2, expected: Range.create(2, 3) },
@@ -57,12 +52,7 @@ describe('Source', () => {
 		})
 	})
 	describe('canRead()', () => {
-		const suites: {
-			string: string
-			cursor: number
-			step?: number
-			expected: boolean
-		}[] = [
+		const suites: { string: string; cursor: number; step?: number; expected: boolean }[] = [
 			{ string: 'fo', cursor: 0, step: 1, expected: true },
 			{ string: 'fo', cursor: 0, step: 2, expected: true },
 			{ string: 'fo', cursor: 0, step: 3, expected: false },
@@ -72,12 +62,7 @@ describe('Source', () => {
 		]
 		for (const { string, cursor, step, expected } of suites) {
 			it(
-				`Should return ${expected} for ${
-					markOffsetInString(
-						string,
-						cursor,
-					)
-				} with step ${step}`,
+				`Should return ${expected} for ${markOffsetInString(string, cursor)} with step ${step}`,
 				() => {
 					const src = new Source(string)
 					src.cursor = cursor
@@ -98,20 +83,12 @@ describe('Source', () => {
 			{ string: 'fo\nbar', cursor: 6, expected: false },
 		]
 		for (const { string, cursor, expected } of suites) {
-			it(
-				`Should return ${expected} for ${
-					markOffsetInString(
-						string,
-						cursor,
-					)
-				}`,
-				() => {
-					const src = new Source(string)
-					src.cursor = cursor
-					const actual = src.canReadInLine()
-					assert.strictEqual(actual, expected)
-				},
-			)
+			it(`Should return ${expected} for ${markOffsetInString(string, cursor)}`, () => {
+				const src = new Source(string)
+				src.cursor = cursor
+				const actual = src.canReadInLine()
+				assert.strictEqual(actual, expected)
+			})
 		}
 	})
 	describe('peek()', () => {
@@ -122,25 +99,13 @@ describe('Source', () => {
 			offset?: number
 			expected: string
 		}[] = [
-			{
-				string: 'fo',
-				cursor: 0,
-				length: 1,
-				offset: undefined,
-				expected: 'f',
-			},
+			{ string: 'fo', cursor: 0, length: 1, offset: undefined, expected: 'f' },
 			{ string: 'fo', cursor: 0, length: 1, offset: 0, expected: 'f' },
 			{ string: 'fo', cursor: 0, length: 1, offset: 1, expected: 'o' },
 			{ string: 'fo', cursor: 0, length: 1, offset: 2, expected: '' },
 			{ string: 'fo', cursor: 1, length: 1, offset: 0, expected: 'o' },
 			{ string: 'fo', cursor: 1, length: 1, offset: 1, expected: '' },
-			{
-				string: 'fo',
-				cursor: 0,
-				length: undefined,
-				offset: 0,
-				expected: 'f',
-			},
+			{ string: 'fo', cursor: 0, length: undefined, offset: 0, expected: 'f' },
 			{ string: 'fo', cursor: 0, length: 0, offset: 0, expected: '' },
 			{ string: 'fo', cursor: 0, length: 2, offset: 0, expected: 'fo' },
 			{ string: 'fo', cursor: 0, length: 3, offset: 0, expected: 'fo' },
@@ -148,10 +113,7 @@ describe('Source', () => {
 		for (const { string, cursor, length, offset, expected } of suites) {
 			it(
 				`Should return '${expected}' for ${
-					markOffsetInString(
-						string,
-						cursor,
-					)
+					markOffsetInString(string, cursor)
 				} with offset ${offset}`,
 				() => {
 					const src = new Source(string)
@@ -171,30 +133,17 @@ describe('Source', () => {
 			{ string: 'qux', cursor: 3, expected: '' },
 		]
 		for (const { string, cursor, expected } of suites) {
-			it(
-				`Should return '${expected}' at ${
-					markOffsetInString(
-						string,
-						cursor,
-					)
-				}`,
-				() => {
-					const src = new Source(string)
-					src.cursor = cursor
-					const actual = src.read()
-					assert.strictEqual(actual, expected)
-					assert.strictEqual(src.cursor, cursor + 1)
-				},
-			)
+			it(`Should return '${expected}' at ${markOffsetInString(string, cursor)}`, () => {
+				const src = new Source(string)
+				src.cursor = cursor
+				const actual = src.read()
+				assert.strictEqual(actual, expected)
+				assert.strictEqual(src.cursor, cursor + 1)
+			})
 		}
 	})
 	describe('skip()', () => {
-		const suites: {
-			string: string
-			cursor: number
-			step?: number
-			expectedCursor: number
-		}[] = [
+		const suites: { string: string; cursor: number; step?: number; expectedCursor: number }[] = [
 			{ string: 'qux', cursor: 0, step: 0, expectedCursor: 0 },
 			{ string: 'qux', cursor: 0, step: undefined, expectedCursor: 1 },
 			{ string: 'qux', cursor: 0, step: 1, expectedCursor: 1 },
@@ -203,16 +152,8 @@ describe('Source', () => {
 		]
 		for (const { string, cursor, step, expectedCursor } of suites) {
 			it(
-				`Should skip from ${
-					markOffsetInString(
-						string,
-						cursor,
-					)
-				} to ${
-					markOffsetInString(
-						string,
-						expectedCursor,
-					)
+				`Should skip from ${markOffsetInString(string, cursor)} to ${
+					markOffsetInString(string, expectedCursor)
 				} with step ${step}`,
 				() => {
 					const src = new Source(string)
@@ -241,28 +182,16 @@ describe('Source', () => {
 			{ string: 'qux\nfoobar', cursor: 4, expected: 'foobar' },
 		]
 		for (const { string, cursor, expected } of suites) {
-			it(
-				`Should return '${expected}' for ${
-					markOffsetInString(
-						string,
-						cursor,
-					)
-				}`,
-				() => {
-					const src = new Source(string)
-					src.cursor = cursor
-					const actual = src.readLine()
-					assert.strictEqual(actual, expected)
-				},
-			)
+			it(`Should return '${expected}' for ${markOffsetInString(string, cursor)}`, () => {
+				const src = new Source(string)
+				src.cursor = cursor
+				const actual = src.readLine()
+				assert.strictEqual(actual, expected)
+			})
 		}
 	})
 	describe('skipLine()', () => {
-		const suites: {
-			string: string
-			cursor: number
-			expectedCursor: number
-		}[] = [
+		const suites: { string: string; cursor: number; expectedCursor: number }[] = [
 			{ string: 'qux', cursor: 0, expectedCursor: 3 },
 			{ string: 'qux\nfoobar', cursor: 0, expectedCursor: 3 },
 			{ string: 'qux\rfoobar', cursor: 0, expectedCursor: 3 },
@@ -272,12 +201,9 @@ describe('Source', () => {
 		]
 		for (const { string, cursor, expectedCursor } of suites) {
 			it(
-				`Should skip from ${
-					markOffsetInString(
-						string,
-						cursor,
-					)
-				} to ${markOffsetInString(string, expectedCursor)}`,
+				`Should skip from ${markOffsetInString(string, cursor)} to ${
+					markOffsetInString(string, expectedCursor)
+				}`,
 				() => {
 					const src = new Source(string)
 					src.cursor = cursor
@@ -289,11 +215,7 @@ describe('Source', () => {
 		}
 	})
 	describe('nextLine()', () => {
-		const suites: {
-			string: string
-			cursor: number
-			expectedCursor: number
-		}[] = [
+		const suites: { string: string; cursor: number; expectedCursor: number }[] = [
 			{ string: 'qux', cursor: 0, expectedCursor: 3 },
 			{ string: 'qux\nfoobar', cursor: 0, expectedCursor: 4 },
 			{ string: 'qux\rfoobar', cursor: 0, expectedCursor: 4 },
@@ -304,12 +226,9 @@ describe('Source', () => {
 		]
 		for (const { string, cursor, expectedCursor } of suites) {
 			it(
-				`Should skip from ${
-					markOffsetInString(
-						string,
-						cursor,
-					)
-				} to ${markOffsetInString(string, expectedCursor)}`,
+				`Should skip from ${markOffsetInString(string, cursor)} to ${
+					markOffsetInString(string, expectedCursor)
+				}`,
 				() => {
 					const src = new Source(string)
 					src.cursor = cursor
@@ -328,11 +247,9 @@ describe('Source', () => {
 		]
 		for (const { string, cursor, expected } of suites) {
 			it(
-				`Should return '${
-					showWhitespaceGlyph(
-						expected,
-					)
-				}' for ${markOffsetInString(string, cursor)}`,
+				`Should return '${showWhitespaceGlyph(expected)}' for ${
+					markOffsetInString(string, cursor)
+				}`,
 				() => {
 					const src = new Source(string)
 					src.cursor = cursor
@@ -343,23 +260,16 @@ describe('Source', () => {
 		}
 	})
 	describe('skipSpace()', () => {
-		const suites: {
-			string: string
-			cursor: number
-			expectedCursor: number
-		}[] = [
+		const suites: { string: string; cursor: number; expectedCursor: number }[] = [
 			{ string: 'foo', cursor: 0, expectedCursor: 0 },
 			{ string: ' \tF', cursor: 0, expectedCursor: 2 },
 			{ string: ' \t', cursor: 0, expectedCursor: 2 },
 		]
 		for (const { string, cursor, expectedCursor } of suites) {
 			it(
-				`Should skip from ${
-					markOffsetInString(
-						string,
-						cursor,
-					)
-				} to ${markOffsetInString(string, expectedCursor)}`,
+				`Should skip from ${markOffsetInString(string, cursor)} to ${
+					markOffsetInString(string, expectedCursor)
+				}`,
 				() => {
 					const src = new Source(string)
 					src.cursor = cursor
@@ -378,11 +288,9 @@ describe('Source', () => {
 		]
 		for (const { string, cursor, expected } of suites) {
 			it(
-				`Should return ${
-					showWhitespaceGlyph(
-						expected,
-					)
-				} for ${markOffsetInString(string, cursor)}`,
+				`Should return ${showWhitespaceGlyph(expected)} for ${
+					markOffsetInString(string, cursor)
+				}`,
 				() => {
 					const src = new Source(string)
 					src.cursor = cursor
@@ -393,23 +301,16 @@ describe('Source', () => {
 		}
 	})
 	describe('skipWhitespace()', () => {
-		const suites: {
-			string: string
-			cursor: number
-			expectedCursor: number
-		}[] = [
+		const suites: { string: string; cursor: number; expectedCursor: number }[] = [
 			{ string: 'foo', cursor: 0, expectedCursor: 0 },
 			{ string: ' \t\r\nF', cursor: 0, expectedCursor: 4 },
 			{ string: ' \t\r\n', cursor: 0, expectedCursor: 4 },
 		]
 		for (const { string, cursor, expectedCursor } of suites) {
 			it(
-				`Should skip from ${
-					markOffsetInString(
-						string,
-						cursor,
-					)
-				} to ${markOffsetInString(string, expectedCursor)}`,
+				`Should skip from ${markOffsetInString(string, cursor)} to ${
+					markOffsetInString(string, expectedCursor)
+				}`,
 				() => {
 					const src = new Source(string)
 					src.cursor = cursor
@@ -431,10 +332,7 @@ describe('Source', () => {
 		for (const { string, cursor, expected } of suites) {
 			it(
 				`Should return '${expected}' for ${
-					markOffsetInString(
-						string,
-						cursor,
-					)
+					markOffsetInString(string, cursor)
 				} when reading until '$'`,
 				() => {
 					const src = new Source(string)
@@ -453,11 +351,9 @@ describe('Source', () => {
 		]
 		for (const { string, cursor, expected } of suites) {
 			it(
-				`Should return ${
-					showWhitespaceGlyph(
-						expected,
-					)
-				} for ${markOffsetInString(string, cursor)}`,
+				`Should return ${showWhitespaceGlyph(expected)} for ${
+					markOffsetInString(string, cursor)
+				}`,
 				() => {
 					const src = new Source(string)
 					src.cursor = cursor
@@ -468,23 +364,16 @@ describe('Source', () => {
 		}
 	})
 	describe('skipUntilLineEnd()', () => {
-		const suites: {
-			string: string
-			cursor: number
-			expectedCursor: number
-		}[] = [
+		const suites: { string: string; cursor: number; expectedCursor: number }[] = [
 			{ string: 'foo', cursor: 0, expectedCursor: 3 },
 			{ string: ' \t\r\n', cursor: 0, expectedCursor: 2 },
 			{ string: 'foo\nbar', cursor: 4, expectedCursor: 7 },
 		]
 		for (const { string, cursor, expectedCursor } of suites) {
 			it(
-				`Should skip from ${
-					markOffsetInString(
-						string,
-						cursor,
-					)
-				} to ${markOffsetInString(string, expectedCursor)}`,
+				`Should skip from ${markOffsetInString(string, cursor)} to ${
+					markOffsetInString(string, expectedCursor)
+				}`,
 				() => {
 					const src = new Source(string)
 					src.cursor = cursor
@@ -496,22 +385,16 @@ describe('Source', () => {
 		}
 	})
 	describe('skipRemaining()', () => {
-		const suites: {
-			string: string
-			cursor: number
-			expectedCursor: number
-		}[] = [
-			{ string: 'foo', cursor: 0, expectedCursor: 3 },
-			{ string: 'foo bar baz qux', cursor: 2, expectedCursor: 15 },
-		]
+		const suites: { string: string; cursor: number; expectedCursor: number }[] = [{
+			string: 'foo',
+			cursor: 0,
+			expectedCursor: 3,
+		}, { string: 'foo bar baz qux', cursor: 2, expectedCursor: 15 }]
 		for (const { string, cursor, expectedCursor } of suites) {
 			it(
-				`Should skip from ${
-					markOffsetInString(
-						string,
-						cursor,
-					)
-				} to ${markOffsetInString(string, expectedCursor)}`,
+				`Should skip from ${markOffsetInString(string, cursor)} to ${
+					markOffsetInString(string, expectedCursor)
+				}`,
 				() => {
 					const src = new Source(string)
 					src.cursor = cursor
@@ -523,12 +406,7 @@ describe('Source', () => {
 		}
 	})
 	describe('hasNonSpaceAheadInLine', () => {
-		const suites: {
-			string: string
-			cursor: number
-			offset?: number
-			expected: boolean
-		}[] = [
+		const suites: { string: string; cursor: number; offset?: number; expected: boolean }[] = [
 			{ string: 'foo', cursor: 0, expected: true },
 			{ string: 'foo', cursor: 2, expected: true },
 			{ string: 'foo', cursor: 3, expected: false },
@@ -552,11 +430,10 @@ describe('Source', () => {
 	})
 	describe('static', () => {
 		describe('isBrigadierQuote()', () => {
-			const suites: { c: string; expected: boolean }[] = [
-				{ c: ' ', expected: false },
-				{ c: '"', expected: true },
-				{ c: "'", expected: true },
-			]
+			const suites: { c: string; expected: boolean }[] = [{ c: ' ', expected: false }, {
+				c: '"',
+				expected: true,
+			}, { c: "'", expected: true }]
 			for (const { c, expected } of suites) {
 				it(`Should return ${expected} for '${showWhitespaceGlyph(c)}'`, () => {
 					const actual = Source.isBrigadierQuote(c)

--- a/packages/core/test/symbol/SymbolUtil.spec.ts
+++ b/packages/core/test/symbol/SymbolUtil.spec.ts
@@ -73,8 +73,7 @@ describe('SymbolUtil', () => {
 			.member('Bar', (member) =>
 				member
 					.enter({ usage: { type: 'definition' } })
-					.member('Qux', (member) =>
-						member.enter({ usage: { type: 'definition' } })))
+					.member('Qux', (member) => member.enter({ usage: { type: 'definition' } })))
 		// const stackSymbols = new SymbolUtil({}, NodeJsExternals.event.EventEmitter)
 		// stackSymbols
 		// 	.query(fileUri, 'advancement', 'Foo')
@@ -139,8 +138,7 @@ describe('SymbolUtil', () => {
 					.member('Bar', (member) =>
 						member
 							.enter({ usage: { type: 'definition' } })
-							.member('Qux', (member) =>
-								member.enter({ usage: { type: 'definition' } })))
+							.member('Qux', (member) => member.enter({ usage: { type: 'definition' } })))
 
 				const query = symbols.query(fileUri, 'advancement', ...path)
 

--- a/packages/core/test/symbol/SymbolUtil.spec.ts
+++ b/packages/core/test/symbol/SymbolUtil.spec.ts
@@ -11,12 +11,10 @@ describe('SymbolUtil', () => {
 		it('Should execute correctly', () => {
 			const symbols = new SymbolUtil({}, NodeJsExternals.event.EventEmitter)
 			symbols.contributeAs('uri_binder', () => {
-				symbols
-					.query(fileUri, 'test', 'Bound')
-					.enter({
-						data: { desc: 'This symbol is URI bound.' },
-						usage: {},
-					})
+				symbols.query(fileUri, 'test', 'Bound').enter({
+					data: { desc: 'This symbol is URI bound.' },
+					usage: {},
+				})
 			})
 			snapshot(SymbolFormatter.stringifySymbolTable(symbols.global))
 		})
@@ -25,39 +23,31 @@ describe('SymbolUtil', () => {
 		it('Should clear all', () => {
 			// Set up the symbol table.
 			const global: SymbolTable = {}
-			const symbols = new SymbolUtil(
-				global,
-				NodeJsExternals.event.EventEmitter,
-			)
-			symbols
-				.query(fileUri, 'mcdoc', 'ShouldBeKept1')
-				.enter({ usage: { type: 'definition' } })
+			const symbols = new SymbolUtil(global, NodeJsExternals.event.EventEmitter)
+			symbols.query(fileUri, 'mcdoc', 'ShouldBeKept1').enter({ usage: { type: 'definition' } })
 				.member('ShouldBeRemoved1', (memberQuery) => {
 					memberQuery.enter({ usage: { type: 'definition' } })
-				})
-				.member('ShouldBeKept2', (memberQuery) => {
+				}).member('ShouldBeKept2', (memberQuery) => {
 					memberQuery.enter({ usage: { type: 'definition' } })
 				})
-			symbols
-				.query(anotherFileUri, 'mcdoc', 'ShouldBeKept1', 'ShouldBeKept2')
-				.enter({ usage: { type: 'definition' } })
-			symbols
-				.query(anotherFileUri, 'mcdoc', 'ShouldBeKept3')
-				.enter({ usage: { type: 'definition' } })
-				.member('ShouldBeKept4', (memberQuery) => {
+			symbols.query(anotherFileUri, 'mcdoc', 'ShouldBeKept1', 'ShouldBeKept2').enter({
+				usage: { type: 'definition' },
+			})
+			symbols.query(anotherFileUri, 'mcdoc', 'ShouldBeKept3').enter({
+				usage: { type: 'definition' },
+			}).member('ShouldBeKept4', (memberQuery) => {
+				memberQuery.enter({ usage: { type: 'definition' } })
+			}).member('ShouldBeKept5', (memberQuery) => {
+				memberQuery.enter({ usage: { type: 'definition' } })
+			})
+			symbols.query(fileUri, 'mcdoc', 'ShouldBeKept3').member(
+				'ShouldBeRemoved3',
+				(memberQuery) => {
 					memberQuery.enter({ usage: { type: 'definition' } })
-				})
-				.member('ShouldBeKept5', (memberQuery) => {
-					memberQuery.enter({ usage: { type: 'definition' } })
-				})
-			symbols
-				.query(fileUri, 'mcdoc', 'ShouldBeKept3')
-				.member('ShouldBeRemoved3', (memberQuery) => {
-					memberQuery.enter({ usage: { type: 'definition' } })
-				})
-				.member('ShouldBeKept5', (memberQuery) => {
-					memberQuery.enter({ usage: { type: 'definition' } })
-				})
+				},
+			).member('ShouldBeKept5', (memberQuery) => {
+				memberQuery.enter({ usage: { type: 'definition' } })
+			})
 			snapshot(SymbolFormatter.stringifySymbolTable(symbols.global))
 
 			symbols.clear({ uri: fileUri })
@@ -67,13 +57,14 @@ describe('SymbolUtil', () => {
 	describe('lookup()', () => {
 		// Set up the symbol table.
 		const symbols = new SymbolUtil({}, NodeJsExternals.event.EventEmitter)
-		symbols
-			.query(fileUri, 'advancement', 'Foo')
-			.enter({ usage: { type: 'definition' } })
-			.member('Bar', (member) =>
-				member
-					.enter({ usage: { type: 'definition' } })
-					.member('Qux', (member) => member.enter({ usage: { type: 'definition' } })))
+		symbols.query(fileUri, 'advancement', 'Foo').enter({ usage: { type: 'definition' } }).member(
+			'Bar',
+			(member) =>
+				member.enter({ usage: { type: 'definition' } }).member(
+					'Qux',
+					(member) => member.enter({ usage: { type: 'definition' } }),
+				),
+		)
 		// const stackSymbols = new SymbolUtil({}, NodeJsExternals.event.EventEmitter)
 		// stackSymbols
 		// 	.query(fileUri, 'advancement', 'Foo')
@@ -128,17 +119,16 @@ describe('SymbolUtil', () => {
 		]
 		for (const path of paths) {
 			it(`Should return correctly for “${path.join('.')}”`, () => {
-				const symbols = new SymbolUtil(
-					{},
-					NodeJsExternals.event.EventEmitter,
-				)
-				symbols
-					.query(fileUri, 'advancement', 'Foo')
-					.enter({ usage: { type: 'definition' } })
-					.member('Bar', (member) =>
-						member
-							.enter({ usage: { type: 'definition' } })
-							.member('Qux', (member) => member.enter({ usage: { type: 'definition' } })))
+				const symbols = new SymbolUtil({}, NodeJsExternals.event.EventEmitter)
+				symbols.query(fileUri, 'advancement', 'Foo').enter({ usage: { type: 'definition' } })
+					.member(
+						'Bar',
+						(member) =>
+							member.enter({ usage: { type: 'definition' } }).member(
+								'Qux',
+								(member) => member.enter({ usage: { type: 'definition' } }),
+							),
+					)
 
 				const query = symbols.query(fileUri, 'advancement', ...path)
 

--- a/packages/core/test/utils.ts
+++ b/packages/core/test/utils.ts
@@ -53,8 +53,7 @@ export function mockProjectData(data: Partial<ProjectData> = {}): ProjectData {
 	const cacheRoot: RootUriString = data.cacheRoot ?? 'file:///cache/'
 	const externals = data.externals ?? NodeJsExternals
 	const logger = data.logger ?? Logger.create()
-	const downloader = data.downloader
-		?? new Downloader(cacheRoot, externals, logger)
+	const downloader = data.downloader ?? new Downloader(cacheRoot, externals, logger)
 	return {
 		cacheRoot,
 		config: data.config ?? VanillaConfig,
@@ -77,11 +76,7 @@ export function mockProjectData(data: Partial<ProjectData> = {}): ProjectData {
  * @returns The string with `\t`, `\r`, `\n`, and `\\` replaced with non-special characters.
  */
 export function showWhitespaceGlyph(string: string) {
-	return string
-		.replace(/\t/g, '⮀')
-		.replace(/\r/g, '←')
-		.replace(/\n/g, '↓')
-		.replace(/\\/g, '⧵') // We replace normal back slashes with ⧵ (U+29f5) here, due to the snapshots being stupid and not escaping them before exporting.
+	return string.replace(/\t/g, '⮀').replace(/\r/g, '←').replace(/\n/g, '↓').replace(/\\/g, '⧵') // We replace normal back slashes with ⧵ (U+29f5) here, due to the snapshots being stupid and not escaping them before exporting.
 }
 
 export function markOffsetInString(string: string, offset: number) {
@@ -138,10 +133,7 @@ export function testParser(
 		removeTopLevelChildren?: boolean
 		simplifySymbol?: boolean
 	} = {},
-): {
-	node: Returnable | 'FAILURE'
-	errors: readonly LanguageError[]
-} {
+): { node: Returnable | 'FAILURE'; errors: readonly LanguageError[] } {
 	/* eslint-enable @typescript-eslint/indent */
 	const src = new Source(text)
 	const ctx = ParserContext.create(mockProjectData(project), {
@@ -149,19 +141,10 @@ export function testParser(
 	})
 	const result: any = parser(src, ctx)
 	if (!noNodeReturn) {
-		removeExtraProperties(
-			result,
-			keepOptions,
-			removeTopLevelChildren,
-			simplifySymbol,
-		)
+		removeExtraProperties(result, keepOptions, removeTopLevelChildren, simplifySymbol)
 	}
 	return {
-		node: result === Failure
-			? 'FAILURE'
-			: result === undefined
-			? 'undefined'
-			: result,
+		node: result === Failure ? 'FAILURE' : result === undefined ? 'undefined' : result,
 		errors: ctx.err.dump(),
 	}
 }
@@ -185,10 +168,7 @@ export function assertType<T>(_value: T): void {
 	)
 }
 
-export function assertError(
-	fn: () => void,
-	errorCallback: (e: unknown) => void = () => {},
-) {
+export function assertError(fn: () => void, errorCallback: (e: unknown) => void = () => {}) {
 	try {
 		fn()
 		fail('Expected an error to be thrown.')
@@ -197,24 +177,15 @@ export function assertError(
 	}
 }
 
-export function snapshotWithUri({
-	specName,
-	uri,
-	value,
-}: {
-	specName: string
-	uri: URL
-	value: {}
-}): void {
+export function snapshotWithUri(
+	{ specName, uri, value }: { specName: string; uri: URL; value: {} },
+): void {
 	snapshotCore({
 		what: value,
 		file: fileURLToPath(uri),
 		specName,
 		ext: '.spec.js',
-		opts: {
-			sortSnapshots: true,
-			useRelativePath: true,
-		},
+		opts: { sortSnapshots: true, useRelativePath: true },
 	})
 }
 
@@ -229,10 +200,7 @@ export class SimpleProject {
 	readonly #global: SymbolTable = Object.create(null)
 	#nodes: Record<string, FileNode<AstNode>> = Object.create(null)
 
-	readonly #symbols = new SymbolUtil(
-		this.#global,
-		NodeJsExternals.event.EventEmitter,
-	)
+	readonly #symbols = new SymbolUtil(this.#global, NodeJsExternals.event.EventEmitter)
 
 	#hasDumped = false
 
@@ -268,12 +236,7 @@ export class SimpleProject {
 		for (const { uri, content } of this.files) {
 			const src = new Source(content)
 			const ctx = ParserContext.create(this.projectData, {
-				doc: TextDocument.create(
-					uri,
-					uri.slice(uri.lastIndexOf('.') + 1),
-					0,
-					content,
-				),
+				doc: TextDocument.create(uri, uri.slice(uri.lastIndexOf('.') + 1), 0, content),
 			})
 			const node = file()(src, ctx)
 			this.#nodes[uri] = node
@@ -338,9 +301,7 @@ export class SimpleProject {
 	public dumpState<T extends keyof SimpleProjectState>(
 		keys: readonly T[],
 	): Pick<SimpleProjectState, T>
-	public dumpState(
-		keys: readonly (keyof SimpleProjectState)[],
-	): Partial<SimpleProjectState> {
+	public dumpState(keys: readonly (keyof SimpleProjectState)[]): Partial<SimpleProjectState> {
 		this.#hasDumped = true
 
 		for (const node of Object.values(this.#nodes)) {
@@ -348,11 +309,8 @@ export class SimpleProject {
 		}
 
 		return {
-			...(keys.includes('colorTokens')
-				&& { colorTokens: this.#colorTokens }),
-			...(keys.includes('global') && {
-				global: SymbolTable.unlink(this.#global),
-			}),
+			...(keys.includes('colorTokens') && { colorTokens: this.#colorTokens }),
+			...(keys.includes('global') && { global: SymbolTable.unlink(this.#global) }),
 			...(keys.includes('nodes') && { nodes: this.#nodes }),
 		}
 	}

--- a/packages/core/test/utils.ts
+++ b/packages/core/test/utils.ts
@@ -53,8 +53,8 @@ export function mockProjectData(data: Partial<ProjectData> = {}): ProjectData {
 	const cacheRoot: RootUriString = data.cacheRoot ?? 'file:///cache/'
 	const externals = data.externals ?? NodeJsExternals
 	const logger = data.logger ?? Logger.create()
-	const downloader = data.downloader ??
-		new Downloader(cacheRoot, externals, logger)
+	const downloader = data.downloader
+		?? new Downloader(cacheRoot, externals, logger)
 	return {
 		cacheRoot,
 		config: data.config ?? VanillaConfig,
@@ -348,8 +348,8 @@ export class SimpleProject {
 		}
 
 		return {
-			...(keys.includes('colorTokens') &&
-				{ colorTokens: this.#colorTokens }),
+			...(keys.includes('colorTokens')
+				&& { colorTokens: this.#colorTokens }),
 			...(keys.includes('global') && {
 				global: SymbolTable.unlink(this.#global),
 			}),

--- a/packages/discord-bot/src/index.ts
+++ b/packages/discord-bot/src/index.ts
@@ -148,9 +148,9 @@ async function loadConfig(): Promise<Config> {
 	const config = (await fileUtil.readJson(NodeJsExternals, path)) as Config
 	if (
 		!(
-			typeof config.clientId === 'string' &&
-			typeof config.guildId === 'string' &&
-			typeof config.token === 'string'
+			typeof config.clientId === 'string'
+			&& typeof config.guildId === 'string'
+			&& typeof config.token === 'string'
 		)
 	) {
 		throw new Error(`Bad config: ${JSON.stringify(config)}`)

--- a/packages/discord-bot/src/index.ts
+++ b/packages/discord-bot/src/index.ts
@@ -4,11 +4,7 @@ import {
 	SlashCommandStringOption,
 } from '@discordjs/builders'
 import { REST } from '@discordjs/rest'
-import type {
-	ColorToken,
-	ColorTokenType,
-	LanguageError,
-} from '@spyglassmc/core'
+import type { ColorToken, ColorTokenType, LanguageError } from '@spyglassmc/core'
 import {
 	ConfigService,
 	ErrorSeverity,
@@ -24,13 +20,7 @@ import * as je from '@spyglassmc/java-edition'
 import * as mcdoc from '@spyglassmc/mcdoc'
 import { Routes } from 'discord-api-types/rest/v9'
 import type { Snowflake } from 'discord.js'
-import {
-	Client,
-	Intents,
-	MessageActionRow,
-	MessageButton,
-	MessageEmbed,
-} from 'discord.js'
+import { Client, Intents, MessageActionRow, MessageButton, MessageEmbed } from 'discord.js'
 import { dirname, join } from 'path'
 import { fileURLToPath, pathToFileURL } from 'url'
 

--- a/packages/java-edition/src/binder/index.ts
+++ b/packages/java-edition/src/binder/index.ts
@@ -233,8 +233,8 @@ export function dissectUri(uri: string, ctx: UriBinderContext) {
 			| ReleaseVersion
 			| undefined
 		if (
-			!loadedVersion || // FIXME: check why this can be undefined sometimes
-			!matchVersion(loadedVersion, def.since, def.until)
+			!loadedVersion // FIXME: check why this can be undefined sometimes
+			|| !matchVersion(loadedVersion, def.since, def.until)
 		) {
 			continue
 		}

--- a/packages/java-edition/src/binder/index.ts
+++ b/packages/java-edition/src/binder/index.ts
@@ -217,9 +217,7 @@ export function dissectUri(uri: string, ctx: UriBinderContext) {
 			const subFolders = match[3].split('/').slice(0, -1)
 
 			for (let i = 0; i < subFolders.length - 1; i++) { // if subFolders is empty, this loop will not run
-				const customCategory = `${match[2]}/${
-					subFolders.slice(0, i + 1).join('/')
-				}`
+				const customCategory = `${match[2]}/${subFolders.slice(0, i + 1).join('/')}`
 
 				def = Categories.get(customCategory)
 

--- a/packages/java-edition/src/binder/index.ts
+++ b/packages/java-edition/src/binder/index.ts
@@ -63,29 +63,16 @@ export const Categories = (() => {
 			pack: 'data_pack',
 			until: '1.21',
 		}],
-		dataPackResource('item_modifier', 'item_modifiers', {
-			since: '1.17',
-			until: '1.21',
-		}),
+		dataPackResource('item_modifier', 'item_modifiers', { since: '1.17', until: '1.21' }),
 		dataPackResource('loot_table', 'loot_tables', { until: '1.21' }),
 		dataPackResource('predicate', 'predicates', { until: '1.21' }),
 		dataPackResource('recipe', 'recipes', { until: '1.21' }),
-		['structures', {
-			category: 'structure',
-			extname: '.nbt',
-			pack: 'data_pack',
-			until: '1.21',
-		}],
+		['structures', { category: 'structure', extname: '.nbt', pack: 'data_pack', until: '1.21' }],
 		dataPackResource('tag/block', 'tags/blocks', { until: '1.21' }),
-		dataPackResource('tag/entity_type', 'tags/entity_types', {
-			until: '1.21',
-		}),
+		dataPackResource('tag/entity_type', 'tags/entity_types', { until: '1.21' }),
 		dataPackResource('tag/fluid', 'tags/fluids', { until: '1.21' }),
 		dataPackResource('tag/function', 'tags/functions', { until: '1.21' }),
-		dataPackResource('tag/game_event', 'tags/game_events', {
-			since: '1.17',
-			until: '1.21',
-		}),
+		dataPackResource('tag/game_event', 'tags/game_events', { since: '1.17', until: '1.21' }),
 		dataPackResource('tag/item', 'tags/items', { until: '1.21' }),
 		// ---------
 
@@ -103,16 +90,9 @@ export const Categories = (() => {
 		dataPackResource('loot_table', { since: '1.21' }),
 		dataPackResource('predicate', { since: '1.21' }),
 		dataPackResource('recipe', { since: '1.21' }),
-		['structure', {
-			category: 'structure',
-			extname: '.nbt',
-			pack: 'data_pack',
-			until: '1.21',
-		}],
+		['structure', { category: 'structure', extname: '.nbt', pack: 'data_pack', until: '1.21' }],
 		dataPackResource('tag/block', 'tags/block', { since: '1.21' }),
-		dataPackResource('tag/entity_type', 'tags/entity_type', {
-			since: '1.21',
-		}),
+		dataPackResource('tag/entity_type', 'tags/entity_type', { since: '1.21' }),
 		dataPackResource('tag/fluid', 'tags/fluid', { since: '1.21' }),
 		dataPackResource('tag/function', 'tags/function', { since: '1.21' }),
 		dataPackResource('tag/game_event', 'tags/game_event', { since: '1.21' }),
@@ -141,25 +121,15 @@ export const Categories = (() => {
 		dataPackResource('worldgen/biome', { since: '1.16.2' }),
 		dataPackResource('worldgen/configured_carver', { since: '1.16.2' }),
 		dataPackResource('worldgen/configured_feature', { since: '1.16.2' }),
-		dataPackResource('worldgen/configured_structure_feature', {
-			since: '1.16.2',
-			until: '1.19',
-		}),
+		dataPackResource('worldgen/configured_structure_feature', { since: '1.16.2', until: '1.19' }),
 		dataPackResource('worldgen/density_function', { since: '1.18.2' }),
-		dataPackResource('worldgen/flat_level_generator_preset', {
-			since: '1.19',
-		}),
-		dataPackResource('worldgen/multi_noise_biome_source_parameter_list', {
-			since: '1.19.4',
-		}),
+		dataPackResource('worldgen/flat_level_generator_preset', { since: '1.19' }),
+		dataPackResource('worldgen/multi_noise_biome_source_parameter_list', { since: '1.19.4' }),
 		dataPackResource('worldgen/noise', { since: '1.18' }),
 		dataPackResource('worldgen/noise_settings', { since: '1.16.2' }),
 		dataPackResource('worldgen/placed_feature', { since: '1.18' }),
 		dataPackResource('worldgen/processor_list', { since: '1.16.2' }),
-		dataPackResource('worldgen/configured_surface_builder', {
-			since: '1.16.2',
-			until: '1.18',
-		}),
+		dataPackResource('worldgen/configured_surface_builder', { since: '1.16.2', until: '1.18' }),
 		dataPackResource('worldgen/structure', { since: '1.19' }),
 		dataPackResource('worldgen/structure_set', { since: '1.18.2' }),
 		dataPackResource('worldgen/template_pool', { since: '1.16.2' }),
@@ -227,29 +197,20 @@ export function dissectUri(uri: string, ctx: UriBinderContext) {
 		if (!def || def.extname !== match[4]) {
 			continue
 		}
-		const loadedVersion = ctx.project['loadedVersion'] as
-			| ReleaseVersion
-			| undefined
+		const loadedVersion = ctx.project['loadedVersion'] as ReleaseVersion | undefined
 		if (
 			!loadedVersion // FIXME: check why this can be undefined sometimes
 			|| !matchVersion(loadedVersion, def.since, def.until)
 		) {
 			continue
 		}
-		return {
-			category: def.category,
-			namespace: match[1],
-			identifier: match[3],
-		}
+		return { category: def.category, namespace: match[1], identifier: match[3] }
 	}
 
 	return undefined
 }
 
-export const uriBinder: UriBinder = (
-	uris: readonly string[],
-	ctx: UriBinderContext,
-) => {
+export const uriBinder: UriBinder = (uris: readonly string[], ctx: UriBinderContext) => {
 	const { customResources } = ctx.config.env
 	for (const [category, def] of customResources) {
 		if (def.pack === 'data_pack') { // TODO
@@ -260,17 +221,9 @@ export const uriBinder: UriBinder = (
 	for (const uri of uris) {
 		const parts = dissectUri(uri, ctx)
 		if (parts) {
-			ctx.symbols
-				.query(
-					uri,
-					parts.category,
-					`${parts.namespace}:${parts.identifier}`,
-				)
-				.enter({
-					usage: {
-						type: 'definition',
-					},
-				})
+			ctx.symbols.query(uri, parts.category, `${parts.namespace}:${parts.identifier}`).enter({
+				usage: { type: 'definition' },
+			})
 		}
 	}
 }

--- a/packages/java-edition/src/common/index.ts
+++ b/packages/java-edition/src/common/index.ts
@@ -37,9 +37,9 @@ export function getTagValues(
 			// const result = ctx.getDocAndNode(uri)
 			const result: any = undefined // FIXME: Use global symbol table to get the result
 			if (
-				!result ||
-				result.node.parserErrors.length ||
-				result.node.checkerErrors?.length
+				!result
+				|| result.node.parserErrors.length
+				|| result.node.checkerErrors?.length
 			) {
 				return ans
 			}

--- a/packages/java-edition/src/common/index.ts
+++ b/packages/java-edition/src/common/index.ts
@@ -9,11 +9,8 @@ export function getUris(
 	id: string,
 	ctx: core.ProcessorContext,
 ): readonly string[] {
-	return (
-		ctx.symbols
-			.query(ctx.doc, category, core.ResourceLocation.lengthen(id))
-			.symbol?.definition?.map((v) => v.uri) ?? []
-	)
+	return (ctx.symbols.query(ctx.doc, category, core.ResourceLocation.lengthen(id)).symbol
+		?.definition?.map((v) => v.uri) ?? [])
 }
 
 export function getTagValues(
@@ -25,51 +22,36 @@ export function getTagValues(
 	const resolveValueNode = (node: ValueNode): string =>
 		json.JsonStringNode.is(node)
 			? node.value
-			: (
-				node.children.find((n) => n.key?.value === 'id')!
-					.value as json.JsonStringNode
-			).value
+			: (node.children.find((n) => n.key?.value === 'id')!.value as json.JsonStringNode).value
 
-	const set = getUris(category, id, ctx).reduce<
-		Set<core.FullResourceLocation>
-	>(
-		(ans, uri) => {
-			// const result = ctx.getDocAndNode(uri)
-			const result: any = undefined // FIXME: Use global symbol table to get the result
-			if (
-				!result
-				|| result.node.parserErrors.length
-				|| result.node.checkerErrors?.length
-			) {
-				return ans
-			}
-
-			// No errors in the node. We can assume it is a semantically correct tag file.
-
-			const rootNode = result.node.children[0] as json.JsonObjectNode
-			const replaceNode = rootNode.children.find(
-				(n) => n.key?.value === 'replace',
-			)?.value as json.JsonBooleanNode | undefined
-			const valuesNode = rootNode.children.find(
-				(n) => n.key?.value === 'values',
-			)?.value as json.JsonArrayNode
-			const replace = replaceNode?.value
-			const values = valuesNode.children.map((n) =>
-				core.ResourceLocation.lengthen(
-					resolveValueNode(n.value as ValueNode),
-				)
-			)
-
-			if (replace) {
-				ans = new Set()
-			}
-			for (const value of values) {
-				ans.add(value)
-			}
-
+	const set = getUris(category, id, ctx).reduce<Set<core.FullResourceLocation>>((ans, uri) => {
+		// const result = ctx.getDocAndNode(uri)
+		const result: any = undefined // FIXME: Use global symbol table to get the result
+		if (!result || result.node.parserErrors.length || result.node.checkerErrors?.length) {
 			return ans
-		},
-		new Set(),
-	)
+		}
+
+		// No errors in the node. We can assume it is a semantically correct tag file.
+
+		const rootNode = result.node.children[0] as json.JsonObjectNode
+		const replaceNode = rootNode.children.find((n) => n.key?.value === 'replace')?.value as
+			| json.JsonBooleanNode
+			| undefined
+		const valuesNode = rootNode.children.find((n) => n.key?.value === 'values')
+			?.value as json.JsonArrayNode
+		const replace = replaceNode?.value
+		const values = valuesNode.children.map((n) =>
+			core.ResourceLocation.lengthen(resolveValueNode(n.value as ValueNode))
+		)
+
+		if (replace) {
+			ans = new Set()
+		}
+		for (const value of values) {
+			ans.add(value)
+		}
+
+		return ans
+	}, new Set())
 	return [...set]
 }

--- a/packages/java-edition/src/dependency/common.ts
+++ b/packages/java-edition/src/dependency/common.ts
@@ -31,9 +31,7 @@ export interface VersionInfo {
 }
 
 export interface PackMcmeta {
-	pack: {
-		pack_format: number
-	}
+	pack: { pack_format: number }
 }
 export namespace PackMcmeta {
 	export function assert(data: any): asserts data is PackMcmeta {

--- a/packages/java-edition/src/dependency/index.ts
+++ b/packages/java-edition/src/dependency/index.ts
@@ -26,10 +26,8 @@ export async function getVersions(
 ): Promise<McmetaVersions | undefined> {
 	return downloader.download<McmetaVersions>({
 		id: 'mc-je/versions.json.gz',
-		uri:
-			'https://raw.githubusercontent.com/misode/mcmeta/summary/versions/data.json.gz',
-		transformer: (buffer) =>
-			core.parseGzippedJson(externals, buffer) as Promise<McmetaVersions>,
+		uri: 'https://raw.githubusercontent.com/misode/mcmeta/summary/versions/data.json.gz',
+		transformer: (buffer) => core.parseGzippedJson(externals, buffer) as Promise<McmetaVersions>,
 		cache: getCacheOptionsBasedOnGitHubCommitSha(
 			'misode',
 			'mcmeta',
@@ -104,8 +102,7 @@ export async function getMcmetaSummary(
 			{
 				id: `mc-je/${version}/${type}.json.gz`,
 				uri: uris[type],
-				transformer: (buffer) =>
-					core.parseGzippedJson(externals, buffer) as Promise<T>,
+				transformer: (buffer) => core.parseGzippedJson(externals, buffer) as Promise<T>,
 				cache: getCacheOptionsBasedOnGitHubCommitSha(
 					'misode',
 					'mcmeta',
@@ -168,8 +165,7 @@ function getCacheOptionsBasedOnGitHubCommitSha(
 	return {
 		checksumExtension: '.commit-sha' as const,
 		checksumJob: {
-			uri:
-				`https://api.github.com/repos/${owner}/${repo}/git/${ref}` as const,
+			uri: `https://api.github.com/repos/${owner}/${repo}/git/${ref}` as const,
 			transformer: (buffer: Uint8Array) => {
 				const response = JSON.parse(
 					core.bufferToString(buffer),

--- a/packages/java-edition/src/dependency/index.ts
+++ b/packages/java-edition/src/dependency/index.ts
@@ -28,11 +28,7 @@ export async function getVersions(
 		id: 'mc-je/versions.json.gz',
 		uri: 'https://raw.githubusercontent.com/misode/mcmeta/summary/versions/data.json.gz',
 		transformer: (buffer) => core.parseGzippedJson(externals, buffer) as Promise<McmetaVersions>,
-		cache: getCacheOptionsBasedOnGitHubCommitSha(
-			'misode',
-			'mcmeta',
-			'refs/heads/summary',
-		),
+		cache: getCacheOptionsBasedOnGitHubCommitSha('misode', 'mcmeta', 'refs/heads/summary'),
 		ttl: DownloaderTtl,
 	})
 }
@@ -56,9 +52,8 @@ export async function getMcmetaSummary(
 	source: string,
 	overridePaths: core.EnvConfig['mcmetaSummaryOverrides'] = {},
 ): Promise<GetMcmetaSummaryResult> {
-	type OverrideConfig = core.EnvConfig['mcmetaSummaryOverrides'][
-		keyof core.EnvConfig['mcmetaSummaryOverrides']
-	]
+	type OverrideConfig =
+		core.EnvConfig['mcmetaSummaryOverrides'][keyof core.EnvConfig['mcmetaSummaryOverrides']]
 	const ref = getGitRef({
 		defaultBranch: 'summary',
 		getTag: (v) => `${v}-summary`,
@@ -68,16 +63,10 @@ export async function getMcmetaSummary(
 	const uris = getMcmetaSummaryUris(version, isLatest, source)
 	let checksum: string | undefined
 
-	async function handleOverride<T>(
-		currentValue: T,
-		overrideConfig: OverrideConfig,
-	) {
+	async function handleOverride<T>(currentValue: T, overrideConfig: OverrideConfig) {
 		if (overrideConfig) {
 			try {
-				const override = (await core.fileUtil.readJson(
-					externals,
-					overrideConfig.path,
-				)) as any
+				const override = (await core.fileUtil.readJson(externals, overrideConfig.path)) as any
 				if (overrideConfig.replace) {
 					return override
 				} else {
@@ -98,20 +87,13 @@ export async function getMcmetaSummary(
 		overrideConfig: OverrideConfig,
 	): Promise<T | undefined> => {
 		const out: core.DownloaderDownloadOut = {}
-		const data = await downloader.download<T>(
-			{
-				id: `mc-je/${version}/${type}.json.gz`,
-				uri: uris[type],
-				transformer: (buffer) => core.parseGzippedJson(externals, buffer) as Promise<T>,
-				cache: getCacheOptionsBasedOnGitHubCommitSha(
-					'misode',
-					'mcmeta',
-					ref,
-				),
-				ttl: DownloaderTtl,
-			},
-			out,
-		)
+		const data = await downloader.download<T>({
+			id: `mc-je/${version}/${type}.json.gz`,
+			uri: uris[type],
+			transformer: (buffer) => core.parseGzippedJson(externals, buffer) as Promise<T>,
+			cache: getCacheOptionsBasedOnGitHubCommitSha('misode', 'mcmeta', ref),
+			ttl: DownloaderTtl,
+		}, out)
 		checksum ||= out.checksum
 		return handleOverride(data, overrideConfig)
 	}
@@ -120,56 +102,40 @@ export async function getMcmetaSummary(
 		await getResource<McmetaStates>('blocks', overridePaths.blocks),
 		await getResource<McmetaCommands>('commands', overridePaths.commands),
 		await handleOverride<McmetaStates>(Fluids, overridePaths.fluids),
-		await getResource<McmetaRegistries>(
-			'registries',
-			overridePaths.registries,
-		),
+		await getResource<McmetaRegistries>('registries', overridePaths.registries),
 	]
 
 	return { blocks, commands, fluids, registries, checksum }
 }
 
-type GitHubRefResponse =
-	| { message: string }
-	| { message?: undefined; ref: string; object: { sha: string } }
-	| { message?: undefined; ref: string; object: { sha: string } }[]
+type GitHubRefResponse = { message: string } | {
+	message?: undefined
+	ref: string
+	object: { sha: string }
+} | { message?: undefined; ref: string; object: { sha: string } }[]
 
-function getGitRef({
-	defaultBranch,
-	getTag,
-	isLatest,
-	version,
-}: {
-	defaultBranch: string
-	getTag: (version: string) => string
-	isLatest: boolean
-	version: string
-}): string {
-	return isLatest
-		? `refs/heads/${defaultBranch}`
-		: `refs/tags/${getTag(version)}`
+function getGitRef(
+	{ defaultBranch, getTag, isLatest, version }: {
+		defaultBranch: string
+		getTag: (version: string) => string
+		isLatest: boolean
+		version: string
+	},
+): string {
+	return isLatest ? `refs/heads/${defaultBranch}` : `refs/tags/${getTag(version)}`
 }
 
 const GitHubApiDownloadOptions = {
-	headers: {
-		Accept: 'application/vnd.github.v3+json',
-		'User-Agent': 'SpyglassMC',
-	},
+	headers: { Accept: 'application/vnd.github.v3+json', 'User-Agent': 'SpyglassMC' },
 }
 
-function getCacheOptionsBasedOnGitHubCommitSha(
-	owner: string,
-	repo: string,
-	ref: string,
-) {
+function getCacheOptionsBasedOnGitHubCommitSha(owner: string, repo: string, ref: string) {
 	return {
 		checksumExtension: '.commit-sha' as const,
 		checksumJob: {
 			uri: `https://api.github.com/repos/${owner}/${repo}/git/${ref}` as const,
 			transformer: (buffer: Uint8Array) => {
-				const response = JSON.parse(
-					core.bufferToString(buffer),
-				) as GitHubRefResponse
+				const response = JSON.parse(core.bufferToString(buffer)) as GitHubRefResponse
 				if (Array.isArray(response)) {
 					return response[0].object.sha
 				} else if (response.message === undefined) {
@@ -192,37 +158,28 @@ function getCacheOptionsBasedOnGitHubCommitSha(
  *
  * @returns The URI to the `.tar.gz` file.
  */
-async function downloadGitHubRepo({
-	defaultBranch,
-	downloader,
-	getTag,
-	repo,
-	isLatest,
-	owner,
-	version,
-}: {
-	defaultBranch: string
-	downloader: core.Downloader
-	getTag: (version: string) => string
-	owner: string
-	repo: string
-	isLatest: boolean
-	version: string
-}): Promise<string> {
+async function downloadGitHubRepo(
+	{ defaultBranch, downloader, getTag, repo, isLatest, owner, version }: {
+		defaultBranch: string
+		downloader: core.Downloader
+		getTag: (version: string) => string
+		owner: string
+		repo: string
+		isLatest: boolean
+		version: string
+	},
+): Promise<string> {
 	const ref = getGitRef({ defaultBranch, getTag, isLatest, version })
 
 	const out: core.DownloaderDownloadOut = {}
-	await downloader.download<Uint8Array>(
-		{
-			id: `mc-je/${version}/${repo}.tar.gz`,
-			uri: `https://api.github.com/repos/${owner}/${repo}/tarball/${ref}`,
-			transformer: (b) => b,
-			cache: getCacheOptionsBasedOnGitHubCommitSha(owner, repo, ref),
-			options: GitHubApiDownloadOptions,
-			ttl: DownloaderTtl,
-		},
-		out,
-	)
+	await downloader.download<Uint8Array>({
+		id: `mc-je/${version}/${repo}.tar.gz`,
+		uri: `https://api.github.com/repos/${owner}/${repo}/tarball/${ref}`,
+		transformer: (b) => b,
+		cache: getCacheOptionsBasedOnGitHubCommitSha(owner, repo, ref),
+		options: GitHubApiDownloadOptions,
+		ttl: DownloaderTtl,
+	}, out)
 
 	return out.cacheUri!
 }
@@ -249,10 +206,7 @@ export async function getVanillaDatapack(
 		isLatest,
 		version,
 	})
-	return {
-		info: { startDepth: 1 },
-		uri,
-	}
+	return { info: { startDepth: 1 }, uri }
 }
 
 /**
@@ -262,27 +216,19 @@ export async function getVanillaDatapack(
  * 	- `startDepth`: The amount of level to skip when unzipping the tarball.
  * 	- `uri`: URI to the `.tar.gz` file.
  */
-export async function getVanillaMcdoc(
-	downloader: core.Downloader,
-): Promise<core.Dependency> {
+export async function getVanillaMcdoc(downloader: core.Downloader): Promise<core.Dependency> {
 	const owner = 'SpyglassMC'
 	const repo = 'vanilla-mcdoc'
 	const ref = 'refs/heads/main'
 	const out: core.DownloaderDownloadOut = {}
-	await downloader.download<Uint8Array>(
-		{
-			id: 'mc-je/vanilla-mcdoc.tar.gz',
-			uri: `https://api.github.com/repos/${owner}/${repo}/tarball/${ref}`,
-			transformer: (b) => b,
-			cache: getCacheOptionsBasedOnGitHubCommitSha(owner, repo, ref),
-			options: GitHubApiDownloadOptions,
-			ttl: DownloaderTtl,
-		},
-		out,
-	)
+	await downloader.download<Uint8Array>({
+		id: 'mc-je/vanilla-mcdoc.tar.gz',
+		uri: `https://api.github.com/repos/${owner}/${repo}/tarball/${ref}`,
+		transformer: (b) => b,
+		cache: getCacheOptionsBasedOnGitHubCommitSha(owner, repo, ref),
+		options: GitHubApiDownloadOptions,
+		ttl: DownloaderTtl,
+	}, out)
 
-	return {
-		info: { startDepth: 1 },
-		uri: out.cacheUri!,
-	}
+	return { info: { startDepth: 1 }, uri: out.cacheUri! }
 }

--- a/packages/java-edition/src/dependency/mcmeta.ts
+++ b/packages/java-edition/src/dependency/mcmeta.ts
@@ -81,8 +81,8 @@ export function resolveConfiguredVersion(
 	return toVersionInfo(
 		versions.find(
 			(v) =>
-				inputVersion === v.id.toLowerCase() ||
-				inputVersion === v.name.toLowerCase(),
+				inputVersion === v.id.toLowerCase()
+				|| inputVersion === v.name.toLowerCase(),
 		),
 	)
 }
@@ -195,8 +195,8 @@ export function symbolRegistrar(summary: McmetaSummary): core.SymbolRegistrar {
 		type Category = core.FileCategory | core.RegistryCategory
 		function isCategory(str: string): str is Category {
 			return (
-				core.FileCategories.includes(str as any) ||
-				core.RegistryCategories.includes(str as any)
+				core.FileCategories.includes(str as any)
+				|| core.RegistryCategories.includes(str as any)
 			)
 		}
 

--- a/packages/java-edition/src/index.ts
+++ b/packages/java-edition/src/index.ts
@@ -84,10 +84,10 @@ export const initialize: core.ProjectInitializer = async (ctx) => {
 		config.env.mcmetaSummaryOverrides,
 	)
 	if (
-		!summary.blocks ||
-		!summary.commands ||
-		!summary.fluids ||
-		!summary.registries
+		!summary.blocks
+		|| !summary.commands
+		|| !summary.fluids
+		|| !summary.registries
 	) {
 		ctx.logger.error(
 			'[je-initialize] Failed loading mcmeta summaries. Expect everything to be broken.',
@@ -105,17 +105,17 @@ export const initialize: core.ProjectInitializer = async (ctx) => {
 		linter: core.linter.nameConvention('value'),
 		nodePredicate: (n) =>
 			// nbt compound keys without mcdoc definition.
-			(!n.symbol &&
-				n.parent?.parent?.type === 'nbt:compound' &&
-				core.PairNode.is(n.parent) &&
-				n.type === 'string' &&
-				n.parent.key === n) ||
+			(!n.symbol
+				&& n.parent?.parent?.type === 'nbt:compound'
+				&& core.PairNode.is(n.parent)
+				&& n.type === 'string'
+				&& n.parent.key === n)
 			// nbt path keys without mcdoc definition.
-			(!n.symbol && n.parent?.type === 'nbt:path' && n.type === 'string') ||
+			|| (!n.symbol && n.parent?.type === 'nbt:path' && n.type === 'string')
 			// mcdoc compound key definition outside of `::minecraft` modules.
-			(mcdoc.StructFieldNode.is(n.parent) &&
-				mcdoc.StructKeyNode.is(n) &&
-				!n.symbol?.path[0]?.startsWith('::minecraft')),
+			|| (mcdoc.StructFieldNode.is(n.parent)
+				&& mcdoc.StructKeyNode.is(n)
+				&& !n.symbol?.path[0]?.startsWith('::minecraft')),
 	})
 
 	mcdoc.runtime.registerAttribute(

--- a/packages/java-edition/src/index.ts
+++ b/packages/java-edition/src/index.ts
@@ -35,10 +35,7 @@ export const initialize: core.ProjectInitializer = async (ctx) => {
 		} catch (e) {
 			if (!externals.error.isKind(e, 'ENOENT')) {
 				// `pack.mcmeta` exists but broken. Log an error.
-				logger.error(
-					`[je.initialize] Failed loading pack.mcmeta “${uri}”`,
-					e,
-				)
+				logger.error(`[je.initialize] Failed loading pack.mcmeta “${uri}”`, e)
 			}
 		}
 		return ans
@@ -55,11 +52,7 @@ export const initialize: core.ProjectInitializer = async (ctx) => {
 	}
 
 	const packMcmeta = await getPackMcmeta()
-	const {
-		release,
-		id: version,
-		isLatest,
-	} = resolveConfiguredVersion(config.env.gameVersion, {
+	const { release, id: version, isLatest } = resolveConfiguredVersion(config.env.gameVersion, {
 		packMcmeta,
 		versions,
 	})
@@ -69,10 +62,7 @@ export const initialize: core.ProjectInitializer = async (ctx) => {
 		() => getVanillaDatapack(downloader, version, isLatest),
 	)
 
-	meta.registerDependencyProvider(
-		'@vanilla-mcdoc',
-		() => getVanillaMcdoc(downloader),
-	)
+	meta.registerDependencyProvider('@vanilla-mcdoc', () => getVanillaMcdoc(downloader))
 
 	const summary = await getMcmetaSummary(
 		ctx.externals,
@@ -83,12 +73,7 @@ export const initialize: core.ProjectInitializer = async (ctx) => {
 		config.env.dataSource,
 		config.env.mcmetaSummaryOverrides,
 	)
-	if (
-		!summary.blocks
-		|| !summary.commands
-		|| !summary.fluids
-		|| !summary.registries
-	) {
+	if (!summary.blocks || !summary.commands || !summary.fluids || !summary.registries) {
 		ctx.logger.error(
 			'[je-initialize] Failed loading mcmeta summaries. Expect everything to be broken.',
 		)
@@ -109,58 +94,42 @@ export const initialize: core.ProjectInitializer = async (ctx) => {
 				&& n.parent?.parent?.type === 'nbt:compound'
 				&& core.PairNode.is(n.parent)
 				&& n.type === 'string'
-				&& n.parent.key === n)
-			// nbt path keys without mcdoc definition.
-			|| (!n.symbol && n.parent?.type === 'nbt:path' && n.type === 'string')
-			// mcdoc compound key definition outside of `::minecraft` modules.
+				&& n.parent.key === n) // nbt path keys without mcdoc definition.
+			|| (!n.symbol && n.parent?.type === 'nbt:path' && n.type === 'string') // mcdoc compound key definition outside of `::minecraft` modules.
 			|| (mcdoc.StructFieldNode.is(n.parent)
 				&& mcdoc.StructKeyNode.is(n)
 				&& !n.symbol?.path[0]?.startsWith('::minecraft')),
 	})
 
-	mcdoc.runtime.registerAttribute(
-		meta,
-		'since',
-		mcdoc.runtime.attribute.validator.string,
-		{
-			filterElement: (config, ctx) => {
-				if (!config.startsWith('1.')) {
-					ctx.logger.warn(`Invalid mcdoc attribute for "since": ${config}`)
-					return true
-				}
-				return ReleaseVersion.cmp(release, config as ReleaseVersion) >= 0
-			},
+	mcdoc.runtime.registerAttribute(meta, 'since', mcdoc.runtime.attribute.validator.string, {
+		filterElement: (config, ctx) => {
+			if (!config.startsWith('1.')) {
+				ctx.logger.warn(`Invalid mcdoc attribute for "since": ${config}`)
+				return true
+			}
+			return ReleaseVersion.cmp(release, config as ReleaseVersion) >= 0
 		},
-	)
-	mcdoc.runtime.registerAttribute(
-		meta,
-		'until',
-		mcdoc.runtime.attribute.validator.string,
-		{
-			filterElement: (config, ctx) => {
-				if (!config.startsWith('1.')) {
-					ctx.logger.warn(`Invalid mcdoc attribute for "until": ${config}`)
-					return true
-				}
-				return ReleaseVersion.cmp(release, config as ReleaseVersion) < 0
-			},
+	})
+	mcdoc.runtime.registerAttribute(meta, 'until', mcdoc.runtime.attribute.validator.string, {
+		filterElement: (config, ctx) => {
+			if (!config.startsWith('1.')) {
+				ctx.logger.warn(`Invalid mcdoc attribute for "until": ${config}`)
+				return true
+			}
+			return ReleaseVersion.cmp(release, config as ReleaseVersion) < 0
 		},
-	)
+	})
 	mcdoc.runtime.registerAttribute(
 		meta,
 		'deprecated',
-		mcdoc.runtime.attribute.validator.optional(
-			mcdoc.runtime.attribute.validator.string,
-		),
+		mcdoc.runtime.attribute.validator.optional(mcdoc.runtime.attribute.validator.string),
 		{
 			mapField: (config, field, ctx) => {
 				if (config === undefined) {
 					return { ...field, deprecated: true }
 				}
 				if (!config.startsWith('1.')) {
-					ctx.logger.warn(
-						`Invalid mcdoc attribute for "deprecated": ${config}`,
-					)
+					ctx.logger.warn(`Invalid mcdoc attribute for "deprecated": ${config}`)
 					return field
 				}
 				if (ReleaseVersion.cmp(release, config as ReleaseVersion) >= 0) {
@@ -176,7 +145,5 @@ export const initialize: core.ProjectInitializer = async (ctx) => {
 	jeMcf.initialize(ctx, summary.commands, release)
 	nbt.initialize(ctx)
 
-	return {
-		loadedVersion: release,
-	}
+	return { loadedVersion: release }
 }

--- a/packages/java-edition/src/json/checker/index.ts
+++ b/packages/java-edition/src/json/checker/index.ts
@@ -7,14 +7,8 @@ function createTagDefinition(registry: string): mcdoc.McdocType {
 	const id: mcdoc.AttributeValue = {
 		kind: 'tree',
 		values: {
-			registry: {
-				kind: 'literal',
-				value: { kind: 'string', value: registry },
-			},
-			tags: {
-				kind: 'literal',
-				value: { kind: 'string', value: 'allowed' },
-			},
+			registry: { kind: 'literal', value: { kind: 'string', value: registry } },
+			tags: { kind: 'literal', value: { kind: 'string', value: 'allowed' } },
 		},
 	}
 	return {
@@ -27,10 +21,7 @@ function createTagDefinition(registry: string): mcdoc.McdocType {
 export const file: core.Checker<json.JsonFileNode> = (node, ctx) => {
 	const child = node.children[0]
 	if (ctx.doc.uri.endsWith('/pack.mcmeta')) {
-		const type: mcdoc.McdocType = {
-			kind: 'reference',
-			path: '::java::pack::Pack',
-		}
+		const type: mcdoc.McdocType = { kind: 'reference', path: '::java::pack::Pack' }
 		return json.checker.index(type)(child, ctx)
 	}
 	const parts = dissectUri(ctx.doc.uri, ctx)

--- a/packages/java-edition/src/mcfunction/checker/index.ts
+++ b/packages/java-edition/src/mcfunction/checker/index.ts
@@ -5,9 +5,7 @@ import type * as mcdoc from '@spyglassmc/mcdoc'
 import * as mcf from '@spyglassmc/mcfunction'
 import * as nbt from '@spyglassmc/nbt'
 import { getTagValues } from '../../common/index.js'
-import type {
-	EntitySelectorInvertableArgumentValueNode,
-} from '../node/index.js'
+import type { EntitySelectorInvertableArgumentValueNode } from '../node/index.js'
 import {
 	BlockNode,
 	ComponentTestExactNode,

--- a/packages/java-edition/src/mcfunction/checker/index.ts
+++ b/packages/java-edition/src/mcfunction/checker/index.ts
@@ -180,8 +180,8 @@ function nbtChecker(dispatchedBy?: core.AstNode): core.SyncChecker<NbtNode> {
 		switch (node.properties.dispatcher) {
 			case 'minecraft:entity':
 				if (nbt.NbtCompoundNode.is(compound)) {
-					const types = (EntityNode.is(dispatchedBy) ||
-							core.ResourceLocationNode.is(dispatchedBy))
+					const types = (EntityNode.is(dispatchedBy)
+							|| core.ResourceLocationNode.is(dispatchedBy))
 						? getTypesFromEntity(dispatchedBy, ctx)
 						: undefined
 					nbt.checker.index('minecraft:entity', types, {

--- a/packages/java-edition/src/mcfunction/checker/index.ts
+++ b/packages/java-edition/src/mcfunction/checker/index.ts
@@ -26,10 +26,7 @@ export const command: core.Checker<mcf.CommandNode> = (node, ctx) => {
 	rootCommand(node.children, 0, ctx)
 }
 
-const getNode = (
-	nodes: mcf.CommandNode['children'],
-	name: string,
-): core.AstNode | undefined => {
+const getNode = (nodes: mcf.CommandNode['children'], name: string): core.AstNode | undefined => {
 	return nodes.find(n => n.path[n.path.length - 1] === name)?.children[0]
 }
 
@@ -67,10 +64,10 @@ const block: core.SyncChecker<BlockNode> = (node, ctx) => {
 		return
 	}
 
-	nbt.checker.index(
-		'minecraft:block_entity',
-		core.ResourceLocationNode.toString(node.id, 'full'),
-	)(node.nbt, ctx)
+	nbt.checker.index('minecraft:block_entity', core.ResourceLocationNode.toString(node.id, 'full'))(
+		node.nbt,
+		ctx,
+	)
 }
 
 const entity: core.SyncChecker<EntityNode> = (node, ctx) => {
@@ -88,11 +85,9 @@ const entity: core.SyncChecker<EntityNode> = (node, ctx) => {
 
 const itemPredicate: core.SyncChecker<ItemPredicateNode> = (node, ctx) => {
 	if (node.nbt) {
-		nbt.checker.index(
-			'minecraft:item',
-			core.ResourceLocationNode.toString(node.id, 'full'),
-			{ isPredicate: true },
-		)(node.nbt, ctx)
+		nbt.checker.index('minecraft:item', core.ResourceLocationNode.toString(node.id, 'full'), {
+			isPredicate: true,
+		})(node.nbt, ctx)
 	}
 	if (!node.tests) {
 		return
@@ -102,15 +97,9 @@ const itemPredicate: core.SyncChecker<ItemPredicateNode> = (node, ctx) => {
 			for (const test of allOfTest.children) {
 				const key = core.ResourceLocationNode.toString(test.key, 'full')
 				if (ComponentTestExactNode.is(test) && test.value) {
-					nbt.checker.index('minecraft:data_component', key)(
-						test.value,
-						ctx,
-					)
+					nbt.checker.index('minecraft:data_component', key)(test.value, ctx)
 				} else if (ComponentTestSubpredicateNode.is(test) && test.value) {
-					nbt.checker.index('minecraft:item_sub_predicate', key)(
-						test.value,
-						ctx,
-					)
+					nbt.checker.index('minecraft:item_sub_predicate', key)(test.value, ctx)
 				}
 			}
 		}
@@ -161,10 +150,7 @@ const nbtResource: core.SyncChecker<NbtResourceNode> = (node, ctx) => {
 	const type: mcdoc.McdocType = {
 		kind: 'dispatcher',
 		registry: 'minecraft:resource',
-		parallelIndices: [{
-			kind: 'static',
-			value: core.ResourceLocation.lengthen(node.category),
-		}],
+		parallelIndices: [{ kind: 'static', value: core.ResourceLocation.lengthen(node.category) }],
 	}
 	nbt.checker.typeDefinition(type)(node.children[0], ctx)
 }
@@ -178,10 +164,10 @@ function nbtChecker(dispatchedBy?: core.AstNode): core.SyncChecker<NbtNode> {
 		switch (node.properties.dispatcher) {
 			case 'minecraft:entity':
 				if (nbt.NbtCompoundNode.is(compound)) {
-					const types = (EntityNode.is(dispatchedBy)
-							|| core.ResourceLocationNode.is(dispatchedBy))
-						? getTypesFromEntity(dispatchedBy, ctx)
-						: undefined
+					const types =
+						(EntityNode.is(dispatchedBy) || core.ResourceLocationNode.is(dispatchedBy))
+							? getTypesFromEntity(dispatchedBy, ctx)
+							: undefined
 					nbt.checker.index('minecraft:entity', types, {
 						isPredicate: node.properties.isPredicate,
 					})(compound, ctx)
@@ -211,17 +197,9 @@ function getTypesFromEntity(
 	ctx: core.CheckerContext,
 ): core.FullResourceLocation[] | undefined {
 	if (core.ResourceLocationNode.is(entity)) {
-		const value = core.ResourceLocationNode.toString(
-			entity,
-			'full',
-			true,
-		)
+		const value = core.ResourceLocationNode.toString(entity, 'full', true)
 		if (value.startsWith(core.ResourceLocation.TagPrefix)) {
-			return getTagValues(
-				'tag/entity_type',
-				value.slice(1),
-				ctx,
-			) as core.FullResourceLocation[]
+			return getTagValues('tag/entity_type', value.slice(1), ctx) as core.FullResourceLocation[]
 		} else {
 			return [value as core.FullResourceLocation]
 		}
@@ -238,24 +216,14 @@ function getTypesFromEntity(
 				continue
 			}
 			const valueNode = pairNode.value as
-				| EntitySelectorInvertableArgumentValueNode<
-					core.ResourceLocationNode
-				>
+				| EntitySelectorInvertableArgumentValueNode<core.ResourceLocationNode>
 				| undefined
 			if (!valueNode || valueNode.inverted) {
 				continue
 			}
-			const value = core.ResourceLocationNode.toString(
-				valueNode.value,
-				'full',
-				true,
-			)
+			const value = core.ResourceLocationNode.toString(valueNode.value, 'full', true)
 			if (value.startsWith(core.ResourceLocation.TagPrefix)) {
-				const tagValues = getTagValues(
-					'tag/entity_type',
-					value.slice(1),
-					ctx,
-				)
+				const tagValues = getTagValues('tag/entity_type', value.slice(1), ctx)
 				if (types === undefined) {
 					types = tagValues.map(core.ResourceLocation.lengthen)
 				} else {
@@ -276,10 +244,7 @@ export function register(meta: core.MetaRegistry) {
 	meta.registerChecker<BlockNode>('mcfunction:block', block)
 	meta.registerChecker<EntityNode>('mcfunction:entity', entity)
 	meta.registerChecker<ItemStackNode>('mcfunction:item_stack', itemStack)
-	meta.registerChecker<ItemPredicateNode>(
-		'mcfunction:item_predicate',
-		itemPredicate,
-	)
+	meta.registerChecker<ItemPredicateNode>('mcfunction:item_predicate', itemPredicate)
 	meta.registerChecker<JsonNode>('mcfunction:json', jsonChecker)
 	meta.registerChecker<ParticleNode>('mcfunction:particle', particle)
 }

--- a/packages/java-edition/src/mcfunction/colorizer/index.ts
+++ b/packages/java-edition/src/mcfunction/colorizer/index.ts
@@ -1,9 +1,5 @@
 import * as core from '@spyglassmc/core'
-import type {
-	CoordinateNode,
-	ObjectiveCriteriaNode,
-	VectorNode,
-} from '../node/index.js'
+import type { CoordinateNode, ObjectiveCriteriaNode, VectorNode } from '../node/index.js'
 
 export const objectiveCriterion: core.Colorizer<ObjectiveCriteriaNode> = (
 	node,

--- a/packages/java-edition/src/mcfunction/colorizer/index.ts
+++ b/packages/java-edition/src/mcfunction/colorizer/index.ts
@@ -10,10 +10,7 @@ export const vector: core.Colorizer<VectorNode> = (node) => {
 }
 
 export function register(meta: core.MetaRegistry) {
-	meta.registerColorizer<CoordinateNode>(
-		'mcfunction:coordinate',
-		core.colorizer.number,
-	)
+	meta.registerColorizer<CoordinateNode>('mcfunction:coordinate', core.colorizer.number)
 	meta.registerColorizer<VectorNode>('mcfunction:vector', vector)
 	meta.registerColorizer<ObjectiveCriteriaNode>(
 		'mcfunction:objective_criteria',

--- a/packages/java-edition/src/mcfunction/common/index.ts
+++ b/packages/java-edition/src/mcfunction/common/index.ts
@@ -5,12 +5,7 @@ export const ColorArgumentValues = [...core.Color.ColorNames, 'reset']
 
 export const EntityAnchorArgumentValues = ['feet', 'eyes']
 
-export const GamemodeArgumentValues = [
-	'adventure',
-	'survival',
-	'creative',
-	'spectator',
-]
+export const GamemodeArgumentValues = ['adventure', 'survival', 'creative', 'spectator']
 
 export function getItemSlotArgumentValues(ctx: core.ContextBase) {
 	const release = ctx.project['loadedVersion'] as ReleaseVersion
@@ -60,17 +55,7 @@ export function getItemSlotsArgumentValues(ctx: core.ContextBase) {
 	]
 }
 
-export const OperationArgumentValues = [
-	'=',
-	'+=',
-	'-=',
-	'*=',
-	'/=',
-	'%=',
-	'<',
-	'>',
-	'><',
-]
+export const OperationArgumentValues = ['=', '+=', '-=', '*=', '/=', '%=', '<', '>', '><']
 
 export const ScoreboardSlotArgumentValues = [
 	'belowName',
@@ -106,15 +91,6 @@ export const HeightmapValues = [
 	'world_surface_wg',
 ]
 
-export const RotationValues = [
-	'none',
-	'clockwise_90',
-	'180',
-	'counterclockwise_90',
-]
+export const RotationValues = ['none', 'clockwise_90', '180', 'counterclockwise_90']
 
-export const MirrorValues = [
-	'none',
-	'left_right',
-	'front_back',
-]
+export const MirrorValues = ['none', 'left_right', 'front_back']

--- a/packages/java-edition/src/mcfunction/completer/argument.ts
+++ b/packages/java-edition/src/mcfunction/completer/argument.ts
@@ -265,10 +265,8 @@ const blockStates: Completer<BlockStatesNode> = (node, ctx) => {
 						),
 						insertText: new InsertTextBuilder()
 							.literal(k)
-							.if(insertValue, (b) =>
-								b.literal('=').placeholder(...states[k]))
-							.if(insertComma, (b) =>
-								b.literal(','))
+							.if(insertValue, (b) => b.literal('=').placeholder(...states[k]))
+							.if(insertComma, (b) => b.literal(','))
 							.build(),
 					})
 				)
@@ -315,8 +313,7 @@ const componentTests: Completer<ComponentTestsNode> = (node, ctx) => {
 		node: node as Mutable<ComponentTestsNode>,
 		needle: ctx.offset,
 		endInclusive: true,
-		predicate: (n) =>
-			ComponentTestExactNode.is(n) || ComponentTestSubpredicateNode.is(n),
+		predicate: (n) => ComponentTestExactNode.is(n) || ComponentTestSubpredicateNode.is(n),
 	})
 	if (test && ComponentTestExactNode.is(test) && test.value) {
 		return completer.dispatch(test.value, ctx)
@@ -362,9 +359,7 @@ const itemPredicate: Completer<ItemPredicateNode> = (node, ctx) => {
 }
 
 const objectiveCriteria: Completer<ObjectiveCriteriaNode> = (node, ctx) => {
-	const ans = ObjectiveCriteriaNode.SimpleValues.map((v) =>
-		CompletionItem.create(v, node)
-	)
+	const ans = ObjectiveCriteriaNode.SimpleValues.map((v) => CompletionItem.create(v, node))
 	if (
 		!node.children?.[0]
 		|| Range.contains(node.children[0], ctx.offset, true)
@@ -423,9 +418,7 @@ const particle: Completer<ParticleNode> = (node, ctx) => {
 		],
 	}
 	if (ParticleNode.isSpecialType(id)) {
-		const numParamsBefore = node.children?.slice(1).filter((n) =>
-			n.range.end < ctx.offset
-		).length
+		const numParamsBefore = node.children?.slice(1).filter((n) => n.range.end < ctx.offset).length
 			?? 0
 		const mock = map[id][numParamsBefore] as
 			| typeof map[keyof typeof map][number]

--- a/packages/java-edition/src/mcfunction/completer/argument.ts
+++ b/packages/java-edition/src/mcfunction/completer/argument.ts
@@ -165,8 +165,8 @@ export const getMockNodes: mcf.completer.MockNodesGetter = (
 		case 'minecraft:resource_key':
 		case 'minecraft:resource_or_tag':
 		case 'minecraft:resource_or_tag_key':
-			const allowTag = treeNode.parser === 'minecraft:resource_or_tag' ||
-				treeNode.parser === 'minecraft:resource_or_tag_key'
+			const allowTag = treeNode.parser === 'minecraft:resource_or_tag'
+				|| treeNode.parser === 'minecraft:resource_or_tag_key'
 			return ResourceLocationNode.mock(range, {
 				category: ResourceLocation.shorten(treeNode.properties.registry) as
 					| RegistryCategory
@@ -216,14 +216,14 @@ const block: Completer<BlockNode> = (node, ctx) => {
 		ans.push(...completer.resourceLocation(node.id, ctx))
 	}
 	if (
-		node.states &&
-		Range.contains(Range.translate(node.states, 1, -1), ctx.offset, true)
+		node.states
+		&& Range.contains(Range.translate(node.states, 1, -1), ctx.offset, true)
 	) {
 		ans.push(...blockStates(node.states, ctx))
 	}
 	if (
-		node.nbt &&
-		Range.contains(Range.translate(node.nbt, 1, -1), ctx.offset, true)
+		node.nbt
+		&& Range.contains(Range.translate(node.nbt, 1, -1), ctx.offset, true)
 	) {
 		ans.push(...completer.dispatch(node.nbt, ctx))
 	}
@@ -253,8 +253,8 @@ const blockStates: Completer<BlockStatesNode> = (node, ctx) => {
 			return Object.keys(states)
 				.filter(
 					(k) =>
-						pair?.key?.value === k ||
-						!existingKeys.some((ek) => ek.value === k),
+						pair?.key?.value === k
+						|| !existingKeys.some((ek) => ek.value === k),
 				)
 				.map((k) =>
 					CompletionItem.create(k, range, {
@@ -294,8 +294,8 @@ const componentList: Completer<ComponentListNode> = (node, ctx) => {
 		ComponentListNode
 	>({
 		key: (_record, pair, ctx, range) => {
-			const id = pair?.key ??
-				ResourceLocationNode.mock(pair?.key ?? range, {
+			const id = pair?.key
+				?? ResourceLocationNode.mock(pair?.key ?? range, {
 					category: 'data_component_type',
 				})
 			return completer.resourceLocation(id, ctx)
@@ -366,13 +366,13 @@ const objectiveCriteria: Completer<ObjectiveCriteriaNode> = (node, ctx) => {
 		CompletionItem.create(v, node)
 	)
 	if (
-		!node.children?.[0] ||
-		Range.contains(node.children[0], ctx.offset, true)
+		!node.children?.[0]
+		|| Range.contains(node.children[0], ctx.offset, true)
 	) {
 		ans.push(
 			...completer.resourceLocation(
-				node.children?.[0] ??
-					ResourceLocationNode.mock(node, {
+				node.children?.[0]
+					?? ResourceLocationNode.mock(node, {
 						category: 'stat_type',
 						namespacePathSep: '.',
 					}),
@@ -381,8 +381,8 @@ const objectiveCriteria: Completer<ObjectiveCriteriaNode> = (node, ctx) => {
 		)
 	}
 	if (
-		node.children?.[1] &&
-		Range.contains(node.children[1], ctx.offset, true)
+		node.children?.[1]
+		&& Range.contains(node.children[1], ctx.offset, true)
 	) {
 		ans.push(...completer.resourceLocation(node.children[1], ctx))
 	}
@@ -425,8 +425,8 @@ const particle: Completer<ParticleNode> = (node, ctx) => {
 	if (ParticleNode.isSpecialType(id)) {
 		const numParamsBefore = node.children?.slice(1).filter((n) =>
 			n.range.end < ctx.offset
-		).length ??
-			0
+		).length
+			?? 0
 		const mock = map[id][numParamsBefore] as
 			| typeof map[keyof typeof map][number]
 			| undefined
@@ -472,8 +472,12 @@ const selector: Completer<EntitySelectorNode> = (node, ctx) => {
 		return completer.literal(node.children[0], ctx)
 	}
 	if (
-		node.arguments &&
-		Range.contains(Range.translate(node.arguments, 1, -1), ctx.offset, true)
+		node.arguments
+		&& Range.contains(
+			Range.translate(node.arguments, 1, -1),
+			ctx.offset,
+			true,
+		)
 	) {
 		return selectorArguments(node.arguments, ctx)
 	}
@@ -494,8 +498,8 @@ const selectorArguments: Completer<EntitySelectorArgumentsNode> = (
 			return [...EntitySelectorNode.ArgumentKeys]
 				.filter(
 					(k) =>
-						EntitySelectorNode.canKeyExist(selector, record, k) ===
-							EntitySelectorNode.Result.Ok,
+						EntitySelectorNode.canKeyExist(selector, record, k)
+							=== EntitySelectorNode.Result.Ok,
 				)
 				.map((k) =>
 					CompletionItem.create(k, range, {

--- a/packages/java-edition/src/mcfunction/completer/argument.ts
+++ b/packages/java-edition/src/mcfunction/completer/argument.ts
@@ -133,13 +133,9 @@ export const getMockNodes: mcf.completer.MockNodesGetter = (
 		case 'minecraft:item_predicate':
 			return ItemPredicateNode.mock(range)
 		case 'minecraft:item_slot':
-			return LiteralNode.mock(range, {
-				pool: getItemSlotArgumentValues(ctx),
-			})
+			return LiteralNode.mock(range, { pool: getItemSlotArgumentValues(ctx) })
 		case 'minecraft:item_slots':
-			return LiteralNode.mock(range, {
-				pool: getItemSlotsArgumentValues(ctx),
-			})
+			return LiteralNode.mock(range, { pool: getItemSlotsArgumentValues(ctx) })
 		case 'minecraft:item_stack':
 			return ItemStackNode.mock(range)
 		case 'minecraft:loot_modifier':
@@ -215,16 +211,10 @@ const block: Completer<BlockNode> = (node, ctx) => {
 	if (Range.contains(node.id, ctx.offset, true)) {
 		ans.push(...completer.resourceLocation(node.id, ctx))
 	}
-	if (
-		node.states
-		&& Range.contains(Range.translate(node.states, 1, -1), ctx.offset, true)
-	) {
+	if (node.states && Range.contains(Range.translate(node.states, 1, -1), ctx.offset, true)) {
 		ans.push(...blockStates(node.states, ctx))
 	}
-	if (
-		node.nbt
-		&& Range.contains(Range.translate(node.nbt, 1, -1), ctx.offset, true)
-	) {
+	if (node.nbt && Range.contains(Range.translate(node.nbt, 1, -1), ctx.offset, true)) {
 		ans.push(...completer.dispatch(node.nbt, ctx))
 	}
 	return ans
@@ -241,42 +231,27 @@ const blockStates: Completer<BlockStatesNode> = (node, ctx) => {
 	const states = getStates('block', blocks, ctx)
 
 	return completer.record<StringNode, StringNode, BlockStatesNode>({
-		key: (
-			_record,
-			pair,
-			_ctx,
-			range,
-			insertValue,
-			insertComma,
-			existingKeys,
-		) => {
-			return Object.keys(states)
-				.filter(
-					(k) =>
-						pair?.key?.value === k
-						|| !existingKeys.some((ek) => ek.value === k),
-				)
-				.map((k) =>
-					CompletionItem.create(k, range, {
-						kind: CompletionKind.Property,
-						detail: localize(
-							'mcfunction.completer.block.states.default-value',
-							localeQuote(states[k][0]),
-						),
-						insertText: new InsertTextBuilder()
-							.literal(k)
-							.if(insertValue, (b) => b.literal('=').placeholder(...states[k]))
-							.if(insertComma, (b) => b.literal(','))
-							.build(),
-					})
-				)
+		key: (_record, pair, _ctx, range, insertValue, insertComma, existingKeys) => {
+			return Object.keys(states).filter((k) =>
+				pair?.key?.value === k || !existingKeys.some((ek) => ek.value === k)
+			).map((k) =>
+				CompletionItem.create(k, range, {
+					kind: CompletionKind.Property,
+					detail: localize(
+						'mcfunction.completer.block.states.default-value',
+						localeQuote(states[k][0]),
+					),
+					insertText: new InsertTextBuilder().literal(k).if(
+						insertValue,
+						(b) => b.literal('=').placeholder(...states[k]),
+					).if(insertComma, (b) => b.literal(',')).build(),
+				})
+			)
 		},
 		value: (_record, pair, ctx) => {
 			if (pair.key && states[pair.key.value]) {
 				return states[pair.key.value].map((v) =>
-					CompletionItem.create(v, pair.value ?? ctx.offset, {
-						kind: CompletionKind.Value,
-					})
+					CompletionItem.create(v, pair.value ?? ctx.offset, { kind: CompletionKind.Value })
 				)
 			}
 
@@ -286,16 +261,10 @@ const blockStates: Completer<BlockStatesNode> = (node, ctx) => {
 }
 
 const componentList: Completer<ComponentListNode> = (node, ctx) => {
-	return completer.record<
-		ResourceLocationNode,
-		nbt.NbtNode,
-		ComponentListNode
-	>({
+	return completer.record<ResourceLocationNode, nbt.NbtNode, ComponentListNode>({
 		key: (_record, pair, ctx, range) => {
 			const id = pair?.key
-				?? ResourceLocationNode.mock(pair?.key ?? range, {
-					category: 'data_component_type',
-				})
+				?? ResourceLocationNode.mock(pair?.key ?? range, { category: 'data_component_type' })
 			return completer.resourceLocation(id, ctx)
 		},
 		value: (_record, pair, ctx) => {
@@ -360,25 +329,16 @@ const itemPredicate: Completer<ItemPredicateNode> = (node, ctx) => {
 
 const objectiveCriteria: Completer<ObjectiveCriteriaNode> = (node, ctx) => {
 	const ans = ObjectiveCriteriaNode.SimpleValues.map((v) => CompletionItem.create(v, node))
-	if (
-		!node.children?.[0]
-		|| Range.contains(node.children[0], ctx.offset, true)
-	) {
+	if (!node.children?.[0] || Range.contains(node.children[0], ctx.offset, true)) {
 		ans.push(
 			...completer.resourceLocation(
 				node.children?.[0]
-					?? ResourceLocationNode.mock(node, {
-						category: 'stat_type',
-						namespacePathSep: '.',
-					}),
+					?? ResourceLocationNode.mock(node, { category: 'stat_type', namespacePathSep: '.' }),
 				ctx,
 			),
 		)
 	}
-	if (
-		node.children?.[1]
-		&& Range.contains(node.children[1], ctx.offset, true)
-	) {
+	if (node.children?.[1] && Range.contains(node.children[1], ctx.offset, true)) {
 		ans.push(...completer.resourceLocation(node.children[1], ctx))
 	}
 	return ans
@@ -398,10 +358,7 @@ const particle: Completer<ParticleNode> = (node, ctx) => {
 	const map: Record<ParticleNode.SpecialType, AstNode[]> = {
 		block: [BlockNode.mock(ctx.offset, false)],
 		block_marker: [BlockNode.mock(ctx.offset, false)],
-		dust: [
-			VectorNode.mock(ctx.offset, { dimension: 3 }),
-			FloatNode.mock(ctx.offset),
-		],
+		dust: [VectorNode.mock(ctx.offset, { dimension: 3 }), FloatNode.mock(ctx.offset)],
 		dust_color_transition: [
 			VectorNode.mock(ctx.offset, { dimension: 3 }),
 			FloatNode.mock(ctx.offset),
@@ -420,9 +377,7 @@ const particle: Completer<ParticleNode> = (node, ctx) => {
 	if (ParticleNode.isSpecialType(id)) {
 		const numParamsBefore = node.children?.slice(1).filter((n) => n.range.end < ctx.offset).length
 			?? 0
-		const mock = map[id][numParamsBefore] as
-			| typeof map[keyof typeof map][number]
-			| undefined
+		const mock = map[id][numParamsBefore] as typeof map[keyof typeof map][number] | undefined
 		if (mock) {
 			return completer.dispatch(mock, ctx)
 		}
@@ -436,12 +391,7 @@ const scoreHolder: Completer<ScoreHolderNode> = (node, ctx) => {
 	if (node.selector && Range.contains(node.selector, ctx.offset, true)) {
 		ans = selector(node.selector, ctx)
 		if (Range.contains(node.children[0], ctx.offset, true)) {
-			ans.push(
-				...completer.symbol(
-					SymbolNode.mock(node, { category: 'score_holder' }),
-					ctx,
-				),
-			)
+			ans.push(...completer.symbol(SymbolNode.mock(node, { category: 'score_holder' }), ctx))
 		}
 	} else {
 		ans = completer.symbol(
@@ -450,9 +400,7 @@ const scoreHolder: Completer<ScoreHolderNode> = (node, ctx) => {
 		)
 		ans.push(
 			...selector(
-				EntitySelectorNode.mock(node, {
-					pool: EntitySelectorAtVariable.filterAvailable(ctx),
-				}),
+				EntitySelectorNode.mock(node, { pool: EntitySelectorAtVariable.filterAvailable(ctx) }),
 				ctx,
 			),
 		)
@@ -464,23 +412,13 @@ const selector: Completer<EntitySelectorNode> = (node, ctx) => {
 	if (Range.contains(node.children[0], ctx.offset, true)) {
 		return completer.literal(node.children[0], ctx)
 	}
-	if (
-		node.arguments
-		&& Range.contains(
-			Range.translate(node.arguments, 1, -1),
-			ctx.offset,
-			true,
-		)
-	) {
+	if (node.arguments && Range.contains(Range.translate(node.arguments, 1, -1), ctx.offset, true)) {
 		return selectorArguments(node.arguments, ctx)
 	}
 	return []
 }
 
-const selectorArguments: Completer<EntitySelectorArgumentsNode> = (
-	node,
-	ctx,
-) => {
+const selectorArguments: Completer<EntitySelectorArgumentsNode> = (node, ctx) => {
 	const selector = node.parent
 	if (!EntitySelectorNode.is(selector)) {
 		return []
@@ -488,22 +426,18 @@ const selectorArguments: Completer<EntitySelectorArgumentsNode> = (
 
 	return completer.record<StringNode, any, EntitySelectorArgumentsNode>({
 		key: (record, pair, _ctx, range, insertValue, insertComma) => {
-			return [...EntitySelectorNode.ArgumentKeys]
-				.filter(
-					(k) =>
-						EntitySelectorNode.canKeyExist(selector, record, k)
-							=== EntitySelectorNode.Result.Ok,
-				)
-				.map((k) =>
-					CompletionItem.create(k, range, {
-						kind: CompletionKind.Property,
-						insertText: new InsertTextBuilder()
-							.literal(k)
-							.if(insertValue, (b) => b.literal('=').placeholder()) // TODO
-							.if(insertComma, (b) => b.literal(','))
-							.build(),
-					})
-				)
+			return [...EntitySelectorNode.ArgumentKeys].filter((k) =>
+				EntitySelectorNode.canKeyExist(selector, record, k) === EntitySelectorNode.Result.Ok
+			).map((k) =>
+				CompletionItem.create(k, range, {
+					kind: CompletionKind.Property,
+					insertText: new InsertTextBuilder().literal(k).if(
+						insertValue,
+						(b) => b.literal('=').placeholder(),
+					) // TODO
+						.if(insertComma, (b) => b.literal(',')).build(),
+				})
+			)
 		},
 		value: (_record, pair, ctx) => {
 			if (pair.value) {
@@ -516,19 +450,15 @@ const selectorArguments: Completer<EntitySelectorArgumentsNode> = (
 
 const intRange: Completer<IntRangeNode> = (node, _ctx) => {
 	return [
-		CompletionItem.create('-2147483648..2147483647', node, {
-			kind: CompletionKind.Constant,
-		}),
+		CompletionItem.create('-2147483648..2147483647', node, { kind: CompletionKind.Constant }),
 	]
 }
 
 const vector: Completer<VectorNode> = (node, _ctx) => {
 	const createCompletion = (coordinate: '~' | '^' | '0.0', sortText: string) =>
-		CompletionItem.create(
-			new Array(node.options.dimension).fill(coordinate).join(' '),
-			node,
-			{ sortText },
-		)
+		CompletionItem.create(new Array(node.options.dimension).fill(coordinate).join(' '), node, {
+			sortText,
+		})
 
 	const ans: CompletionItem[] = []
 	ans.push(createCompletion('~', 'a'))
@@ -542,37 +472,19 @@ const vector: Completer<VectorNode> = (node, _ctx) => {
 
 export function register(meta: MetaRegistry) {
 	meta.registerCompleter<BlockNode>('mcfunction:block', block)
-	meta.registerCompleter<ComponentListNode>(
-		'mcfunction:component_list',
-		componentList,
-	)
-	meta.registerCompleter<ComponentTestsNode>(
-		'mcfunction:component_tests',
-		componentTests,
-	)
+	meta.registerCompleter<ComponentListNode>('mcfunction:component_list', componentList)
+	meta.registerCompleter<ComponentTestsNode>('mcfunction:component_tests', componentTests)
 	meta.registerCompleter<CoordinateNode>('mcfunction:coordinate', coordinate)
-	meta.registerCompleter<EntitySelectorNode>(
-		'mcfunction:entity_selector',
-		selector,
-	)
+	meta.registerCompleter<EntitySelectorNode>('mcfunction:entity_selector', selector)
 	meta.registerCompleter<EntitySelectorArgumentsNode>(
 		'mcfunction:entity_selector/arguments',
 		selectorArguments,
 	)
 	meta.registerCompleter<IntRangeNode>('mcfunction:int_range', intRange)
 	meta.registerCompleter<ItemStackNode>('mcfunction:item_stack', itemStack)
-	meta.registerCompleter<ItemPredicateNode>(
-		'mcfunction:item_predicate',
-		itemPredicate,
-	)
-	meta.registerCompleter<ObjectiveCriteriaNode>(
-		'mcfunction:objective_criteria',
-		objectiveCriteria,
-	)
+	meta.registerCompleter<ItemPredicateNode>('mcfunction:item_predicate', itemPredicate)
+	meta.registerCompleter<ObjectiveCriteriaNode>('mcfunction:objective_criteria', objectiveCriteria)
 	meta.registerCompleter<ParticleNode>('mcfunction:particle', particle)
-	meta.registerCompleter<ScoreHolderNode>(
-		'mcfunction:score_holder',
-		scoreHolder,
-	)
+	meta.registerCompleter<ScoreHolderNode>('mcfunction:score_holder', scoreHolder)
 	meta.registerCompleter<VectorNode>('mcfunction:vector', vector)
 }

--- a/packages/java-edition/src/mcfunction/index.ts
+++ b/packages/java-edition/src/mcfunction/index.ts
@@ -37,37 +37,16 @@ export const initialize = (
 
 	meta.registerLanguage('mcfunction', {
 		extensions: ['.mcfunction'],
-		parser: mcf.entry(tree, parser.argument, {
-			supportsBackslashContinuation,
-			supportsMacros,
-		}),
+		parser: mcf.entry(tree, parser.argument, { supportsBackslashContinuation, supportsMacros }),
 		completer: mcf.completer.entry(tree, completer.getMockNodes),
-		triggerCharacters: [
-			' ',
-			'[',
-			'=',
-			'!',
-			',',
-			'{',
-			':',
-			'/',
-			'.',
-			'"',
-			"'",
-		],
+		triggerCharacters: [' ', '[', '=', '!', ',', '{', ':', '/', '.', '"', "'"],
 	})
 
 	meta.registerParser('mcfunction:block_predicate', parser.blockPredicate)
 	meta.registerParser('mcfunction:particle', parser.particle)
 	meta.registerParser('mcfunction:tag', parser.tag())
 	meta.registerParser('mcfunction:team', parser.team())
-	meta.registerParser<mcf.CommandNode>(
-		'mcfunction:command',
-		mcf.command(
-			tree,
-			parser.argument,
-		),
-	)
+	meta.registerParser<mcf.CommandNode>('mcfunction:command', mcf.command(tree, parser.argument))
 
 	registerMcdocAttributes(meta, tree)
 

--- a/packages/java-edition/src/mcfunction/index.ts
+++ b/packages/java-edition/src/mcfunction/index.ts
@@ -32,8 +32,7 @@ export const initialize = (
 
 	mcf.initialize(ctx)
 
-	const supportsBackslashContinuation =
-		ReleaseVersion.cmp(releaseVersion, '1.20.2') >= 0
+	const supportsBackslashContinuation = ReleaseVersion.cmp(releaseVersion, '1.20.2') >= 0
 	const supportsMacros = ReleaseVersion.cmp(releaseVersion, '1.20.2') >= 0
 
 	meta.registerLanguage('mcfunction', {

--- a/packages/java-edition/src/mcfunction/inlayHintProvider.ts
+++ b/packages/java-edition/src/mcfunction/inlayHintProvider.ts
@@ -16,9 +16,9 @@ export const inlayHintProvider: core.InlayHintProvider<
 			const node = n as mcf.CommandChildNode
 			const config = ctx.config.env.feature.inlayHint
 			if (
-				config === true ||
-				(typeof config === 'object' &&
-					config.enabledNodes.includes(node.children[0].type))
+				config === true
+				|| (typeof config === 'object'
+					&& config.enabledNodes.includes(node.children[0].type))
 			) {
 				ans.push({
 					offset: node.range.start,

--- a/packages/java-edition/src/mcfunction/inlayHintProvider.ts
+++ b/packages/java-edition/src/mcfunction/inlayHintProvider.ts
@@ -1,32 +1,27 @@
 import * as core from '@spyglassmc/core'
 import * as mcf from '@spyglassmc/mcfunction'
 
-export const inlayHintProvider: core.InlayHintProvider<
-	core.FileNode<mcf.McfunctionNode>
-> = (node, ctx) => {
+export const inlayHintProvider: core.InlayHintProvider<core.FileNode<mcf.McfunctionNode>> = (
+	node,
+	ctx,
+) => {
 	if (node.children[0]?.type !== 'mcfunction:entry') {
 		return []
 	}
 	const ans: core.InlayHint[] = []
-	core.traversePreOrder(
-		node,
-		(_) => true,
-		mcf.CommandChildNode.is,
-		(n) => {
-			const node = n as mcf.CommandChildNode
-			const config = ctx.config.env.feature.inlayHint
-			if (
-				config === true
-				|| (typeof config === 'object'
-					&& config.enabledNodes.includes(node.children[0].type))
-			) {
-				ans.push({
-					offset: node.range.start,
-					label: `${node.path[node.path.length - 1]}:`,
-					paddingRight: true,
-				})
-			}
-		},
-	)
+	core.traversePreOrder(node, (_) => true, mcf.CommandChildNode.is, (n) => {
+		const node = n as mcf.CommandChildNode
+		const config = ctx.config.env.feature.inlayHint
+		if (
+			config === true
+			|| (typeof config === 'object' && config.enabledNodes.includes(node.children[0].type))
+		) {
+			ans.push({
+				offset: node.range.start,
+				label: `${node.path[node.path.length - 1]}:`,
+				paddingRight: true,
+			})
+		}
+	})
 	return ans
 }

--- a/packages/java-edition/src/mcfunction/mcdocAttributes.ts
+++ b/packages/java-edition/src/mcfunction/mcdocAttributes.ts
@@ -3,11 +3,7 @@ import { localize } from '@spyglassmc/locales'
 import * as mcdoc from '@spyglassmc/mcdoc'
 import * as mcf from '@spyglassmc/mcfunction'
 import { getItemSlotsArgumentValues } from './common/index.js'
-import {
-	EntitySelectorAtVariable,
-	EntitySelectorNode,
-	ScoreHolderNode,
-} from './node/argument.js'
+import { EntitySelectorAtVariable, EntitySelectorNode, ScoreHolderNode } from './node/argument.js'
 import * as parser from './parser/index.js'
 
 export function registerMcdocAttributes(
@@ -30,13 +26,11 @@ export function registerMcdocAttributes(
 	})
 	mcdoc.runtime.registerAttribute(meta, 'objective', () => undefined, {
 		stringParser: () => parser.objective('reference'),
-		stringMocker: (_, ctx) =>
-			core.SymbolNode.mock(ctx.offset, { category: 'objective' }),
+		stringMocker: (_, ctx) => core.SymbolNode.mock(ctx.offset, { category: 'objective' }),
 	})
 	mcdoc.runtime.registerAttribute(meta, 'team', () => undefined, {
 		stringParser: () => parser.team('reference'),
-		stringMocker: (_, ctx) =>
-			core.SymbolNode.mock(ctx.offset, { category: 'team' }),
+		stringMocker: (_, ctx) => core.SymbolNode.mock(ctx.offset, { category: 'team' }),
 	})
 	mcdoc.runtime.registerAttribute(meta, 'score_holder', () => undefined, {
 		stringParser: () =>
@@ -47,8 +41,7 @@ export function registerMcdocAttributes(
 		stringMocker: (_, ctx) => ScoreHolderNode.mock(ctx.offset),
 	})
 	mcdoc.runtime.registerAttribute(meta, 'selector', () => undefined, {
-		stringParser: () =>
-			makeInfallible(parser.selector(), localize('selector')),
+		stringParser: () => makeInfallible(parser.selector(), localize('selector')),
 		stringMocker: (_, ctx) =>
 			EntitySelectorNode.mock(ctx.offset, {
 				pool: EntitySelectorAtVariable.filterAvailable(ctx),

--- a/packages/java-edition/src/mcfunction/mcdocAttributes.ts
+++ b/packages/java-edition/src/mcfunction/mcdocAttributes.ts
@@ -6,10 +6,7 @@ import { getItemSlotsArgumentValues } from './common/index.js'
 import { EntitySelectorAtVariable, EntitySelectorNode, ScoreHolderNode } from './node/argument.js'
 import * as parser from './parser/index.js'
 
-export function registerMcdocAttributes(
-	meta: core.MetaRegistry,
-	rootTreeNode: mcf.RootTreeNode,
-) {
+export function registerMcdocAttributes(meta: core.MetaRegistry, rootTreeNode: mcf.RootTreeNode) {
 	mcdoc.runtime.registerAttribute(meta, 'command', () => undefined, {
 		// TODO: validate slash
 		// TODO: fix completer inside commands
@@ -33,11 +30,7 @@ export function registerMcdocAttributes(
 		stringMocker: (_, ctx) => core.SymbolNode.mock(ctx.offset, { category: 'team' }),
 	})
 	mcdoc.runtime.registerAttribute(meta, 'score_holder', () => undefined, {
-		stringParser: () =>
-			makeInfallible(
-				parser.scoreHolder('multiple'),
-				localize('score-holder'),
-			),
+		stringParser: () => makeInfallible(parser.scoreHolder('multiple'), localize('score-holder')),
 		stringMocker: (_, ctx) => ScoreHolderNode.mock(ctx.offset),
 	})
 	mcdoc.runtime.registerAttribute(meta, 'selector', () => undefined, {
@@ -50,9 +43,7 @@ export function registerMcdocAttributes(
 	mcdoc.runtime.registerAttribute(meta, 'item_slots', () => undefined, {
 		stringParser: () => parser.itemSlots,
 		stringMocker: (_, ctx) =>
-			core.LiteralNode.mock(ctx.offset, {
-				pool: getItemSlotsArgumentValues(ctx),
-			}),
+			core.LiteralNode.mock(ctx.offset, { pool: getItemSlotsArgumentValues(ctx) }),
 	})
 	mcdoc.runtime.registerAttribute(meta, 'uuid', () => undefined, {
 		stringParser: () => parser.uuid,

--- a/packages/java-edition/src/mcfunction/node/argument.ts
+++ b/packages/java-edition/src/mcfunction/node/argument.ts
@@ -4,9 +4,7 @@ import type * as nbt from '@spyglassmc/nbt'
 import { ReleaseVersion } from '../../dependency/common.js'
 import type { NbtParserProperties } from '../tree/argument.js'
 
-export interface BlockStatesNode
-	extends core.RecordBaseNode<core.StringNode, core.StringNode>
-{
+export interface BlockStatesNode extends core.RecordBaseNode<core.StringNode, core.StringNode> {
 	type: 'mcfunction:block/states'
 }
 export namespace BlockStatesNode {
@@ -87,12 +85,11 @@ export interface EntitySelectorAdvancementsArgumentCriteriaNode
 {
 	type: 'mcfunction:entity_selector/arguments/advancements/criteria'
 }
-export interface EntitySelectorAdvancementsArgumentNode
-	extends
-		core.RecordBaseNode<
-			core.ResourceLocationNode,
-			core.BooleanNode | EntitySelectorAdvancementsArgumentCriteriaNode
-		>
+export interface EntitySelectorAdvancementsArgumentNode extends
+	core.RecordBaseNode<
+		core.ResourceLocationNode,
+		core.BooleanNode | EntitySelectorAdvancementsArgumentCriteriaNode
+	>
 {
 	type: 'mcfunction:entity_selector/arguments/advancements'
 }
@@ -108,9 +105,7 @@ export interface EntitySelectorInvertableArgumentValueNode<
 	value: T
 	inverted: boolean
 }
-export interface EntitySelectorArgumentsNode
-	extends core.RecordBaseNode<core.StringNode, any>
-{
+export interface EntitySelectorArgumentsNode extends core.RecordBaseNode<core.StringNode, any> {
 	type: 'mcfunction:entity_selector/arguments'
 }
 export namespace EntitySelectorArgumentsNode {
@@ -228,8 +223,7 @@ export namespace EntitySelectorNode {
 		argument: core.DeepReadonly<EntitySelectorArgumentsNode>,
 		key: string,
 	): Result {
-		const hasKey = (key: string): boolean =>
-			!!argument.children.find((p) => p.key?.value === key)
+		const hasKey = (key: string): boolean => !!argument.children.find((p) => p.key?.value === key)
 		const hasNonInvertedKey = (key: string): boolean =>
 			!!argument.children.find(
 				(p) =>
@@ -295,8 +289,7 @@ export interface FloatRangeNode extends core.AstNode {
 
 export interface ItemStackNode extends core.AstNode {
 	type: 'mcfunction:item_stack'
-	children:
-		(core.ResourceLocationNode | ComponentListNode | nbt.NbtCompoundNode)[]
+	children: (core.ResourceLocationNode | ComponentListNode | nbt.NbtCompoundNode)[]
 	id: core.ResourceLocationNode
 	components?: ComponentListNode // since 1.20.5
 	nbt?: nbt.NbtCompoundNode // until 1.20.5

--- a/packages/java-edition/src/mcfunction/node/argument.ts
+++ b/packages/java-edition/src/mcfunction/node/argument.ts
@@ -117,8 +117,8 @@ export namespace EntitySelectorArgumentsNode {
 	/* istanbul ignore next */
 	export function is(node: core.AstNode): node is EntitySelectorArgumentsNode {
 		return (
-			(node as EntitySelectorArgumentsNode).type ===
-				'mcfunction:entity_selector/arguments'
+			(node as EntitySelectorArgumentsNode).type
+				=== 'mcfunction:entity_selector/arguments'
 		)
 	}
 }
@@ -148,8 +148,8 @@ export namespace EntitySelectorAtVariable {
 	export function filterAvailable(ctx: core.ContextBase) {
 		const release = ctx.project['loadedVersion'] as ReleaseVersion | undefined
 		return EntitySelectorAtVariables.filter(variable =>
-			!(variable === '@n' && release &&
-				ReleaseVersion.cmp(release, '1.21') < 0)
+			!(variable === '@n' && release
+				&& ReleaseVersion.cmp(release, '1.21') < 0)
 		)
 	}
 }
@@ -172,8 +172,8 @@ export namespace EntitySelectorNode {
 		node: T,
 	): node is core.InheritReadonly<EntitySelectorNode, T> {
 		return (
-			(node as EntitySelectorNode | undefined)?.type ===
-				'mcfunction:entity_selector'
+			(node as EntitySelectorNode | undefined)?.type
+				=== 'mcfunction:entity_selector'
 		)
 	}
 
@@ -233,8 +233,8 @@ export namespace EntitySelectorNode {
 		const hasNonInvertedKey = (key: string): boolean =>
 			!!argument.children.find(
 				(p) =>
-					p.key?.value === key &&
-					!(p.value as EntitySelectorInvertableArgumentValueNode<
+					p.key?.value === key
+					&& !(p.value as EntitySelectorInvertableArgumentValueNode<
 						core.AstNode
 					>)
 						?.inverted,
@@ -303,8 +303,8 @@ export interface ItemStackNode extends core.AstNode {
 }
 export namespace ItemStackNode {
 	export function is(node: core.AstNode | undefined): node is ItemStackNode {
-		return (node as ItemStackNode | undefined)?.type ===
-			'mcfunction:item_stack'
+		return (node as ItemStackNode | undefined)?.type
+			=== 'mcfunction:item_stack'
 	}
 
 	export function mock(
@@ -347,8 +347,8 @@ export namespace ItemPredicateNode {
 	export function is(
 		node: core.AstNode | undefined,
 	): node is ItemPredicateNode {
-		return (node as ItemPredicateNode | undefined)?.type ===
-			'mcfunction:item_predicate'
+		return (node as ItemPredicateNode | undefined)?.type
+			=== 'mcfunction:item_predicate'
 	}
 
 	export function mock(
@@ -385,8 +385,8 @@ export interface ComponentTestsAnyOfNode extends core.AstNode {
 
 export namespace ComponentTestsAnyOfNode {
 	export function is(node: core.AstNode): node is ComponentTestsAnyOfNode {
-		return (node as ComponentTestsAnyOfNode).type ===
-			'mcfunction:component_tests_any_of'
+		return (node as ComponentTestsAnyOfNode).type
+			=== 'mcfunction:component_tests_any_of'
 	}
 }
 
@@ -397,8 +397,8 @@ export interface ComponentTestsAllOfNode extends core.AstNode {
 
 export namespace ComponentTestsAllOfNode {
 	export function is(node: core.AstNode): node is ComponentTestsAllOfNode {
-		return (node as ComponentTestsAllOfNode).type ===
-			'mcfunction:component_tests_all_of'
+		return (node as ComponentTestsAllOfNode).type
+			=== 'mcfunction:component_tests_all_of'
 	}
 }
 
@@ -419,8 +419,8 @@ export interface ComponentTestExactNode extends ComponentTestBaseNode {
 }
 export namespace ComponentTestExactNode {
 	export function is(node: core.AstNode): node is ComponentTestExactNode {
-		return (node as ComponentTestExactNode).type ===
-			'mcfunction:component_test_exact'
+		return (node as ComponentTestExactNode).type
+			=== 'mcfunction:component_test_exact'
 	}
 }
 
@@ -431,8 +431,8 @@ export interface ComponentTestExistsNode extends ComponentTestBaseNode {
 }
 export namespace ComponentTestExistsNode {
 	export function is(node: core.AstNode): node is ComponentTestExistsNode {
-		return (node as ComponentTestExistsNode).type ===
-			'mcfunction:component_test_exists'
+		return (node as ComponentTestExistsNode).type
+			=== 'mcfunction:component_test_exists'
 	}
 }
 
@@ -446,8 +446,8 @@ export namespace ComponentTestSubpredicateNode {
 	export function is(
 		node: core.AstNode,
 	): node is ComponentTestSubpredicateNode {
-		return (node as ComponentTestSubpredicateNode).type ===
-			'mcfunction:component_test_sub_predicate'
+		return (node as ComponentTestSubpredicateNode).type
+			=== 'mcfunction:component_test_sub_predicate'
 	}
 }
 

--- a/packages/java-edition/src/mcfunction/node/argument.ts
+++ b/packages/java-edition/src/mcfunction/node/argument.ts
@@ -15,36 +15,19 @@ export namespace BlockStatesNode {
 }
 export interface BlockNode extends core.AstNode {
 	type: 'mcfunction:block'
-	children: (
-		| core.ResourceLocationNode
-		| BlockStatesNode
-		| nbt.NbtCompoundNode
-	)[]
+	children: (core.ResourceLocationNode | BlockStatesNode | nbt.NbtCompoundNode)[]
 	id: core.ResourceLocationNode
 	states?: BlockStatesNode
 	nbt?: nbt.NbtCompoundNode
 }
 export namespace BlockNode {
-	export function is(
-		node: core.DeepReadonly<core.AstNode> | undefined,
-	): node is BlockNode {
+	export function is(node: core.DeepReadonly<core.AstNode> | undefined): node is BlockNode {
 		return (node as BlockNode | undefined)?.type === 'mcfunction:block'
 	}
 
-	export function mock(
-		range: core.RangeLike,
-		isPredicate: boolean,
-	): BlockNode {
-		const id = core.ResourceLocationNode.mock(range, {
-			category: 'block',
-			allowTag: isPredicate,
-		})
-		return {
-			type: 'mcfunction:block',
-			range: core.Range.get(range),
-			children: [id],
-			id,
-		}
+	export function mock(range: core.RangeLike, isPredicate: boolean): BlockNode {
+		const id = core.ResourceLocationNode.mock(range, { category: 'block', allowTag: isPredicate })
+		return { type: 'mcfunction:block', range: core.Range.get(range), children: [id], id }
 	}
 }
 
@@ -57,12 +40,7 @@ export interface CoordinateNode extends core.FloatBaseNode {
 }
 export namespace CoordinateNode {
 	export function mock(range: core.RangeLike): CoordinateNode {
-		return {
-			type: 'mcfunction:coordinate',
-			range: core.Range.get(range),
-			notation: '',
-			value: 0,
-		}
+		return { type: 'mcfunction:coordinate', range: core.Range.get(range), notation: '', value: 0 }
 	}
 
 	/**
@@ -98,9 +76,9 @@ export interface EntitySelectorScoresArgumentNode
 {
 	type: 'mcfunction:entity_selector/arguments/scores'
 }
-export interface EntitySelectorInvertableArgumentValueNode<
-	T extends core.AstNode,
-> extends core.SequenceNode<core.LiteralNode | T> {
+export interface EntitySelectorInvertableArgumentValueNode<T extends core.AstNode>
+	extends core.SequenceNode<core.LiteralNode | T>
+{
 	type: 'mcfunction:entity_selector/arguments/value/invertable'
 	value: T
 	inverted: boolean
@@ -111,10 +89,7 @@ export interface EntitySelectorArgumentsNode extends core.RecordBaseNode<core.St
 export namespace EntitySelectorArgumentsNode {
 	/* istanbul ignore next */
 	export function is(node: core.AstNode): node is EntitySelectorArgumentsNode {
-		return (
-			(node as EntitySelectorArgumentsNode).type
-				=== 'mcfunction:entity_selector/arguments'
-		)
+		return ((node as EntitySelectorArgumentsNode).type === 'mcfunction:entity_selector/arguments')
 	}
 }
 const EntitySelectorVariables = ['a', 'e', 'p', 'r', 's', 'n'] as const
@@ -125,16 +100,12 @@ export namespace EntitySelectorVariable {
 		return EntitySelectorVariables.includes(value as EntitySelectorVariable)
 	}
 }
-const EntitySelectorAtVariables = EntitySelectorVariables.map(
-	(v) => `@${v}` as const,
-)
+const EntitySelectorAtVariables = EntitySelectorVariables.map((v) => `@${v}` as const)
 export type EntitySelectorAtVariable = typeof EntitySelectorAtVariables[number]
 export namespace EntitySelectorAtVariable {
 	/* istanbul ignore next */
 	export function is(value: string): value is EntitySelectorAtVariable {
-		return EntitySelectorAtVariables.includes(
-			value as EntitySelectorAtVariable,
-		)
+		return EntitySelectorAtVariables.includes(value as EntitySelectorAtVariable)
 	}
 
 	/**
@@ -143,8 +114,7 @@ export namespace EntitySelectorAtVariable {
 	export function filterAvailable(ctx: core.ContextBase) {
 		const release = ctx.project['loadedVersion'] as ReleaseVersion | undefined
 		return EntitySelectorAtVariables.filter(variable =>
-			!(variable === '@n' && release
-				&& ReleaseVersion.cmp(release, '1.21') < 0)
+			!(variable === '@n' && release && ReleaseVersion.cmp(release, '1.21') < 0)
 		)
 	}
 }
@@ -166,16 +136,10 @@ export namespace EntitySelectorNode {
 	export function is<T extends core.DeepReadonly<core.AstNode> | undefined>(
 		node: T,
 	): node is core.InheritReadonly<EntitySelectorNode, T> {
-		return (
-			(node as EntitySelectorNode | undefined)?.type
-				=== 'mcfunction:entity_selector'
-		)
+		return ((node as EntitySelectorNode | undefined)?.type === 'mcfunction:entity_selector')
 	}
 
-	export function mock(
-		range: core.RangeLike,
-		options: core.LiteralOptions,
-	): EntitySelectorNode {
+	export function mock(range: core.RangeLike, options: core.LiteralOptions): EntitySelectorNode {
 		const literal = core.LiteralNode.mock(range, options)
 		return {
 			type: 'mcfunction:entity_selector',
@@ -210,8 +174,7 @@ export namespace EntitySelectorNode {
 			'y_rotation',
 		] as const,
 	)
-	export type ArgumentKey = typeof ArgumentKeys extends Set<infer T> ? T
-		: undefined
+	export type ArgumentKey = typeof ArgumentKeys extends Set<infer T> ? T : undefined
 
 	export const enum Result {
 		Ok,
@@ -225,13 +188,9 @@ export namespace EntitySelectorNode {
 	): Result {
 		const hasKey = (key: string): boolean => !!argument.children.find((p) => p.key?.value === key)
 		const hasNonInvertedKey = (key: string): boolean =>
-			!!argument.children.find(
-				(p) =>
-					p.key?.value === key
-					&& !(p.value as EntitySelectorInvertableArgumentValueNode<
-						core.AstNode
-					>)
-						?.inverted,
+			!!argument.children.find((p) =>
+				p.key?.value === key
+				&& !(p.value as EntitySelectorInvertableArgumentValueNode<core.AstNode>)?.inverted
 			)
 		switch (key) {
 			case 'advancements':
@@ -260,9 +219,7 @@ export namespace EntitySelectorNode {
 					: Result.Ok
 			case 'type':
 				return selector.typeLimited
-					? hasKey(key)
-						? Result.Duplicated
-						: Result.NotApplicable
+					? hasKey(key) ? Result.Duplicated : Result.NotApplicable
 					: Result.Ok
 		}
 		return Result.Ok
@@ -296,20 +253,12 @@ export interface ItemStackNode extends core.AstNode {
 }
 export namespace ItemStackNode {
 	export function is(node: core.AstNode | undefined): node is ItemStackNode {
-		return (node as ItemStackNode | undefined)?.type
-			=== 'mcfunction:item_stack'
+		return (node as ItemStackNode | undefined)?.type === 'mcfunction:item_stack'
 	}
 
-	export function mock(
-		range: core.RangeLike,
-	): ItemStackNode {
+	export function mock(range: core.RangeLike): ItemStackNode {
 		const id = core.ResourceLocationNode.mock(range, { category: 'item' })
-		return {
-			type: 'mcfunction:item_stack',
-			range: core.Range.get(range),
-			children: [id],
-			id,
-		}
+		return { type: 'mcfunction:item_stack', range: core.Range.get(range), children: [id], id }
 	}
 }
 
@@ -326,37 +275,20 @@ export namespace ComponentListNode {
 
 export interface ItemPredicateNode extends core.AstNode {
 	type: 'mcfunction:item_predicate'
-	children: (
-		| core.ResourceLocationNode
-		| core.LiteralNode
-		| ComponentTestsNode
-		| nbt.NbtCompoundNode
-	)[]
+	children:
+		(core.ResourceLocationNode | core.LiteralNode | ComponentTestsNode | nbt.NbtCompoundNode)[]
 	id: core.ResourceLocationNode | core.LiteralNode
 	tests?: ComponentTestsNode // since 1.20.5
 	nbt?: nbt.NbtCompoundNode // until 1.20.5
 }
 export namespace ItemPredicateNode {
-	export function is(
-		node: core.AstNode | undefined,
-	): node is ItemPredicateNode {
-		return (node as ItemPredicateNode | undefined)?.type
-			=== 'mcfunction:item_predicate'
+	export function is(node: core.AstNode | undefined): node is ItemPredicateNode {
+		return (node as ItemPredicateNode | undefined)?.type === 'mcfunction:item_predicate'
 	}
 
-	export function mock(
-		range: core.RangeLike,
-	): ItemPredicateNode {
-		const id = core.ResourceLocationNode.mock(range, {
-			category: 'item',
-			allowTag: true,
-		})
-		return {
-			type: 'mcfunction:item_predicate',
-			range: core.Range.get(range),
-			children: [id],
-			id,
-		}
+	export function mock(range: core.RangeLike): ItemPredicateNode {
+		const id = core.ResourceLocationNode.mock(range, { category: 'item', allowTag: true })
+		return { type: 'mcfunction:item_predicate', range: core.Range.get(range), children: [id], id }
 	}
 }
 
@@ -378,8 +310,7 @@ export interface ComponentTestsAnyOfNode extends core.AstNode {
 
 export namespace ComponentTestsAnyOfNode {
 	export function is(node: core.AstNode): node is ComponentTestsAnyOfNode {
-		return (node as ComponentTestsAnyOfNode).type
-			=== 'mcfunction:component_tests_any_of'
+		return (node as ComponentTestsAnyOfNode).type === 'mcfunction:component_tests_any_of'
 	}
 }
 
@@ -390,8 +321,7 @@ export interface ComponentTestsAllOfNode extends core.AstNode {
 
 export namespace ComponentTestsAllOfNode {
 	export function is(node: core.AstNode): node is ComponentTestsAllOfNode {
-		return (node as ComponentTestsAllOfNode).type
-			=== 'mcfunction:component_tests_all_of'
+		return (node as ComponentTestsAllOfNode).type === 'mcfunction:component_tests_all_of'
 	}
 }
 
@@ -412,8 +342,7 @@ export interface ComponentTestExactNode extends ComponentTestBaseNode {
 }
 export namespace ComponentTestExactNode {
 	export function is(node: core.AstNode): node is ComponentTestExactNode {
-		return (node as ComponentTestExactNode).type
-			=== 'mcfunction:component_test_exact'
+		return (node as ComponentTestExactNode).type === 'mcfunction:component_test_exact'
 	}
 }
 
@@ -424,8 +353,7 @@ export interface ComponentTestExistsNode extends ComponentTestBaseNode {
 }
 export namespace ComponentTestExistsNode {
 	export function is(node: core.AstNode): node is ComponentTestExistsNode {
-		return (node as ComponentTestExistsNode).type
-			=== 'mcfunction:component_test_exists'
+		return (node as ComponentTestExistsNode).type === 'mcfunction:component_test_exists'
 	}
 }
 
@@ -436,9 +364,7 @@ export interface ComponentTestSubpredicateNode extends ComponentTestBaseNode {
 	value?: nbt.NbtNode
 }
 export namespace ComponentTestSubpredicateNode {
-	export function is(
-		node: core.AstNode,
-	): node is ComponentTestSubpredicateNode {
+	export function is(node: core.AstNode): node is ComponentTestSubpredicateNode {
 		return (node as ComponentTestSubpredicateNode).type
 			=== 'mcfunction:component_test_sub_predicate'
 	}
@@ -534,10 +460,7 @@ export namespace ObjectiveCriteriaNode {
 	export const ComplexSep = ':'
 
 	export function mock(range: core.RangeLike): ObjectiveCriteriaNode {
-		return {
-			type: 'mcfunction:objective_criteria',
-			range: core.Range.get(range),
-		}
+		return { type: 'mcfunction:objective_criteria', range: core.Range.get(range) }
 	}
 }
 
@@ -570,11 +493,8 @@ export namespace ParticleNode {
 			'vibration',
 		] as const,
 	)
-	export type SpecialType = typeof SpecialTypes extends Set<infer T> ? T
-		: undefined
-	export function isSpecialType(
-		type: string | undefined,
-	): type is SpecialType {
+	export type SpecialType = typeof SpecialTypes extends Set<infer T> ? T : undefined
+	export function isSpecialType(type: string | undefined): type is SpecialType {
 		return SpecialTypes.has(type as SpecialType)
 	}
 
@@ -583,15 +503,8 @@ export namespace ParticleNode {
 	}
 
 	export function mock(range: core.RangeLike): ParticleNode {
-		const id = core.ResourceLocationNode.mock(range, {
-			category: 'particle_type',
-		})
-		return {
-			type: 'mcfunction:particle',
-			range: core.Range.get(range),
-			children: [id],
-			id,
-		}
+		const id = core.ResourceLocationNode.mock(range, { category: 'particle_type' })
+		return { type: 'mcfunction:particle', range: core.Range.get(range), children: [id], id }
 	}
 }
 
@@ -620,12 +533,7 @@ export interface TimeNode extends core.AstNode {
 	unit?: string
 }
 export namespace TimeNode {
-	export const UnitToTicks = new Map<string, number>([
-		['', 1],
-		['t', 1],
-		['s', 20],
-		['d', 24000],
-	])
+	export const UnitToTicks = new Map<string, number>([['', 1], ['t', 1], ['s', 20], ['d', 24000]])
 	export const Units = [...UnitToTicks.keys()]
 }
 

--- a/packages/java-edition/src/mcfunction/parser/argument.ts
+++ b/packages/java-edition/src/mcfunction/parser/argument.ts
@@ -102,9 +102,7 @@ function shouldUseOldItemStackFormat(ctx: core.ParserContext) {
  * @returns The parser for the specified argument tree node. All argument parsers used in the `mcfunction` package
  * fail on empty input.
  */
-export const argument: mcf.ArgumentParserGetter = (
-	rawTreeNode,
-): core.Parser | undefined => {
+export const argument: mcf.ArgumentParserGetter = (rawTreeNode): core.Parser | undefined => {
 	const treeNode = rawTreeNode as ArgumentTreeNode
 
 	const wrap = <T extends core.AstNode>(parser: core.Parser<T>): core.Parser =>
@@ -118,9 +116,7 @@ export const argument: mcf.ArgumentParserGetter = (
 		case 'brigadier:float':
 			return wrap(float(treeNode.properties?.min, treeNode.properties?.max))
 		case 'brigadier:integer':
-			return wrap(
-				integer(treeNode.properties?.min, treeNode.properties?.max),
-			)
+			return wrap(integer(treeNode.properties?.min, treeNode.properties?.max))
 		case 'brigadier:long':
 			return wrap(long(treeNode.properties?.min, treeNode.properties?.max))
 		case 'brigadier:string':
@@ -149,46 +145,32 @@ export const argument: mcf.ArgumentParserGetter = (
 			return wrap(blockState)
 		case 'minecraft:color':
 			return wrap(
-				core.map(core.literal(...ColorArgumentValues), (res) => ({
-					...res,
-					color: core.Color.NamedColors.has(res.value)
-						? core.Color.fromCompositeInt(
-							core.Color.NamedColors.get(res.value)!,
-						)
-						: undefined,
-				})),
+				core.map(
+					core.literal(...ColorArgumentValues),
+					(res) => ({
+						...res,
+						color: core.Color.NamedColors.has(res.value)
+							? core.Color.fromCompositeInt(core.Color.NamedColors.get(res.value)!)
+							: undefined,
+					}),
+				),
 			)
 		case 'minecraft:column_pos':
 			return wrap(vector({ dimension: 2, integersOnly: true }))
 		case 'minecraft:component':
 			return wrap(jsonParser('::java::server::util::text::Text'))
 		case 'minecraft:dimension':
-			return wrap(
-				core.resourceLocation({
-					category: 'dimension',
-				}),
-			)
+			return wrap(core.resourceLocation({ category: 'dimension' }))
 		case 'minecraft:entity':
-			return wrap(
-				entity(treeNode.properties.amount, treeNode.properties.type),
-			)
+			return wrap(entity(treeNode.properties.amount, treeNode.properties.type))
 		case 'minecraft:entity_anchor':
 			return wrap(core.literal(...EntityAnchorArgumentValues))
 		case 'minecraft:entity_summon':
-			return wrap(
-				core.resourceLocation({
-					category: 'entity_type',
-				}),
-			)
+			return wrap(core.resourceLocation({ category: 'entity_type' }))
 		case 'minecraft:float_range':
 			return wrap(range('float'))
 		case 'minecraft:function':
-			return wrap(
-				core.resourceLocation({
-					category: 'function',
-					allowTag: true,
-				}),
-			)
+			return wrap(core.resourceLocation({ category: 'function', allowTag: true }))
 		case 'minecraft:gamemode':
 			return wrap(core.literal(...GamemodeArgumentValues))
 		case 'minecraft:game_profile':
@@ -198,11 +180,7 @@ export const argument: mcf.ArgumentParserGetter = (
 		case 'minecraft:int_range':
 			return wrap(range('integer'))
 		case 'minecraft:item_enchantment':
-			return wrap(
-				core.resourceLocation({
-					category: 'enchantment',
-				}),
-			)
+			return wrap(core.resourceLocation({ category: 'enchantment' }))
 		case 'minecraft:item_predicate':
 			return wrap(itemPredicate)
 		case 'minecraft:item_slot':
@@ -220,11 +198,7 @@ export const argument: mcf.ArgumentParserGetter = (
 		case 'minecraft:message':
 			return wrap(message)
 		case 'minecraft:mob_effect':
-			return wrap(
-				core.resourceLocation({
-					category: 'mob_effect',
-				}),
-			)
+			return wrap(core.resourceLocation({ category: 'mob_effect' }))
 		case 'minecraft:nbt_compound_tag':
 			return wrap(nbtParser(nbt.parser.compound, treeNode.properties))
 		case 'minecraft:nbt_path':
@@ -242,12 +216,7 @@ export const argument: mcf.ArgumentParserGetter = (
 		case 'minecraft:objective_criteria':
 			return wrap(objectiveCriteria)
 		case 'minecraft:operation':
-			return wrap(
-				core.literal({
-					pool: OperationArgumentValues,
-					colorTokenType: 'operator',
-				}),
-			)
+			return wrap(core.literal({ pool: OperationArgumentValues, colorTokenType: 'operator' }))
 		case 'minecraft:particle':
 			return wrap(particle)
 		case 'minecraft:resource':
@@ -258,21 +227,14 @@ export const argument: mcf.ArgumentParserGetter = (
 				|| treeNode.parser === 'minecraft:resource_or_tag_key'
 			return wrap(
 				core.resourceLocation({
-					category: core.ResourceLocation.shorten(
-						treeNode.properties.registry,
-					) as core.RegistryCategory | core.WorldgenFileCategory,
+					category: core.ResourceLocation.shorten(treeNode.properties.registry) as
+						| core.RegistryCategory
+						| core.WorldgenFileCategory,
 					allowTag,
 				}),
 			)
 		case 'minecraft:resource_location':
-			return wrap(
-				core.resourceLocation(
-					treeNode.properties ?? {
-						pool: [],
-						allowUnknown: true,
-					},
-				),
-			)
+			return wrap(core.resourceLocation(treeNode.properties ?? { pool: [], allowUnknown: true }))
 		case 'minecraft:rotation':
 			return wrap(vector({ dimension: 2, noLocal: true }))
 		case 'minecraft:score_holder':
@@ -315,18 +277,13 @@ export const argument: mcf.ArgumentParserGetter = (
 
 function block(isPredicate: boolean): core.InfallibleParser<BlockNode> {
 	return core.map<
-		core.SequenceUtil<
-			core.ResourceLocationNode | BlockStatesNode | nbt.NbtCompoundNode
-		>,
+		core.SequenceUtil<core.ResourceLocationNode | BlockStatesNode | nbt.NbtCompoundNode>,
 		BlockNode
 	>(
 		core.sequence([
 			core.resourceLocation({ category: 'block', allowTag: isPredicate }),
 			core.optional(
-				core.map<
-					core.RecordNode<core.StringNode, core.StringNode>,
-					BlockStatesNode
-				>(
+				core.map<core.RecordNode<core.StringNode, core.StringNode>, BlockStatesNode>(
 					core.failOnEmpty(
 						core.record<core.StringNode, core.StringNode>({
 							start: '[',
@@ -343,10 +300,7 @@ function block(isPredicate: boolean): core.InfallibleParser<BlockNode> {
 							end: ']',
 						}),
 					),
-					(res) => ({
-						...res,
-						type: 'mcfunction:block/states',
-					}),
+					(res) => ({ ...res, type: 'mcfunction:block/states' }),
 				),
 			),
 			core.optional(core.failOnEmpty(nbt.parser.compound)),
@@ -367,43 +321,19 @@ function block(isPredicate: boolean): core.InfallibleParser<BlockNode> {
 const blockState: core.InfallibleParser<BlockNode> = block(false)
 export const blockPredicate: core.InfallibleParser<BlockNode> = block(true)
 
-function double(
-	min = DoubleMin,
-	max = DoubleMax,
-): core.InfallibleParser<core.FloatNode> {
-	return core.float({
-		pattern: FloatPattern,
-		min,
-		max,
-	})
+function double(min = DoubleMin, max = DoubleMax): core.InfallibleParser<core.FloatNode> {
+	return core.float({ pattern: FloatPattern, min, max })
 }
 
-function float(
-	min = FloatMin,
-	max = FloatMax,
-): core.InfallibleParser<core.FloatNode> {
-	return core.float({
-		pattern: FloatPattern,
-		min,
-		max,
-	})
+function float(min = FloatMin, max = FloatMax): core.InfallibleParser<core.FloatNode> {
+	return core.float({ pattern: FloatPattern, min, max })
 }
 
-function integer(
-	min = IntegerMin,
-	max = IntegerMax,
-): core.InfallibleParser<core.IntegerNode> {
-	return core.integer({
-		pattern: IntegerPattern,
-		min,
-		max,
-	})
+function integer(min = IntegerMin, max = IntegerMax): core.InfallibleParser<core.IntegerNode> {
+	return core.integer({ pattern: IntegerPattern, min, max })
 }
 
-function long(
-	min?: number,
-	max?: number,
-): core.InfallibleParser<core.LongNode> {
+function long(min?: number, max?: number): core.InfallibleParser<core.LongNode> {
 	return core.long({
 		pattern: IntegerPattern,
 		min: BigInt(min ?? LongMin),
@@ -411,9 +341,7 @@ function long(
 	})
 }
 
-function coordinate(
-	integerOnly = false,
-): core.InfallibleParser<CoordinateNode> {
+function coordinate(integerOnly = false): core.InfallibleParser<CoordinateNode> {
 	return (src, ctx): CoordinateNode => {
 		const ans: CoordinateNode = {
 			type: 'mcfunction:coordinate',
@@ -429,10 +357,7 @@ function coordinate(
 		}
 
 		if ((src.canReadInLine() && src.peek() !== ' ') || ans.notation === '') {
-			const result = (integerOnly && ans.notation === '' ? integer : double)()(
-				src,
-				ctx,
-			)
+			const result = (integerOnly && ans.notation === '' ? integer : double)()(src, ctx)
 			ans.value = Number(result.value)
 		}
 
@@ -447,28 +372,18 @@ function entity(
 	type: 'entities' | 'players',
 ): core.Parser<EntityNode> {
 	return core.map<core.StringNode | EntitySelectorNode | UuidNode, EntityNode>(
-		core.select([
-			{
-				predicate: (src) => src.peek() === '@',
-				parser: selector(),
-			},
-			{
-				parser: core.any([
-					validateLength<core.StringNode>(
-						core.brigadierString,
-						PlayerNameMaxLength,
-						'mcfunction.parser.entity-selector.player-name.too-long',
-					),
-					uuid,
-				]),
-			},
-		]),
+		core.select([{ predicate: (src) => src.peek() === '@', parser: selector() }, {
+			parser: core.any([
+				validateLength<core.StringNode>(
+					core.brigadierString,
+					PlayerNameMaxLength,
+					'mcfunction.parser.entity-selector.player-name.too-long',
+				),
+				uuid,
+			]),
+		}]),
 		(res, _src, ctx) => {
-			const ans: EntityNode = {
-				type: 'mcfunction:entity',
-				range: res.range,
-				children: [res],
-			}
+			const ans: EntityNode = { type: 'mcfunction:entity', range: res.range, children: [res] }
 
 			if (core.StringNode.is(res)) {
 				ans.playerName = res
@@ -479,26 +394,14 @@ function entity(
 			}
 
 			if (amount === 'single' && ans.selector && !ans.selector.single) {
-				ctx.err.report(
-					localize(
-						'mcfunction.parser.entity-selector.multiple-disallowed',
-					),
-					ans,
-				)
+				ctx.err.report(localize('mcfunction.parser.entity-selector.multiple-disallowed'), ans)
 			}
 			if (
 				type === 'players'
 				&& (ans.uuid
-					|| (ans.selector
-						&& !ans.selector.playersOnly
-						&& !ans.selector.currentEntity))
+					|| (ans.selector && !ans.selector.playersOnly && !ans.selector.currentEntity))
 			) {
-				ctx.err.report(
-					localize(
-						'mcfunction.parser.entity-selector.entities-disallowed',
-					),
-					ans,
-				)
+				ctx.err.report(localize('mcfunction.parser.entity-selector.entities-disallowed'), ans)
 			}
 
 			return ans
@@ -514,19 +417,14 @@ const itemSlot: core.InfallibleParser<core.LiteralNode> = (src, ctx) => {
 	return core.literal(...getItemSlotArgumentValues(ctx))(src, ctx)
 }
 
-export const itemSlots: core.InfallibleParser<core.LiteralNode> = (
-	src,
-	ctx,
-) => {
+export const itemSlots: core.InfallibleParser<core.LiteralNode> = (src, ctx) => {
 	return core.literal(...getItemSlotsArgumentValues(ctx))(src, ctx)
 }
 
 const itemStack: core.InfallibleParser<ItemStackNode> = (src, ctx) => {
 	const oldFormat = shouldUseOldItemStackFormat(ctx)
 	return core.map<
-		core.SequenceUtil<
-			core.ResourceLocationNode | ComponentListNode | nbt.NbtCompoundNode
-		>,
+		core.SequenceUtil<core.ResourceLocationNode | ComponentListNode | nbt.NbtCompoundNode>,
 		ItemStackNode
 	>(
 		core.sequence([
@@ -553,10 +451,7 @@ const itemPredicate: core.InfallibleParser<ItemPredicateNode> = (src, ctx) => {
 	const oldFormat = shouldUseOldItemStackFormat(ctx)
 	return core.map<
 		core.SequenceUtil<
-			| core.LiteralNode
-			| core.ResourceLocationNode
-			| ComponentTestsNode
-			| nbt.NbtCompoundNode
+			core.LiteralNode | core.ResourceLocationNode | ComponentTestsNode | nbt.NbtCompoundNode
 		>,
 		ItemPredicateNode
 	>(
@@ -578,9 +473,7 @@ const itemPredicate: core.InfallibleParser<ItemPredicateNode> = (src, ctx) => {
 				children: res.children,
 				id: (res.children.find(core.ResourceLocationNode.is)
 					|| res.children.find(core.LiteralNode.is))!,
-				tests: res.children.find(
-					ComponentTestsNode.is,
-				),
+				tests: res.children.find(ComponentTestsNode.is),
 				nbt: res.children.find(nbt.NbtCompoundNode.is),
 			}
 			return ans
@@ -588,21 +481,11 @@ const itemPredicate: core.InfallibleParser<ItemPredicateNode> = (src, ctx) => {
 	)(src, ctx)
 }
 
-export function jsonParser(
-	typeRef: `::${string}::${string}`,
-): core.Parser<JsonNode> {
-	return core.map(
-		json.parser.entry,
-		(res) => {
-			const ans: JsonNode = {
-				type: 'mcfunction:json',
-				range: res.range,
-				children: [res],
-				typeRef,
-			}
-			return ans
-		},
-	)
+export function jsonParser(typeRef: `::${string}::${string}`): core.Parser<JsonNode> {
+	return core.map(json.parser.entry, (res) => {
+		const ans: JsonNode = { type: 'mcfunction:json', range: res.range, children: [res], typeRef }
+		return ans
+	})
 }
 
 const message: core.InfallibleParser<MessageNode> = (src, ctx) => {
@@ -617,10 +500,7 @@ const message: core.InfallibleParser<MessageNode> = (src, ctx) => {
 			ans.children.push(selector()(src, ctx) as EntitySelectorNode)
 		} else {
 			ans.children.push(
-				core.stopBefore(
-					greedyString,
-					...EntitySelectorAtVariable.filterAvailable(ctx),
-				)(
+				core.stopBefore(greedyString, ...EntitySelectorAtVariable.filterAvailable(ctx))(
 					src,
 					ctx,
 				),
@@ -635,18 +515,10 @@ function nbtParser(
 	parser: core.Parser<nbt.NbtNode>,
 	properties?: NbtParserProperties,
 ): core.Parser<NbtNode> {
-	return core.map(
-		parser,
-		(res) => {
-			const ans: NbtNode = {
-				type: 'mcfunction:nbt',
-				range: res.range,
-				children: [res],
-				properties,
-			}
-			return ans
-		},
-	)
+	return core.map(parser, (res) => {
+		const ans: NbtNode = { type: 'mcfunction:nbt', range: res.range, children: [res], properties }
+		return ans
+	})
 }
 
 export const particle: core.InfallibleParser<ParticleNode> = (src, ctx) => {
@@ -672,50 +544,45 @@ export const particle: core.InfallibleParser<ParticleNode> = (src, ctx) => {
 	type CN = Exclude<ParticleNode['children'], undefined>[number]
 	const sep = core.map(mcf.sep, () => [])
 	const vec = vector({ dimension: 3 })
-	const color = core.map<VectorNode, VectorNode>(vec, (res) => ({
-		...res,
-		color: res.children.length === 3
-			? {
-				value: core.Color.fromDecRGB(
-					res.children[0].value,
-					res.children[1].value,
-					res.children[2].value,
-				),
-				format: [core.ColorFormat.DecRGB],
-			}
-			: undefined,
-	}))
-	const map: Record<
-		ParticleNode.SpecialType,
-		core.InfallibleParser<CN | core.SequenceUtil<CN>>
-	> = {
-		block: blockState,
-		block_marker: blockState,
-		dust: sequence([color, float()], sep),
-		dust_color_transition: sequence([color, float(), color], sep),
-		falling_dust: blockState,
-		item: itemStack,
-		sculk_charge: float(),
-		shriek: integer(),
-		vibration: sequence([vec, integer()], sep),
-	}
+	const color = core.map<VectorNode, VectorNode>(
+		vec,
+		(res) => ({
+			...res,
+			color: res.children.length === 3
+				? {
+					value: core.Color.fromDecRGB(
+						res.children[0].value,
+						res.children[1].value,
+						res.children[2].value,
+					),
+					format: [core.ColorFormat.DecRGB],
+				}
+				: undefined,
+		}),
+	)
+	const map: Record<ParticleNode.SpecialType, core.InfallibleParser<CN | core.SequenceUtil<CN>>> =
+		{
+			block: blockState,
+			block_marker: blockState,
+			dust: sequence([color, float()], sep),
+			dust_color_transition: sequence([color, float(), color], sep),
+			falling_dust: blockState,
+			item: itemStack,
+			sculk_charge: float(),
+			shriek: integer(),
+			vibration: sequence([vec, integer()], sep),
+		}
 	return core.map(
-		sequence(
-			[
-				core.resourceLocation({ category: 'particle_type' }),
-				{
-					get: (res) => {
-						return map[
-							core.ResourceLocationNode.toString(
-								res.children[0] as core.ResourceLocationNode,
-								'short',
-							) as ParticleNode.SpecialType
-						] as typeof map[keyof typeof map] | undefined
-					},
-				},
-			],
-			sep,
-		),
+		sequence([core.resourceLocation({ category: 'particle_type' }), {
+			get: (res) => {
+				return map[
+					core.ResourceLocationNode.toString(
+						res.children[0] as core.ResourceLocationNode,
+						'short',
+					) as ParticleNode.SpecialType
+				] as typeof map[keyof typeof map] | undefined
+			},
+		}], sep),
 		(res) => {
 			const ans: ParticleNode = {
 				type: 'mcfunction:particle',
@@ -750,9 +617,7 @@ function range(
 		? float(min, max)
 		: integer(min, max)
 	const low = core.failOnEmpty(core.stopBefore(number, '..'))
-	const sep = core.failOnEmpty(
-		core.literal({ pool: ['..'], colorTokenType: 'keyword' }),
-	)
+	const sep = core.failOnEmpty(core.literal({ pool: ['..'], colorTokenType: 'keyword' }))
 	const high = core.failOnEmpty(number)
 	return core.map<
 		core.SequenceUtil<core.FloatNode | core.IntegerNode | core.LiteralNode>,
@@ -770,18 +635,13 @@ function range(
 				: res.children.filter(core.IntegerNode.is)
 			const sepNode = res.children.find(core.LiteralNode.is)
 			const ans: FloatRangeNode | IntRangeNode = {
-				type: type === 'float'
-					? 'mcfunction:float_range'
-					: 'mcfunction:int_range',
+				type: type === 'float' ? 'mcfunction:float_range' : 'mcfunction:int_range',
 				range: res.range,
 				children: res.children as any,
 				value: sepNode
 					? valueNodes.length === 2
 						? [valueNodes[0].value, valueNodes[1].value]
-						: core.Range.endsBefore(
-								valueNodes[0].range,
-								sepNode.range.start,
-							)
+						: core.Range.endsBefore(valueNodes[0].range, sepNode.range.start)
 						? [valueNodes[0].value, undefined]
 						: [undefined, valueNodes[0].value]
 					: [valueNodes[0].value, valueNodes[0].value],
@@ -793,11 +653,7 @@ function range(
 				&& ans.value[0] > ans.value[1]
 			) {
 				ctx.err.report(
-					localize(
-						'mcfunction.parser.range.min>max',
-						ans.value[0],
-						ans.value[1],
-					),
+					localize('mcfunction.parser.range.min>max', ans.value[0], ans.value[1]),
 					res,
 				)
 			}
@@ -807,26 +663,20 @@ function range(
 }
 
 function resourceOrInline(category: core.FileCategory) {
-	return core.select([
-		{
-			predicate: (src) => core.LegalResourceLocationCharacters.has(src.peek()),
-			parser: core.resourceLocation({ category }),
-		},
-		{
-			parser: core.map(
-				nbt.parser.entry,
-				(res) => {
-					const ans: NbtResourceNode = {
-						type: 'mcfunction:nbt_resource',
-						range: res.range,
-						children: [res],
-						category,
-					}
-					return ans
-				},
-			),
-		},
-	])
+	return core.select([{
+		predicate: (src) => core.LegalResourceLocationCharacters.has(src.peek()),
+		parser: core.resourceLocation({ category }),
+	}, {
+		parser: core.map(nbt.parser.entry, (res) => {
+			const ans: NbtResourceNode = {
+				type: 'mcfunction:nbt_resource',
+				range: res.range,
+				children: [res],
+				category,
+			}
+			return ans
+		}),
+	}])
 }
 
 function selectorPrefix(): core.InfallibleParser<core.LiteralNode> {
@@ -843,10 +693,7 @@ function selectorPrefix(): core.InfallibleParser<core.LiteralNode> {
 		}
 
 		if (!allowedVariables.includes(value as EntitySelectorAtVariable)) {
-			ctx.err.report(
-				localize('mcfunction.parser.entity-selector.invalid', ans.value),
-				ans,
-			)
+			ctx.err.report(localize('mcfunction.parser.entity-selector.invalid', ans.value), ans)
 		}
 
 		return ans
@@ -867,429 +714,289 @@ export function selector(): core.Parser<EntitySelectorNode> {
 		core.SequenceUtil<core.LiteralNode | EntitySelectorArgumentsNode>,
 		EntitySelectorNode
 	>(
-		core.sequence([
-			core.failOnEmpty(
-				selectorPrefix(),
-			),
-			{
-				get: (res) => {
-					const variable = core.LiteralNode.is(res.children?.[0])
-						? res.children[0].value
-						: undefined
+		core.sequence([core.failOnEmpty(selectorPrefix()), {
+			get: (res) => {
+				const variable = core.LiteralNode.is(res.children?.[0])
+					? res.children[0].value
+					: undefined
 
-					currentEntity = variable ? variable === '@s' : undefined
-					playersOnly = variable
-						? variable === '@p' || variable === '@a' || variable === '@r'
-						: undefined
-					predicates = variable === '@e' ? ['Entity::isAlive'] : undefined
-					single = variable
-						? ['@p', '@r', '@s', '@n'].includes(variable)
-						: undefined
-					typeLimited = playersOnly
+				currentEntity = variable ? variable === '@s' : undefined
+				playersOnly = variable
+					? variable === '@p' || variable === '@a' || variable === '@r'
+					: undefined
+				predicates = variable === '@e' ? ['Entity::isAlive'] : undefined
+				single = variable ? ['@p', '@r', '@s', '@n'].includes(variable) : undefined
+				typeLimited = playersOnly
 
-					function invertable<T extends core.AstNode>(
-						parser: core.Parser<T>,
-					): core.Parser<EntitySelectorInvertableArgumentValueNode<T>> {
-						return core.map<
-							core.SequenceUtil<core.LiteralNode | T>,
-							EntitySelectorInvertableArgumentValueNode<T>
-						>(
-							core.sequence([
-								core.optional(
-									core.failOnEmpty(
-										core.literal({
-											pool: ['!'],
-											colorTokenType: 'keyword',
-										}),
-									),
-								),
-								(src) => {
-									src.skipSpace()
-									return undefined
-								},
-								parser,
-							]),
-							(res) => {
-								const ans: EntitySelectorInvertableArgumentValueNode<
-									T
-								> = {
-									type: 'mcfunction:entity_selector/arguments/value/invertable',
-									range: res.range,
-									children: res.children,
-									inverted: !!res.children.find(
-										(n) => core.LiteralNode.is(n) && n.value === '!',
-									),
-									value: res.children.find(
-										(n) => !core.LiteralNode.is(n) || n.value !== '!',
-									) as T,
-								}
-								return ans
+				function invertable<T extends core.AstNode>(
+					parser: core.Parser<T>,
+				): core.Parser<EntitySelectorInvertableArgumentValueNode<T>> {
+					return core.map<
+						core.SequenceUtil<core.LiteralNode | T>,
+						EntitySelectorInvertableArgumentValueNode<T>
+					>(
+						core.sequence([
+							core.optional(
+								core.failOnEmpty(core.literal({ pool: ['!'], colorTokenType: 'keyword' })),
+							),
+							(src) => {
+								src.skipSpace()
+								return undefined
 							},
-						)
-					}
+							parser,
+						]),
+						(res) => {
+							const ans: EntitySelectorInvertableArgumentValueNode<T> = {
+								type: 'mcfunction:entity_selector/arguments/value/invertable',
+								range: res.range,
+								children: res.children,
+								inverted: !!res.children.find((n) =>
+									core.LiteralNode.is(n) && n.value === '!'
+								),
+								value: res.children.find((n) =>
+									!core.LiteralNode.is(n) || n.value !== '!'
+								) as T,
+							}
+							return ans
+						},
+					)
+				}
 
-					return core.optional(
-						core.map<
-							core.RecordNode<core.StringNode, core.AstNode>,
-							EntitySelectorArgumentsNode
-						>(
-							core.failOnEmpty(
-								core.record({
-									start: '[',
-									pair: {
-										key: core.string({
-											...core.BrigadierStringOptions,
-											value: {
-												parser: core.literal({
-													pool: [
-														...EntitySelectorNode.ArgumentKeys,
-													],
-													colorTokenType: 'property',
-												}),
-												type: 'literal',
-											},
-										}),
-										sep: '=',
+				return core.optional(
+					core.map<
+						core.RecordNode<core.StringNode, core.AstNode>,
+						EntitySelectorArgumentsNode
+					>(
+						core.failOnEmpty(
+							core.record({
+								start: '[',
+								pair: {
+									key: core.string({
+										...core.BrigadierStringOptions,
 										value: {
-											get: (record, key) => {
-												const hasKey = (key: string): boolean =>
-													!!record.children.find((p) => p.key?.value === key)
-												const hasNonInvertedKey = (
-													key: string,
-												): boolean =>
-													!!record.children.find(
-														(p) =>
-															p.key?.value === key
-															&& !(
-																p.value as EntitySelectorInvertableArgumentValueNode<
-																	core.AstNode
-																>
-															)?.inverted,
-													)
-												switch (key?.value) {
-													case 'advancements':
-														return core.map<
-															core.RecordNode<
-																core.ResourceLocationNode,
-																| core.BooleanNode
-																| EntitySelectorAdvancementsArgumentCriteriaNode
-															>,
-															EntitySelectorAdvancementsArgumentNode
-														>(
-															core.record<
-																core.ResourceLocationNode,
-																| core.BooleanNode
-																| EntitySelectorAdvancementsArgumentCriteriaNode
-															>({
-																start: '{',
-																pair: {
-																	key: core.resourceLocation({
-																		category: 'advancement',
-																	}),
-																	sep: '=',
-																	value: core.select([
-																		{
-																			predicate: (src) => src.peek() === '{',
-																			parser: core.map<
-																				core.RecordNode<
-																					core.StringNode,
-																					core.BooleanNode
-																				>,
-																				EntitySelectorAdvancementsArgumentCriteriaNode
-																			>(
-																				core.record<
-																					core.StringNode,
-																					core.BooleanNode
-																				>({
-																					start: '{',
-																					pair: {
-																						key: unquotedString,
-																						sep: '=',
-																						value: core
-																							.boolean,
-																						end: ',',
-																						trailingEnd: true,
-																					},
-																					end: '}',
-																				}),
-																				(res) => {
-																					const ans:
-																						EntitySelectorAdvancementsArgumentCriteriaNode =
-																							{
-																								...res,
-																								type:
-																									'mcfunction:entity_selector/arguments/advancements/criteria',
-																							}
-																					return ans
-																				},
-																			),
-																		},
-																		{
-																			parser: core.boolean,
-																		},
-																	]),
-																	end: ',',
-																	trailingEnd: true,
-																},
-																end: '}',
-															}),
-															(res, _, ctx) => {
-																if (hasKey(key.value)) {
-																	ctx.err.report(
-																		localize(
-																			'duplicate-key',
-																			localeQuote(key.value),
-																		),
-																		key,
-																	)
-																}
-																const ans: EntitySelectorAdvancementsArgumentNode =
-																	{
-																		...res,
-																		type:
-																			'mcfunction:entity_selector/arguments/advancements',
-																	}
-																return ans
-															},
-														)
-													case 'distance':
-														return core.map<FloatRangeNode>(
-															range('float', 0),
-															(res, _, ctx) => {
-																dimensionLimited = true
-																// x, y, z, dx, dy, dz take precedence over distance, so we use ??= instead of = to ensure it won't override the result.
-																chunkLimited ??= !playersOnly
-																	&& res.value[1] !== undefined
-																if (hasKey(key.value)) {
-																	ctx.err.report(
-																		localize(
-																			'duplicate-key',
-																			localeQuote(key.value),
-																		),
-																		key,
-																	)
-																}
-																return res
-															},
-														)
-													case 'gamemode':
-														return core.map<
-															EntitySelectorInvertableArgumentValueNode<
-																core.StringNode
-															>
-														>(
-															invertable(
-																core.string({
-																	unquotable: core
-																		.BrigadierUnquotableOption,
-																	value: {
-																		type: 'literal',
-																		parser: core.literal(
-																			...GamemodeArgumentValues,
-																		),
-																	},
+											parser: core.literal({
+												pool: [...EntitySelectorNode.ArgumentKeys],
+												colorTokenType: 'property',
+											}),
+											type: 'literal',
+										},
+									}),
+									sep: '=',
+									value: {
+										get: (record, key) => {
+											const hasKey = (key: string): boolean =>
+												!!record.children.find((p) => p.key?.value === key)
+											const hasNonInvertedKey = (key: string): boolean =>
+												!!record.children.find((p) =>
+													p.key?.value === key
+													&& !(p.value as EntitySelectorInvertableArgumentValueNode<
+														core.AstNode
+													>)?.inverted
+												)
+											switch (key?.value) {
+												case 'advancements':
+													return core.map<
+														core.RecordNode<
+															core.ResourceLocationNode,
+															| core.BooleanNode
+															| EntitySelectorAdvancementsArgumentCriteriaNode
+														>,
+														EntitySelectorAdvancementsArgumentNode
+													>(
+														core.record<
+															core.ResourceLocationNode,
+															| core.BooleanNode
+															| EntitySelectorAdvancementsArgumentCriteriaNode
+														>({
+															start: '{',
+															pair: {
+																key: core.resourceLocation({
+																	category: 'advancement',
 																}),
-															),
-															(res, _, ctx) => {
-																playersOnly = true
-																if (
-																	res.inverted
-																		? hasNonInvertedKey(
-																			key.value,
-																		)
-																		: hasKey(key.value)
-																) {
-																	ctx.err.report(
-																		localize(
-																			'duplicate-key',
-																			localeQuote(key.value),
-																		),
-																		key,
-																	)
-																}
-																return res
+																sep: '=',
+																value: core.select([{
+																	predicate: (src) => src.peek() === '{',
+																	parser: core.map<
+																		core.RecordNode<
+																			core.StringNode,
+																			core.BooleanNode
+																		>,
+																		EntitySelectorAdvancementsArgumentCriteriaNode
+																	>(
+																		core.record<
+																			core.StringNode,
+																			core.BooleanNode
+																		>({
+																			start: '{',
+																			pair: {
+																				key: unquotedString,
+																				sep: '=',
+																				value: core.boolean,
+																				end: ',',
+																				trailingEnd: true,
+																			},
+																			end: '}',
+																		}),
+																		(res) => {
+																			const ans:
+																				EntitySelectorAdvancementsArgumentCriteriaNode =
+																					{
+																						...res,
+																						type:
+																							'mcfunction:entity_selector/arguments/advancements/criteria',
+																					}
+																			return ans
+																		},
+																	),
+																}, { parser: core.boolean }]),
+																end: ',',
+																trailingEnd: true,
 															},
-														)
-													case 'limit':
-														return core.map<core.IntegerNode>(
-															integer(0),
-															(res, _, ctx) => {
-																single = res.value <= 1
-																if (hasKey(key.value)) {
-																	ctx.err.report(
-																		localize(
-																			'duplicate-key',
-																			localeQuote(key.value),
-																		),
-																		key,
-																	)
-																}
-																if (currentEntity) {
-																	ctx.err.report(
-																		localize(
-																			'mcfunction.parser.entity-selector.arguments.not-applicable',
-																			localeQuote(key.value),
-																		),
-																		key,
-																	)
-																}
-																return res
-															},
-														)
-													case 'level':
-														return core.map<IntRangeNode>(
-															range('integer', 0),
-															(res, _, ctx) => {
-																playersOnly = true
-																if (hasKey(key.value)) {
-																	ctx.err.report(
-																		localize(
-																			'duplicate-key',
-																			localeQuote(key.value),
-																		),
-																		key,
-																	)
-																}
-																return res
-															},
-														)
-													case 'name':
-														return core.map<
-															EntitySelectorInvertableArgumentValueNode<
-																core.StringNode
-															>
-														>(
-															invertable(core.brigadierString),
-															(res, _, ctx) => {
-																if (
-																	res.inverted
-																		? hasNonInvertedKey(
-																			key.value,
-																		)
-																		: hasKey(key.value)
-																) {
-																	ctx.err.report(
-																		localize(
-																			'duplicate-key',
-																			localeQuote(key.value),
-																		),
-																		key,
-																	)
-																}
-																return res
-															},
-														)
-													case 'nbt':
-														return invertable(nbt.parser.compound)
-													case 'predicate':
-														return invertable(
-															core.resourceLocation({
-																category: 'predicate',
-															}),
-														)
-													case 'scores':
-														return core.map<
-															core.RecordNode<
-																core.SymbolNode,
-																IntRangeNode
-															>,
-															EntitySelectorScoresArgumentNode
-														>(
-															core.record<
-																core.SymbolNode,
-																IntRangeNode
-															>({
-																start: '{',
-																pair: {
-																	key: objective('reference', [
-																		'[',
-																		'=',
-																		',',
-																		']',
-																		'{',
-																		'}',
-																	]),
-																	sep: '=',
-																	value: range('integer'),
-																	end: ',',
-																	trailingEnd: true,
-																},
-																end: '}',
-															}),
-															(res, _, ctx) => {
-																if (hasKey(key.value)) {
-																	ctx.err.report(
-																		localize(
-																			'duplicate-key',
-																			localeQuote(key.value),
-																		),
-																		key,
-																	)
-																}
-																const ans: EntitySelectorScoresArgumentNode = {
-																	...res,
-																	type:
-																		'mcfunction:entity_selector/arguments/scores',
-																}
-																return ans
-															},
-														)
-													case 'sort':
-														return core.map<core.StringNode>(
+															end: '}',
+														}),
+														(res, _, ctx) => {
+															if (hasKey(key.value)) {
+																ctx.err.report(
+																	localize(
+																		'duplicate-key',
+																		localeQuote(key.value),
+																	),
+																	key,
+																)
+															}
+															const ans: EntitySelectorAdvancementsArgumentNode = {
+																...res,
+																type:
+																	'mcfunction:entity_selector/arguments/advancements',
+															}
+															return ans
+														},
+													)
+												case 'distance':
+													return core.map<FloatRangeNode>(
+														range('float', 0),
+														(res, _, ctx) => {
+															dimensionLimited = true
+															// x, y, z, dx, dy, dz take precedence over distance, so we use ??= instead of = to ensure it won't override the result.
+															chunkLimited ??= !playersOnly
+																&& res.value[1] !== undefined
+															if (hasKey(key.value)) {
+																ctx.err.report(
+																	localize(
+																		'duplicate-key',
+																		localeQuote(key.value),
+																	),
+																	key,
+																)
+															}
+															return res
+														},
+													)
+												case 'gamemode':
+													return core.map<
+														EntitySelectorInvertableArgumentValueNode<core.StringNode>
+													>(
+														invertable(
 															core.string({
-																unquotable: core
-																	.BrigadierUnquotableOption,
+																unquotable: core.BrigadierUnquotableOption,
 																value: {
 																	type: 'literal',
-																	parser: core.literal(
-																		'arbitrary',
-																		'furthest',
-																		'nearest',
-																		'random',
-																	),
+																	parser: core.literal(...GamemodeArgumentValues),
 																},
 															}),
-															(res, _, ctx) => {
-																if (hasKey(key.value)) {
-																	ctx.err.report(
-																		localize(
-																			'duplicate-key',
-																			localeQuote(key.value),
-																		),
-																		key,
-																	)
-																}
-																if (currentEntity) {
-																	ctx.err.report(
-																		localize(
-																			'mcfunction.parser.entity-selector.arguments.not-applicable',
-																			localeQuote(key.value),
-																		),
-																		key,
-																	)
-																}
-																return res
-															},
-														)
-													case 'tag':
-														return invertable(
-															tag([
-																'[',
-																'=',
-																',',
-																']',
-																'{',
-																'}',
-															]),
-														)
-													case 'team':
-														return core.map<
-															EntitySelectorInvertableArgumentValueNode<
-																core.SymbolNode
-															>
-														>(
-															invertable(
-																team('reference', [
+														),
+														(res, _, ctx) => {
+															playersOnly = true
+															if (
+																res.inverted
+																	? hasNonInvertedKey(key.value)
+																	: hasKey(key.value)
+															) {
+																ctx.err.report(
+																	localize(
+																		'duplicate-key',
+																		localeQuote(key.value),
+																	),
+																	key,
+																)
+															}
+															return res
+														},
+													)
+												case 'limit':
+													return core.map<core.IntegerNode>(
+														integer(0),
+														(res, _, ctx) => {
+															single = res.value <= 1
+															if (hasKey(key.value)) {
+																ctx.err.report(
+																	localize(
+																		'duplicate-key',
+																		localeQuote(key.value),
+																	),
+																	key,
+																)
+															}
+															if (currentEntity) {
+																ctx.err.report(
+																	localize(
+																		'mcfunction.parser.entity-selector.arguments.not-applicable',
+																		localeQuote(key.value),
+																	),
+																	key,
+																)
+															}
+															return res
+														},
+													)
+												case 'level':
+													return core.map<IntRangeNode>(
+														range('integer', 0),
+														(res, _, ctx) => {
+															playersOnly = true
+															if (hasKey(key.value)) {
+																ctx.err.report(
+																	localize(
+																		'duplicate-key',
+																		localeQuote(key.value),
+																	),
+																	key,
+																)
+															}
+															return res
+														},
+													)
+												case 'name':
+													return core.map<
+														EntitySelectorInvertableArgumentValueNode<core.StringNode>
+													>(invertable(core.brigadierString), (res, _, ctx) => {
+														if (
+															res.inverted
+																? hasNonInvertedKey(key.value)
+																: hasKey(key.value)
+														) {
+															ctx.err.report(
+																localize('duplicate-key', localeQuote(key.value)),
+																key,
+															)
+														}
+														return res
+													})
+												case 'nbt':
+													return invertable(nbt.parser.compound)
+												case 'predicate':
+													return invertable(
+														core.resourceLocation({ category: 'predicate' }),
+													)
+												case 'scores':
+													return core.map<
+														core.RecordNode<core.SymbolNode, IntRangeNode>,
+														EntitySelectorScoresArgumentNode
+													>(
+														core.record<core.SymbolNode, IntRangeNode>({
+															start: '{',
+															pair: {
+																key: objective('reference', [
 																	'[',
 																	'=',
 																	',',
@@ -1297,187 +1004,224 @@ export function selector(): core.Parser<EntitySelectorNode> {
 																	'{',
 																	'}',
 																]),
-															),
-															(res, _, ctx) => {
-																if (
-																	res.inverted
-																		? hasNonInvertedKey(
-																			key.value,
-																		)
-																		: hasKey(key.value)
-																) {
-																	ctx.err.report(
-																		localize(
-																			'duplicate-key',
-																			localeQuote(key.value),
-																		),
-																		key,
-																	)
-																}
-																return res
+																sep: '=',
+																value: range('integer'),
+																end: ',',
+																trailingEnd: true,
 															},
-														)
-													case 'type':
-														return core.map<
-															EntitySelectorInvertableArgumentValueNode<
-																core.ResourceLocationNode
-															>
-														>(
-															invertable(
-																core.resourceLocation({
-																	category: 'entity_type',
-																	allowTag: true,
-																}),
-															),
-															(res, _, ctx) => {
-																if (typeLimited) {
-																	if (hasKey(key.value)) {
-																		ctx.err.report(
-																			localize(
-																				'duplicate-key',
-																				localeQuote(
-																					key.value,
-																				),
-																			),
-																			key,
-																		)
-																	} else {
-																		ctx.err.report(
-																			localize(
-																				'mcfunction.parser.entity-selector.arguments.not-applicable',
-																				localeQuote(
-																					key.value,
-																				),
-																			),
-																			key,
-																		)
-																	}
-																} else if (
-																	!res.inverted
-																	&& !res.value.isTag
-																) {
-																	typeLimited = true
-																	if (
-																		core.ResourceLocationNode
-																			.toString(
-																				res.value,
-																				'short',
-																			) === 'player'
-																	) {
-																		playersOnly = true
-																	}
-																}
-																return res
-															},
-														)
-													case 'x':
-													case 'y':
-													case 'z':
-														return core.map<core.FloatNode>(
-															double(),
-															(res, _, ctx) => {
-																dimensionLimited = true
-																if (hasKey(key.value)) {
-																	ctx.err.report(
-																		localize(
-																			'duplicate-key',
-																			localeQuote(key.value),
-																		),
-																		key,
-																	)
-																}
-																return res
-															},
-														)
-													case 'dx':
-													case 'dy':
-													case 'dz':
-														return core.map<core.FloatNode>(
-															double(),
-															(res, _, ctx) => {
-																dimensionLimited = true
-																chunkLimited = !playersOnly
-																if (hasKey(key.value)) {
-																	ctx.err.report(
-																		localize(
-																			'duplicate-key',
-																			localeQuote(key.value),
-																		),
-																		key,
-																	)
-																}
-																return res
-															},
-														)
-													case 'x_rotation':
-													case 'y_rotation':
-														return core.map<FloatRangeNode>(
-															range(
-																'float',
-																undefined,
-																undefined,
-																true,
-															),
-															(res, _, ctx) => {
-																if (hasKey(key.value)) {
-																	ctx.err.report(
-																		localize(
-																			'duplicate-key',
-																			localeQuote(key.value),
-																		),
-																		key,
-																	)
-																}
-																return res
-															},
-														)
-													case undefined:
-														// The key is empty. Let's just fail the value as well.
-														return (): core.Result<never> => core.Failure
-													default:
-														// The key is unknown.
-														return (
-															_src,
-															ctx,
-														): core.Result<never> => {
-															ctx.err.report(
-																localize(
-																	'mcfunction.parser.entity-selector.arguments.unknown',
-																	localeQuote(key!.value),
+															end: '}',
+														}),
+														(res, _, ctx) => {
+															if (hasKey(key.value)) {
+																ctx.err.report(
+																	localize(
+																		'duplicate-key',
+																		localeQuote(key.value),
+																	),
+																	key,
+																)
+															}
+															const ans: EntitySelectorScoresArgumentNode = {
+																...res,
+																type: 'mcfunction:entity_selector/arguments/scores',
+															}
+															return ans
+														},
+													)
+												case 'sort':
+													return core.map<core.StringNode>(
+														core.string({
+															unquotable: core.BrigadierUnquotableOption,
+															value: {
+																type: 'literal',
+																parser: core.literal(
+																	'arbitrary',
+																	'furthest',
+																	'nearest',
+																	'random',
 																),
-																key!,
+															},
+														}),
+														(res, _, ctx) => {
+															if (hasKey(key.value)) {
+																ctx.err.report(
+																	localize(
+																		'duplicate-key',
+																		localeQuote(key.value),
+																	),
+																	key,
+																)
+															}
+															if (currentEntity) {
+																ctx.err.report(
+																	localize(
+																		'mcfunction.parser.entity-selector.arguments.not-applicable',
+																		localeQuote(key.value),
+																	),
+																	key,
+																)
+															}
+															return res
+														},
+													)
+												case 'tag':
+													return invertable(tag(['[', '=', ',', ']', '{', '}']))
+												case 'team':
+													return core.map<
+														EntitySelectorInvertableArgumentValueNode<core.SymbolNode>
+													>(
+														invertable(
+															team('reference', ['[', '=', ',', ']', '{', '}']),
+														),
+														(res, _, ctx) => {
+															if (
+																res.inverted
+																	? hasNonInvertedKey(key.value)
+																	: hasKey(key.value)
+															) {
+																ctx.err.report(
+																	localize(
+																		'duplicate-key',
+																		localeQuote(key.value),
+																	),
+																	key,
+																)
+															}
+															return res
+														},
+													)
+												case 'type':
+													return core.map<
+														EntitySelectorInvertableArgumentValueNode<
+															core.ResourceLocationNode
+														>
+													>(
+														invertable(
+															core.resourceLocation({
+																category: 'entity_type',
+																allowTag: true,
+															}),
+														),
+														(res, _, ctx) => {
+															if (typeLimited) {
+																if (hasKey(key.value)) {
+																	ctx.err.report(
+																		localize(
+																			'duplicate-key',
+																			localeQuote(key.value),
+																		),
+																		key,
+																	)
+																} else {
+																	ctx.err.report(
+																		localize(
+																			'mcfunction.parser.entity-selector.arguments.not-applicable',
+																			localeQuote(key.value),
+																		),
+																		key,
+																	)
+																}
+															} else if (!res.inverted && !res.value.isTag) {
+																typeLimited = true
+																if (
+																	core.ResourceLocationNode.toString(
+																		res.value,
+																		'short',
+																	) === 'player'
+																) {
+																	playersOnly = true
+																}
+															}
+															return res
+														},
+													)
+												case 'x':
+												case 'y':
+												case 'z':
+													return core.map<core.FloatNode>(double(), (res, _, ctx) => {
+														dimensionLimited = true
+														if (hasKey(key.value)) {
+															ctx.err.report(
+																localize('duplicate-key', localeQuote(key.value)),
+																key,
 															)
-															return core.Failure
 														}
-												}
-											},
+														return res
+													})
+												case 'dx':
+												case 'dy':
+												case 'dz':
+													return core.map<core.FloatNode>(double(), (res, _, ctx) => {
+														dimensionLimited = true
+														chunkLimited = !playersOnly
+														if (hasKey(key.value)) {
+															ctx.err.report(
+																localize('duplicate-key', localeQuote(key.value)),
+																key,
+															)
+														}
+														return res
+													})
+												case 'x_rotation':
+												case 'y_rotation':
+													return core.map<FloatRangeNode>(
+														range('float', undefined, undefined, true),
+														(res, _, ctx) => {
+															if (hasKey(key.value)) {
+																ctx.err.report(
+																	localize(
+																		'duplicate-key',
+																		localeQuote(key.value),
+																	),
+																	key,
+																)
+															}
+															return res
+														},
+													)
+												case undefined:
+													// The key is empty. Let's just fail the value as well.
+													return (): core.Result<never> => core.Failure
+												default:
+													// The key is unknown.
+													return (_src, ctx): core.Result<never> => {
+														ctx.err.report(
+															localize(
+																'mcfunction.parser.entity-selector.arguments.unknown',
+																localeQuote(key!.value),
+															),
+															key!,
+														)
+														return core.Failure
+													}
+											}
 										},
-										end: ',',
-										trailingEnd: true,
 									},
-									end: ']',
-								}),
-							),
-							(res) => {
-								const ans: EntitySelectorArgumentsNode = {
-									...res,
-									type: 'mcfunction:entity_selector/arguments',
-								}
-								return ans
-							},
+									end: ',',
+									trailingEnd: true,
+								},
+								end: ']',
+							}),
 						),
-					)
-				},
+						(res) => {
+							const ans: EntitySelectorArgumentsNode = {
+								...res,
+								type: 'mcfunction:entity_selector/arguments',
+							}
+							return ans
+						},
+					),
+				)
 			},
-		]),
+		}]),
 		(res) => {
 			const ans: EntitySelectorNode = {
 				type: 'mcfunction:entity_selector',
 				range: res.range,
 				children: res.children as EntitySelectorNode['children'],
-				variable: res.children
-					.find(core.LiteralNode.is)!
-					.value.slice(1) as EntitySelectorVariable,
+				variable: res.children.find(core.LiteralNode.is)!.value.slice(
+					1,
+				) as EntitySelectorVariable,
 				arguments: res.children.find(EntitySelectorArgumentsNode.is),
 				chunkLimited,
 				currentEntity,
@@ -1508,12 +1252,10 @@ function getEntitySelectorHover(node: EntitySelectorNode) {
 		ans = `**Performance**: ${grades.get(4)}
 - \`currentEntity\`: \`${node.currentEntity}\``
 	} else {
-		const amountOfTrue = [
-			node.chunkLimited,
-			node.dimensionLimited,
-			node.playersOnly,
-			node.typeLimited,
-		].filter((v) => v).length
+		const amountOfTrue =
+			[node.chunkLimited, node.dimensionLimited, node.playersOnly, node.typeLimited].filter((
+				v,
+			) => v).length
 		ans = `**Performance**: ${grades.get(amountOfTrue)}
 - \`chunkLimited\`: \`${!!node.chunkLimited}\`
 - \`dimensionLimited\`: \`${!!node.dimensionLimited}\`
@@ -1530,27 +1272,17 @@ ${node.predicates.map((p) => `- \`${p}\``).join('\n')}`
 	return ans
 }
 
-export const scoreHolderFakeName: core.Parser<core.SymbolNode> = validateLength<
-	core.SymbolNode
->(
+export const scoreHolderFakeName: core.Parser<core.SymbolNode> = validateLength<core.SymbolNode>(
 	symbol('score_holder'),
 	FakeNameMaxLength,
 	'mcfunction.parser.score_holder.fake-name.too-long',
 )
 
-export function scoreHolder(
-	amount: 'multiple' | 'single',
-): core.Parser<ScoreHolderNode> {
+export function scoreHolder(amount: 'multiple' | 'single'): core.Parser<ScoreHolderNode> {
 	return core.map<core.SymbolNode | EntitySelectorNode, ScoreHolderNode>(
-		core.select([
-			{
-				predicate: (src) => src.peek() === '@',
-				parser: selector(),
-			},
-			{
-				parser: scoreHolderFakeName,
-			},
-		]),
+		core.select([{ predicate: (src) => src.peek() === '@', parser: selector() }, {
+			parser: scoreHolderFakeName,
+		}]),
 		(res, _src, ctx) => {
 			const ans: ScoreHolderNode = {
 				type: 'mcfunction:score_holder',
@@ -1565,12 +1297,7 @@ export function scoreHolder(
 			}
 
 			if (amount === 'single' && ans.selector && !ans.selector.single) {
-				ctx.err.report(
-					localize(
-						'mcfunction.parser.entity-selector.multiple-disallowed',
-					),
-					ans,
-				)
+				ctx.err.report(localize('mcfunction.parser.entity-selector.multiple-disallowed'), ans)
 			}
 
 			return ans
@@ -1582,11 +1309,7 @@ function symbol(
 	options: core.AllCategory | core.SymbolOptions,
 	terminators: string[] = [],
 ): core.InfallibleParser<core.SymbolNode> {
-	return core.stopBefore(
-		core.symbol(options as never),
-		core.Whitespaces,
-		terminators,
-	)
+	return core.stopBefore(core.symbol(options as never), core.Whitespaces, terminators)
 }
 
 export function objective(
@@ -1600,64 +1323,42 @@ export function objective(
 	)
 }
 
-const objectiveCriteria: core.InfallibleParser<ObjectiveCriteriaNode> = core
-	.map(
-		core.any([
-			core.sequence([
-				core.stopBefore(
-					core.resourceLocation({
-						category: 'stat_type',
-						namespacePathSep: '.',
-					}),
-					':',
-				),
-				core.failOnEmpty(core.literal(':')),
-				{
-					get: (res) => {
-						if (core.ResourceLocationNode.is(res.children[0])) {
-							const category = ObjectiveCriteriaNode.ComplexCategories
-								.get(
-									core.ResourceLocationNode.toString(
-										res.children[0],
-										'short',
-									),
-								)
-							if (category) {
-								return core.resourceLocation({
-									category,
-									namespacePathSep: '.',
-								})
-							}
+const objectiveCriteria: core.InfallibleParser<ObjectiveCriteriaNode> = core.map(
+	core.any([
+		core.sequence([
+			core.stopBefore(
+				core.resourceLocation({ category: 'stat_type', namespacePathSep: '.' }),
+				':',
+			),
+			core.failOnEmpty(core.literal(':')),
+			{
+				get: (res) => {
+					if (core.ResourceLocationNode.is(res.children[0])) {
+						const category = ObjectiveCriteriaNode.ComplexCategories.get(
+							core.ResourceLocationNode.toString(res.children[0], 'short'),
+						)
+						if (category) {
+							return core.resourceLocation({ category, namespacePathSep: '.' })
 						}
-						return core.resourceLocation({
-							pool: [],
-							allowUnknown: true,
-							namespacePathSep: '.',
-						})
-					},
+					}
+					return core.resourceLocation({ pool: [], allowUnknown: true, namespacePathSep: '.' })
 				},
-			]),
-			core.literal(...ObjectiveCriteriaNode.SimpleValues),
+			},
 		]),
-		(res) => {
-			const ans: ObjectiveCriteriaNode = {
-				type: 'mcfunction:objective_criteria',
-				range: res.range,
-			}
-			if (core.LiteralNode.is(res)) {
-				ans.simpleValue = res.value
-			} else {
-				ans.children = res.children.filter(
-					core.ResourceLocationNode.is,
-				) as typeof ans['children']
-			}
-			return ans
-		},
-	)
+		core.literal(...ObjectiveCriteriaNode.SimpleValues),
+	]),
+	(res) => {
+		const ans: ObjectiveCriteriaNode = { type: 'mcfunction:objective_criteria', range: res.range }
+		if (core.LiteralNode.is(res)) {
+			ans.simpleValue = res.value
+		} else {
+			ans.children = res.children.filter(core.ResourceLocationNode.is) as typeof ans['children']
+		}
+		return ans
+	},
+)
 
-export function tag(
-	terminators: string[] = [],
-): core.InfallibleParser<core.SymbolNode> {
+export function tag(terminators: string[] = []): core.InfallibleParser<core.SymbolNode> {
 	return unquotableSymbol('tag', terminators)
 }
 
@@ -1701,11 +1402,7 @@ const unquotedString: core.InfallibleParser<core.StringNode> = core.string({
 const UuidPattern = /^[0-9a-f]+-[0-9a-f]+-[0-9a-f]+-[0-9a-f]+-[0-9a-f]+$/i
 
 export const uuid: core.InfallibleParser<UuidNode> = (src, ctx): UuidNode => {
-	const ans: UuidNode = {
-		type: 'mcfunction:uuid',
-		range: core.Range.create(src),
-		bits: [0n, 0n],
-	}
+	const ans: UuidNode = { type: 'mcfunction:uuid', range: core.Range.create(src), bits: [0n, 0n] }
 
 	const raw = src.readUntil(' ', '\r', '\n', '\r')
 
@@ -1722,10 +1419,7 @@ export const uuid: core.InfallibleParser<UuidNode> = (src, ctx): UuidNode => {
 			const parts = raw.split('-').map((p) => BigInt(`0x${p}`))
 			if (parts.every((p) => p <= LongMax)) {
 				isLegal = true
-				ans.bits[0] = BigInt.asIntN(
-					64,
-					(parts[0] << 32n) | (parts[1] << 16n) | parts[2],
-				)
+				ans.bits[0] = BigInt.asIntN(64, (parts[0] << 32n) | (parts[1] << 16n) | parts[2])
 				ans.bits[1] = BigInt.asIntN(64, (parts[3] << 48n) | parts[4])
 			}
 		} catch {
@@ -1766,18 +1460,13 @@ function validateUnquotable(
 ): core.InfallibleParser<core.SymbolNode> {
 	return core.map(parser, (res, _src, ctx) => {
 		if (!res.value.match(core.BrigadierUnquotablePattern)) {
-			ctx.err.report(
-				localize('parser.string.illegal-brigadier', localeQuote(res.value)),
-				res,
-			)
+			ctx.err.report(localize('parser.string.illegal-brigadier', localeQuote(res.value)), res)
 		}
 		return res
 	})
 }
 
-function vector(
-	options: VectorNode.Options,
-): core.InfallibleParser<VectorNode> {
+function vector(options: VectorNode.Options): core.InfallibleParser<VectorNode> {
 	return (src, ctx): VectorNode => {
 		const ans: VectorNode = {
 			type: 'mcfunction:vector',
@@ -1800,19 +1489,13 @@ function vector(
 				: coordinate(options.integersOnly)(src, ctx)
 			ans.children.push(coord as never)
 
-			if (
-				(ans.system === CoordinateSystem.Local)
-					!== (coord.notation === '^')
-			) {
+			if ((ans.system === CoordinateSystem.Local) !== (coord.notation === '^')) {
 				ctx.err.report(localize('mcfunction.parser.vector.mixed'), coord)
 			}
 		}
 
 		if (options.noLocal && ans.system === CoordinateSystem.Local) {
-			ctx.err.report(
-				localize('mcfunction.parser.vector.local-disallowed'),
-				ans,
-			)
+			ctx.err.report(localize('mcfunction.parser.vector.local-disallowed'), ans)
 		}
 
 		ans.range.end = src.cursor
@@ -1849,10 +1532,7 @@ const componentTest: core.InfallibleParser<ComponentTestNode> = (src, ctx) => {
 	const negated = src.trySkip('!')
 	src.skipWhitespace()
 
-	const key = core.resourceLocation({ category: 'data_component_type' })(
-		src,
-		ctx,
-	)
+	const key = core.resourceLocation({ category: 'data_component_type' })(src, ctx)
 	src.skipWhitespace()
 
 	if (src.trySkip('=')) {
@@ -1908,10 +1588,7 @@ const componentTest: core.InfallibleParser<ComponentTestNode> = (src, ctx) => {
 	return ans
 }
 
-const componentTestsAllOf: core.InfallibleParser<ComponentTestsAllOfNode> = (
-	src,
-	ctx,
-) => {
+const componentTestsAllOf: core.InfallibleParser<ComponentTestsAllOfNode> = (src, ctx) => {
 	const ans: ComponentTestsAllOfNode = {
 		type: 'mcfunction:component_tests_all_of',
 		range: core.Range.create(src),
@@ -1938,10 +1615,7 @@ const componentTestsAllOf: core.InfallibleParser<ComponentTestsAllOfNode> = (
 	return ans
 }
 
-const componentTestsAnyOf: core.InfallibleParser<ComponentTestsAnyOfNode> = (
-	src,
-	ctx,
-) => {
+const componentTestsAnyOf: core.InfallibleParser<ComponentTestsAnyOfNode> = (src, ctx) => {
 	const ans: ComponentTestsAnyOfNode = {
 		type: 'mcfunction:component_tests_any_of',
 		range: core.Range.create(src),

--- a/packages/java-edition/src/mcfunction/parser/argument.ts
+++ b/packages/java-edition/src/mcfunction/parser/argument.ts
@@ -429,11 +429,10 @@ function coordinate(
 		}
 
 		if ((src.canReadInLine() && src.peek() !== ' ') || ans.notation === '') {
-			const result =
-				(integerOnly && ans.notation === '' ? integer : double)()(
-					src,
-					ctx,
-				)
+			const result = (integerOnly && ans.notation === '' ? integer : double)()(
+				src,
+				ctx,
+			)
 			ans.value = Number(result.value)
 		}
 
@@ -747,8 +746,9 @@ function range(
 	max?: number,
 	cycleable?: boolean,
 ): core.Parser<FloatRangeNode | IntRangeNode> {
-	const number: core.Parser<core.FloatNode | core.IntegerNode> =
-		type === 'float' ? float(min, max) : integer(min, max)
+	const number: core.Parser<core.FloatNode | core.IntegerNode> = type === 'float'
+		? float(min, max)
+		: integer(min, max)
 	const low = core.failOnEmpty(core.stopBefore(number, '..'))
 	const sep = core.failOnEmpty(
 		core.literal({ pool: ['..'], colorTokenType: 'keyword' }),
@@ -809,8 +809,7 @@ function range(
 function resourceOrInline(category: core.FileCategory) {
 	return core.select([
 		{
-			predicate: (src) =>
-				core.LegalResourceLocationCharacters.has(src.peek()),
+			predicate: (src) => core.LegalResourceLocationCharacters.has(src.peek()),
 			parser: core.resourceLocation({ category }),
 		},
 		{
@@ -914,8 +913,7 @@ export function selector(): core.Parser<EntitySelectorNode> {
 								const ans: EntitySelectorInvertableArgumentValueNode<
 									T
 								> = {
-									type:
-										'mcfunction:entity_selector/arguments/value/invertable',
+									type: 'mcfunction:entity_selector/arguments/value/invertable',
 									range: res.range,
 									children: res.children,
 									inverted: !!res.children.find(
@@ -955,9 +953,7 @@ export function selector(): core.Parser<EntitySelectorNode> {
 										value: {
 											get: (record, key) => {
 												const hasKey = (key: string): boolean =>
-													!!record.children.find((p) =>
-														p.key?.value === key
-													)
+													!!record.children.find((p) => p.key?.value === key)
 												const hasNonInvertedKey = (
 													key: string,
 												): boolean =>
@@ -993,8 +989,7 @@ export function selector(): core.Parser<EntitySelectorNode> {
 																	sep: '=',
 																	value: core.select([
 																		{
-																			predicate: (src) =>
-																				src.peek() === '{',
+																			predicate: (src) => src.peek() === '{',
 																			parser: core.map<
 																				core.RecordNode<
 																					core.StringNode,
@@ -1008,14 +1003,12 @@ export function selector(): core.Parser<EntitySelectorNode> {
 																				>({
 																					start: '{',
 																					pair: {
-																						key:
-																							unquotedString,
+																						key: unquotedString,
 																						sep: '=',
 																						value: core
 																							.boolean,
 																						end: ',',
-																						trailingEnd:
-																							true,
+																						trailingEnd: true,
 																					},
 																					end: '}',
 																				}),
@@ -1050,13 +1043,12 @@ export function selector(): core.Parser<EntitySelectorNode> {
 																		key,
 																	)
 																}
-																const ans:
-																	EntitySelectorAdvancementsArgumentNode =
-																		{
-																			...res,
-																			type:
-																				'mcfunction:entity_selector/arguments/advancements',
-																		}
+																const ans: EntitySelectorAdvancementsArgumentNode =
+																	{
+																		...res,
+																		type:
+																			'mcfunction:entity_selector/arguments/advancements',
+																	}
 																return ans
 															},
 														)
@@ -1234,13 +1226,11 @@ export function selector(): core.Parser<EntitySelectorNode> {
 																		key,
 																	)
 																}
-																const ans:
-																	EntitySelectorScoresArgumentNode =
-																		{
-																			...res,
-																			type:
-																				'mcfunction:entity_selector/arguments/scores',
-																		}
+																const ans: EntitySelectorScoresArgumentNode = {
+																	...res,
+																	type:
+																		'mcfunction:entity_selector/arguments/scores',
+																}
 																return ans
 															},
 														)
@@ -1443,8 +1433,7 @@ export function selector(): core.Parser<EntitySelectorNode> {
 														)
 													case undefined:
 														// The key is empty. Let's just fail the value as well.
-														return (): core.Result<never> =>
-															core.Failure
+														return (): core.Result<never> => core.Failure
 													default:
 														// The key is unknown.
 														return (

--- a/packages/java-edition/src/mcfunction/parser/argument.ts
+++ b/packages/java-edition/src/mcfunction/parser/argument.ts
@@ -254,8 +254,8 @@ export const argument: mcf.ArgumentParserGetter = (
 		case 'minecraft:resource_key':
 		case 'minecraft:resource_or_tag':
 		case 'minecraft:resource_or_tag_key':
-			const allowTag = treeNode.parser === 'minecraft:resource_or_tag' ||
-				treeNode.parser === 'minecraft:resource_or_tag_key'
+			const allowTag = treeNode.parser === 'minecraft:resource_or_tag'
+				|| treeNode.parser === 'minecraft:resource_or_tag_key'
 			return wrap(
 				core.resourceLocation({
 					category: core.ResourceLocation.shorten(
@@ -488,11 +488,11 @@ function entity(
 				)
 			}
 			if (
-				type === 'players' &&
-				(ans.uuid ||
-					(ans.selector &&
-						!ans.selector.playersOnly &&
-						!ans.selector.currentEntity))
+				type === 'players'
+				&& (ans.uuid
+					|| (ans.selector
+						&& !ans.selector.playersOnly
+						&& !ans.selector.currentEntity))
 			) {
 				ctx.err.report(
 					localize(
@@ -577,8 +577,8 @@ const itemPredicate: core.InfallibleParser<ItemPredicateNode> = (src, ctx) => {
 				type: 'mcfunction:item_predicate',
 				range: res.range,
 				children: res.children,
-				id: (res.children.find(core.ResourceLocationNode.is) ||
-					res.children.find(core.LiteralNode.is))!,
+				id: (res.children.find(core.ResourceLocationNode.is)
+					|| res.children.find(core.LiteralNode.is))!,
 				tests: res.children.find(
 					ComponentTestsNode.is,
 				),
@@ -787,10 +787,10 @@ function range(
 					: [valueNodes[0].value, valueNodes[0].value],
 			}
 			if (
-				!cycleable &&
-				ans.value[0] !== undefined &&
-				ans.value[1] !== undefined &&
-				ans.value[0] > ans.value[1]
+				!cycleable
+				&& ans.value[0] !== undefined
+				&& ans.value[1] !== undefined
+				&& ans.value[0] > ans.value[1]
 			) {
 				ctx.err.report(
 					localize(
@@ -963,8 +963,8 @@ export function selector(): core.Parser<EntitySelectorNode> {
 												): boolean =>
 													!!record.children.find(
 														(p) =>
-															p.key?.value === key &&
-															!(
+															p.key?.value === key
+															&& !(
 																p.value as EntitySelectorInvertableArgumentValueNode<
 																	core.AstNode
 																>
@@ -1066,8 +1066,8 @@ export function selector(): core.Parser<EntitySelectorNode> {
 															(res, _, ctx) => {
 																dimensionLimited = true
 																// x, y, z, dx, dy, dz take precedence over distance, so we use ??= instead of = to ensure it won't override the result.
-																chunkLimited ??= !playersOnly &&
-																	res.value[1] !== undefined
+																chunkLimited ??= !playersOnly
+																	&& res.value[1] !== undefined
 																if (hasKey(key.value)) {
 																	ctx.err.report(
 																		localize(
@@ -1363,8 +1363,8 @@ export function selector(): core.Parser<EntitySelectorNode> {
 																		)
 																	}
 																} else if (
-																	!res.inverted &&
-																	!res.value.isTag
+																	!res.inverted
+																	&& !res.value.isTag
 																) {
 																	typeLimited = true
 																	if (
@@ -1812,8 +1812,8 @@ function vector(
 			ans.children.push(coord as never)
 
 			if (
-				(ans.system === CoordinateSystem.Local) !==
-					(coord.notation === '^')
+				(ans.system === CoordinateSystem.Local)
+					!== (coord.notation === '^')
 			) {
 				ctx.err.report(localize('mcfunction.parser.vector.mixed'), coord)
 			}

--- a/packages/java-edition/src/mcfunction/signatureHelpProvider.ts
+++ b/packages/java-edition/src/mcfunction/signatureHelpProvider.ts
@@ -41,25 +41,17 @@ export function signatureHelpProvider(
 			return undefined
 		}
 
-		const ans: core.SignatureHelp = {
-			activeSignature: 0,
-			signatures: [],
-		}
+		const ans: core.SignatureHelp = { activeSignature: 0, signatures: [] }
 
 		ans.signatures = options.map((v) => {
 			const part1 = v[selectedIndex]
-			const part2 = selectedIndex + 1 < v.length
-				? ` ${v[selectedIndex + 1]}`
-				: ''
+			const part2 = selectedIndex + 1 < v.length ? ` ${v[selectedIndex + 1]}` : ''
 			const label = `${part1}${part2}`
 			return {
 				label,
 				activeParameter: 0,
 				// documentation: localize('mcfunction.signature-help.command-documentation', v[0]),
-				parameters: [
-					{ label: [0, part1.length] },
-					{ label: [part1.length, label.length] },
-				],
+				parameters: [{ label: [0, part1.length] }, { label: [part1.length, label.length] }],
 			}
 		})
 
@@ -86,8 +78,7 @@ function getOptions(
 		if (!name) {
 			break
 		}
-		treeNode = mcf.resolveParentTreeNode(treeNode, rootTreeNode).treeNode
-			?.children?.[name]
+		treeNode = mcf.resolveParentTreeNode(treeNode, rootTreeNode).treeNode?.children?.[name]
 		if (!treeNode) {
 			break
 		}
@@ -97,12 +88,9 @@ function getOptions(
 	if (treeNode) {
 		treeNode = mcf.resolveParentTreeNode(treeNode, rootTreeNode).treeNode
 		if (treeNode?.children) {
-			return mcf
-				.treeNodeChildrenToStringArray(
-					treeNode.children,
-					treeNode.executable,
-				)
-				.map((v) => [...current, v])
+			return mcf.treeNodeChildrenToStringArray(treeNode.children, treeNode.executable).map((
+				v,
+			) => [...current, v])
 		}
 	}
 

--- a/packages/java-edition/src/mcfunction/tree/argument.ts
+++ b/packages/java-edition/src/mcfunction/tree/argument.ts
@@ -42,37 +42,25 @@ export interface BrigadierStringArgumentTreeNode extends mcf.ArgumentTreeNode {
 export interface MinecraftAngleArgumentTreeNode extends mcf.ArgumentTreeNode {
 	parser: 'minecraft:angle'
 }
-export interface MinecraftBlockPosArgumentTreeNode
-	extends mcf.ArgumentTreeNode
-{
+export interface MinecraftBlockPosArgumentTreeNode extends mcf.ArgumentTreeNode {
 	parser: 'minecraft:block_pos'
 }
-export interface MinecraftBlockPredicateArgumentTreeNode
-	extends mcf.ArgumentTreeNode
-{
+export interface MinecraftBlockPredicateArgumentTreeNode extends mcf.ArgumentTreeNode {
 	parser: 'minecraft:block_predicate'
 }
-export interface MinecraftBlockStateArgumentTreeNode
-	extends mcf.ArgumentTreeNode
-{
+export interface MinecraftBlockStateArgumentTreeNode extends mcf.ArgumentTreeNode {
 	parser: 'minecraft:block_state'
 }
 export interface MinecraftColorArgumentTreeNode extends mcf.ArgumentTreeNode {
 	parser: 'minecraft:color'
 }
-export interface MinecraftColumnPosArgumentTreeNode
-	extends mcf.ArgumentTreeNode
-{
+export interface MinecraftColumnPosArgumentTreeNode extends mcf.ArgumentTreeNode {
 	parser: 'minecraft:column_pos'
 }
-export interface MinecraftComponentArgumentTreeNode
-	extends mcf.ArgumentTreeNode
-{
+export interface MinecraftComponentArgumentTreeNode extends mcf.ArgumentTreeNode {
 	parser: 'minecraft:component'
 }
-export interface MinecraftDimensionArgumentTreeNode
-	extends mcf.ArgumentTreeNode
-{
+export interface MinecraftDimensionArgumentTreeNode extends mcf.ArgumentTreeNode {
 	parser: 'minecraft:dimension'
 }
 export interface MinecraftEntityArgumentTreeNode extends mcf.ArgumentTreeNode {
@@ -82,92 +70,58 @@ export interface MinecraftEntityArgumentTreeNode extends mcf.ArgumentTreeNode {
 		type: 'entities' | 'players'
 	}
 }
-export interface MinecraftEntityAnchorArgumentTreeNode
-	extends mcf.ArgumentTreeNode
-{
+export interface MinecraftEntityAnchorArgumentTreeNode extends mcf.ArgumentTreeNode {
 	parser: 'minecraft:entity_anchor'
 }
-export interface MinecraftEntitySummonArgumentTreeNode
-	extends mcf.ArgumentTreeNode
-{
+export interface MinecraftEntitySummonArgumentTreeNode extends mcf.ArgumentTreeNode {
 	parser: 'minecraft:entity_summon'
 }
-export interface MinecraftFloatRangeArgumentTreeNode
-	extends mcf.ArgumentTreeNode
-{
+export interface MinecraftFloatRangeArgumentTreeNode extends mcf.ArgumentTreeNode {
 	parser: 'minecraft:float_range'
 }
-export interface MinecraftFunctionArgumentTreeNode
-	extends mcf.ArgumentTreeNode
-{
+export interface MinecraftFunctionArgumentTreeNode extends mcf.ArgumentTreeNode {
 	parser: 'minecraft:function'
 }
-export interface MinecraftGamemodeArgumentTreeNode
-	extends mcf.ArgumentTreeNode
-{
+export interface MinecraftGamemodeArgumentTreeNode extends mcf.ArgumentTreeNode {
 	parser: 'minecraft:gamemode'
 }
-export interface MinecraftGameProfileArgumentTreeNode
-	extends mcf.ArgumentTreeNode
-{
+export interface MinecraftGameProfileArgumentTreeNode extends mcf.ArgumentTreeNode {
 	parser: 'minecraft:game_profile'
 }
-export interface MinecraftHeightmapArgumentTreeNode
-	extends mcf.ArgumentTreeNode
-{
+export interface MinecraftHeightmapArgumentTreeNode extends mcf.ArgumentTreeNode {
 	parser: 'minecraft:heightmap'
 }
-export interface MinecraftIntRangeArgumentTreeNode
-	extends mcf.ArgumentTreeNode
-{
+export interface MinecraftIntRangeArgumentTreeNode extends mcf.ArgumentTreeNode {
 	parser: 'minecraft:int_range'
 }
-export interface MinecraftItemEnchantmentArgumentTreeNode
-	extends mcf.ArgumentTreeNode
-{
+export interface MinecraftItemEnchantmentArgumentTreeNode extends mcf.ArgumentTreeNode {
 	parser: 'minecraft:item_enchantment'
 }
-export interface MinecraftItemPredicateArgumentTreeNode
-	extends mcf.ArgumentTreeNode
-{
+export interface MinecraftItemPredicateArgumentTreeNode extends mcf.ArgumentTreeNode {
 	parser: 'minecraft:item_predicate'
 }
-export interface MinecraftItemSlotArgumentTreeNode
-	extends mcf.ArgumentTreeNode
-{
+export interface MinecraftItemSlotArgumentTreeNode extends mcf.ArgumentTreeNode {
 	parser: 'minecraft:item_slot'
 }
-export interface MinecraftItemSlotsArgumentTreeNode
-	extends mcf.ArgumentTreeNode
-{
+export interface MinecraftItemSlotsArgumentTreeNode extends mcf.ArgumentTreeNode {
 	parser: 'minecraft:item_slots'
 }
-export interface MinecraftItemStackArgumentTreeNode
-	extends mcf.ArgumentTreeNode
-{
+export interface MinecraftItemStackArgumentTreeNode extends mcf.ArgumentTreeNode {
 	parser: 'minecraft:item_stack'
 }
-export interface MinecraftLootModifierArgumentTreeNode
-	extends mcf.ArgumentTreeNode
-{
+export interface MinecraftLootModifierArgumentTreeNode extends mcf.ArgumentTreeNode {
 	parser: 'minecraft:loot_modifier'
 }
-export interface MinecraftLootPredicateArgumentTreeNode
-	extends mcf.ArgumentTreeNode
-{
+export interface MinecraftLootPredicateArgumentTreeNode extends mcf.ArgumentTreeNode {
 	parser: 'minecraft:loot_predicate'
 }
-export interface MinecraftLootTableArgumentTreeNode
-	extends mcf.ArgumentTreeNode
-{
+export interface MinecraftLootTableArgumentTreeNode extends mcf.ArgumentTreeNode {
 	parser: 'minecraft:loot_table'
 }
 export interface MinecraftMessageArgumentTreeNode extends mcf.ArgumentTreeNode {
 	parser: 'minecraft:message'
 }
-export interface MinecraftMobEffectArgumentTreeNode
-	extends mcf.ArgumentTreeNode
-{
+export interface MinecraftMobEffectArgumentTreeNode extends mcf.ArgumentTreeNode {
 	parser: 'minecraft:mob_effect'
 }
 export interface NbtParserProperties extends Record<string, unknown> {
@@ -206,9 +160,7 @@ export interface NbtParserProperties extends Record<string, unknown> {
 	 */
 	isPredicate?: boolean
 }
-export interface MinecraftNbtCompoundTagArgumentTreeNode
-	extends mcf.ArgumentTreeNode
-{
+export interface MinecraftNbtCompoundTagArgumentTreeNode extends mcf.ArgumentTreeNode {
 	parser: 'minecraft:nbt_compound_tag'
 	properties?: NbtParserProperties
 }
@@ -220,80 +172,56 @@ export interface MinecraftNbtTagArgumentTreeNode extends mcf.ArgumentTreeNode {
 	parser: 'minecraft:nbt_tag'
 	properties?: NbtParserProperties
 }
-export interface MinecraftObjectiveArgumentTreeNode
-	extends mcf.ArgumentTreeNode
-{
+export interface MinecraftObjectiveArgumentTreeNode extends mcf.ArgumentTreeNode {
 	parser: 'minecraft:objective'
 }
-export interface MinecraftObjectiveCriteriaArgumentTreeNode
-	extends mcf.ArgumentTreeNode
-{
+export interface MinecraftObjectiveCriteriaArgumentTreeNode extends mcf.ArgumentTreeNode {
 	parser: 'minecraft:objective_criteria'
 }
-export interface MinecraftOperationArgumentTreeNode
-	extends mcf.ArgumentTreeNode
-{
+export interface MinecraftOperationArgumentTreeNode extends mcf.ArgumentTreeNode {
 	parser: 'minecraft:operation'
 }
-export interface MinecraftParticleArgumentTreeNode
-	extends mcf.ArgumentTreeNode
-{
+export interface MinecraftParticleArgumentTreeNode extends mcf.ArgumentTreeNode {
 	parser: 'minecraft:particle'
 }
-export interface MinecraftResourceArgumentTreeNode
-	extends mcf.ArgumentTreeNode
-{
+export interface MinecraftResourceArgumentTreeNode extends mcf.ArgumentTreeNode {
 	parser: 'minecraft:resource'
 	properties: {
 		registry: string
 	}
 }
-export interface MinecraftResourceKeyArgumentTreeNode
-	extends mcf.ArgumentTreeNode
-{
+export interface MinecraftResourceKeyArgumentTreeNode extends mcf.ArgumentTreeNode {
 	parser: 'minecraft:resource_key'
 	properties: {
 		registry: string
 	}
 }
-export interface MinecraftResourceLocationArgumentTreeNode
-	extends mcf.ArgumentTreeNode
-{
+export interface MinecraftResourceLocationArgumentTreeNode extends mcf.ArgumentTreeNode {
 	parser: 'minecraft:resource_location'
 	properties?: core.ResourceLocationOptions
 }
-export interface MinecraftResourceOrTagArgumentTreeNode
-	extends mcf.ArgumentTreeNode
-{
+export interface MinecraftResourceOrTagArgumentTreeNode extends mcf.ArgumentTreeNode {
 	parser: 'minecraft:resource_or_tag'
 	properties: {
 		registry: string
 	}
 }
-export interface MinecraftResourceOrTagKeyArgumentTreeNode
-	extends mcf.ArgumentTreeNode
-{
+export interface MinecraftResourceOrTagKeyArgumentTreeNode extends mcf.ArgumentTreeNode {
 	parser: 'minecraft:resource_or_tag_key'
 	properties: {
 		registry: string
 	}
 }
-export interface MinecraftRotationArgumentTreeNode
-	extends mcf.ArgumentTreeNode
-{
+export interface MinecraftRotationArgumentTreeNode extends mcf.ArgumentTreeNode {
 	parser: 'minecraft:rotation'
 }
-export interface MinecraftScoreHolderArgumentTreeNode
-	extends mcf.ArgumentTreeNode
-{
+export interface MinecraftScoreHolderArgumentTreeNode extends mcf.ArgumentTreeNode {
 	parser: 'minecraft:score_holder'
 	properties: {
 		amount: 'single' | 'multiple'
 	}
 }
-export interface MinecraftScoreboardSlotArgumentTreeNode
-	extends mcf.ArgumentTreeNode
-{
+export interface MinecraftScoreboardSlotArgumentTreeNode extends mcf.ArgumentTreeNode {
 	parser: 'minecraft:scoreboard_slot'
 }
 export interface MinecraftStyleArgumentTreeNode extends mcf.ArgumentTreeNode {
@@ -305,14 +233,10 @@ export interface MinecraftSwizzleArgumentTreeNode extends mcf.ArgumentTreeNode {
 export interface MinecraftTeamArgumentTreeNode extends mcf.ArgumentTreeNode {
 	parser: 'minecraft:team'
 }
-export interface MinecraftTemplateMirrorArgumentTreeNode
-	extends mcf.ArgumentTreeNode
-{
+export interface MinecraftTemplateMirrorArgumentTreeNode extends mcf.ArgumentTreeNode {
 	parser: 'minecraft:template_mirror'
 }
-export interface MinecraftTemplateRotationArgumentTreeNode
-	extends mcf.ArgumentTreeNode
-{
+export interface MinecraftTemplateRotationArgumentTreeNode extends mcf.ArgumentTreeNode {
 	parser: 'minecraft:template_rotation'
 }
 export interface MinecraftTimeArgumentTreeNode extends mcf.ArgumentTreeNode {

--- a/packages/java-edition/src/mcfunction/tree/argument.ts
+++ b/packages/java-edition/src/mcfunction/tree/argument.ts
@@ -7,37 +7,23 @@ export interface BrigadierBoolArgumentTreeNode extends mcf.ArgumentTreeNode {
 }
 export interface BrigadierDoubleArgumentTreeNode extends mcf.ArgumentTreeNode {
 	parser: 'brigadier:double'
-	properties?: {
-		min: number
-		max: number
-	}
+	properties?: { min: number; max: number }
 }
 export interface BrigadierFloatArgumentTreeNode extends mcf.ArgumentTreeNode {
 	parser: 'brigadier:float'
-	properties?: {
-		min: number
-		max: number
-	}
+	properties?: { min: number; max: number }
 }
 export interface BrigadierIntegerArgumentTreeNode extends mcf.ArgumentTreeNode {
 	parser: 'brigadier:integer'
-	properties?: {
-		min: number
-		max: number
-	}
+	properties?: { min: number; max: number }
 }
 export interface BrigadierLongArgumentTreeNode extends mcf.ArgumentTreeNode {
 	parser: 'brigadier:long'
-	properties?: {
-		min: number
-		max: number
-	}
+	properties?: { min: number; max: number }
 }
 export interface BrigadierStringArgumentTreeNode extends mcf.ArgumentTreeNode {
 	parser: 'brigadier:string'
-	properties: {
-		type: 'word' | 'phrase' | 'greedy'
-	}
+	properties: { type: 'word' | 'phrase' | 'greedy' }
 }
 export interface MinecraftAngleArgumentTreeNode extends mcf.ArgumentTreeNode {
 	parser: 'minecraft:angle'
@@ -65,10 +51,7 @@ export interface MinecraftDimensionArgumentTreeNode extends mcf.ArgumentTreeNode
 }
 export interface MinecraftEntityArgumentTreeNode extends mcf.ArgumentTreeNode {
 	parser: 'minecraft:entity'
-	properties: {
-		amount: 'multiple' | 'single'
-		type: 'entities' | 'players'
-	}
+	properties: { amount: 'multiple' | 'single'; type: 'entities' | 'players' }
 }
 export interface MinecraftEntityAnchorArgumentTreeNode extends mcf.ArgumentTreeNode {
 	parser: 'minecraft:entity_anchor'
@@ -186,15 +169,11 @@ export interface MinecraftParticleArgumentTreeNode extends mcf.ArgumentTreeNode 
 }
 export interface MinecraftResourceArgumentTreeNode extends mcf.ArgumentTreeNode {
 	parser: 'minecraft:resource'
-	properties: {
-		registry: string
-	}
+	properties: { registry: string }
 }
 export interface MinecraftResourceKeyArgumentTreeNode extends mcf.ArgumentTreeNode {
 	parser: 'minecraft:resource_key'
-	properties: {
-		registry: string
-	}
+	properties: { registry: string }
 }
 export interface MinecraftResourceLocationArgumentTreeNode extends mcf.ArgumentTreeNode {
 	parser: 'minecraft:resource_location'
@@ -202,24 +181,18 @@ export interface MinecraftResourceLocationArgumentTreeNode extends mcf.ArgumentT
 }
 export interface MinecraftResourceOrTagArgumentTreeNode extends mcf.ArgumentTreeNode {
 	parser: 'minecraft:resource_or_tag'
-	properties: {
-		registry: string
-	}
+	properties: { registry: string }
 }
 export interface MinecraftResourceOrTagKeyArgumentTreeNode extends mcf.ArgumentTreeNode {
 	parser: 'minecraft:resource_or_tag_key'
-	properties: {
-		registry: string
-	}
+	properties: { registry: string }
 }
 export interface MinecraftRotationArgumentTreeNode extends mcf.ArgumentTreeNode {
 	parser: 'minecraft:rotation'
 }
 export interface MinecraftScoreHolderArgumentTreeNode extends mcf.ArgumentTreeNode {
 	parser: 'minecraft:score_holder'
-	properties: {
-		amount: 'single' | 'multiple'
-	}
+	properties: { amount: 'single' | 'multiple' }
 }
 export interface MinecraftScoreboardSlotArgumentTreeNode extends mcf.ArgumentTreeNode {
 	parser: 'minecraft:scoreboard_slot'

--- a/packages/java-edition/src/mcfunction/tree/patch.ts
+++ b/packages/java-edition/src/mcfunction/tree/patch.ts
@@ -1,8 +1,5 @@
 import { SymbolAccessType } from '@spyglassmc/core'
-import type {
-	PartialRootTreeNode,
-	PartialTreeNode,
-} from '@spyglassmc/mcfunction'
+import type { PartialRootTreeNode, PartialTreeNode } from '@spyglassmc/mcfunction'
 import { ReleaseVersion } from '../../dependency/index.js'
 import type { NbtParserProperties } from './argument.js'
 
@@ -32,8 +29,7 @@ export function getPatch(release: ReleaseVersion): PartialRootTreeNode {
 														children: {
 															uuid: {
 																properties: {
-																	category:
-																		'attribute_modifier_uuid',
+																	category: 'attribute_modifier_uuid',
 																	usageType: 'definition',
 																},
 															},
@@ -43,8 +39,7 @@ export function getPatch(release: ReleaseVersion): PartialRootTreeNode {
 														children: {
 															uuid: {
 																properties: {
-																	category:
-																		'attribute_modifier_uuid',
+																	category: 'attribute_modifier_uuid',
 																},
 															},
 														},
@@ -55,8 +50,7 @@ export function getPatch(release: ReleaseVersion): PartialRootTreeNode {
 																children: {
 																	uuid: {
 																		properties: {
-																			category:
-																				'attribute_modifier_uuid',
+																			category: 'attribute_modifier_uuid',
 																		},
 																	},
 																},
@@ -211,11 +205,10 @@ export function getPatch(release: ReleaseVersion): PartialRootTreeNode {
 																					sourceSlot: {
 																						children: {
 																							modifier: {
-																								properties:
-																									{
-																										category:
-																											'item_modifier',
-																									},
+																								properties: {
+																									category:
+																										'item_modifier',
+																								},
 																							},
 																						},
 																					},
@@ -230,11 +223,10 @@ export function getPatch(release: ReleaseVersion): PartialRootTreeNode {
 																					sourceSlot: {
 																						children: {
 																							modifier: {
-																								properties:
-																									{
-																										category:
-																											'item_modifier',
-																									},
+																								properties: {
+																									category:
+																										'item_modifier',
+																								},
 																							},
 																						},
 																					},
@@ -265,11 +257,10 @@ export function getPatch(release: ReleaseVersion): PartialRootTreeNode {
 																					sourceSlot: {
 																						children: {
 																							modifier: {
-																								properties:
-																									{
-																										category:
-																											'item_modifier',
-																									},
+																								properties: {
+																									category:
+																										'item_modifier',
+																								},
 																							},
 																						},
 																					},
@@ -284,11 +275,10 @@ export function getPatch(release: ReleaseVersion): PartialRootTreeNode {
 																					sourceSlot: {
 																						children: {
 																							modifier: {
-																								properties:
-																									{
-																										category:
-																											'item_modifier',
-																									},
+																								properties: {
+																									category:
+																										'item_modifier',
+																								},
 																							},
 																						},
 																					},

--- a/packages/java-edition/src/mcfunction/tree/patchValidator.ts
+++ b/packages/java-edition/src/mcfunction/tree/patchValidator.ts
@@ -20,8 +20,8 @@ export function validatePatchedTree(tree: RootTreeNode, logger: core.Logger) {
 
 	function walk(node: TreeNode, path: readonly string[]) {
 		if (
-			node.type === 'argument' && PatchRequiredParsers.has(node.parser) &&
-			!node.properties
+			node.type === 'argument' && PatchRequiredParsers.has(node.parser)
+			&& !node.properties
 		) {
 			logger.warn(
 				`[validatePatchedTree] Patch required: ${node.parser} at ${

--- a/packages/java-edition/src/mcfunction/tree/patchValidator.ts
+++ b/packages/java-edition/src/mcfunction/tree/patchValidator.ts
@@ -24,9 +24,7 @@ export function validatePatchedTree(tree: RootTreeNode, logger: core.Logger) {
 			&& !node.properties
 		) {
 			logger.warn(
-				`[validatePatchedTree] Patch required: ${node.parser} at ${
-					path.join('.')
-				}`,
+				`[validatePatchedTree] Patch required: ${node.parser} at ${path.join('.')}`,
 			)
 		}
 

--- a/packages/java-edition/src/mcfunction/tree/patchValidator.ts
+++ b/packages/java-edition/src/mcfunction/tree/patchValidator.ts
@@ -19,13 +19,8 @@ export function validatePatchedTree(tree: RootTreeNode, logger: core.Logger) {
 	walk(tree, [])
 
 	function walk(node: TreeNode, path: readonly string[]) {
-		if (
-			node.type === 'argument' && PatchRequiredParsers.has(node.parser)
-			&& !node.properties
-		) {
-			logger.warn(
-				`[validatePatchedTree] Patch required: ${node.parser} at ${path.join('.')}`,
-			)
+		if (node.type === 'argument' && PatchRequiredParsers.has(node.parser) && !node.properties) {
+			logger.warn(`[validatePatchedTree] Patch required: ${node.parser} at ${path.join('.')}`)
 		}
 
 		for (const [key, value] of Object.entries(node.children ?? {})) {

--- a/packages/java-edition/test/dependency/mcmeta.spec.ts
+++ b/packages/java-edition/test/dependency/mcmeta.spec.ts
@@ -6,11 +6,7 @@ import * as path from 'path'
 import snapshot from 'snap-shot-it'
 import url from 'url'
 import type { PackMcmeta } from '../../lib/dependency/common.js'
-import type {
-	McmetaRegistries,
-	McmetaStates,
-	McmetaVersions,
-} from '../../lib/dependency/mcmeta.js'
+import type { McmetaRegistries, McmetaStates, McmetaVersions } from '../../lib/dependency/mcmeta.js'
 import {
 	Fluids,
 	getMcmetaSummaryUris,
@@ -45,16 +41,15 @@ const Fixtures = {
 
 describe('mcmeta', () => {
 	describe('resolveConfiguredVersion()', () => {
-		const suites: { version: string; packMcmeta?: PackMcmeta | undefined }[] =
-			[
-				{ version: 'Auto', packMcmeta: { pack: { pack_format: 6 } } },
-				{ version: 'Latest Release' },
-				{ version: 'Latest Snapshot' },
-				{ version: 'unknown' },
-				{ version: '20w06a' },
-				{ version: '22w03a' },
-				{ version: '1.16.5' },
-			]
+		const suites: { version: string; packMcmeta?: PackMcmeta | undefined }[] = [
+			{ version: 'Auto', packMcmeta: { pack: { pack_format: 6 } } },
+			{ version: 'Latest Release' },
+			{ version: 'Latest Snapshot' },
+			{ version: 'unknown' },
+			{ version: '20w06a' },
+			{ version: '22w03a' },
+			{ version: '1.16.5' },
+		]
 		for (const { version, packMcmeta } of suites) {
 			it(`Should resolve "${version}"`, async () => {
 				const actual = resolveConfiguredVersion(version, {

--- a/packages/java-edition/test/json/binder/index.spec.ts
+++ b/packages/java-edition/test/json/binder/index.spec.ts
@@ -14,8 +14,7 @@ describe('dissectUri()', () => {
 		{ uri: 'file:///data/minecraft/tags/block/bar.json', version: '1.21' },
 		{ uri: 'file:///data/qux/dimension/foo/baz.json', version: '1.16' },
 		{
-			uri:
-				'file:///data/minecraft/advancements/data/foo/predicates/bar.json',
+			uri: 'file:///data/minecraft/advancements/data/foo/predicates/bar.json',
 		},
 		{ uri: 'file:///pack.mcmeta' },
 		{ uri: 'file:///data/loot_tables/foo.json' },

--- a/packages/java-edition/test/json/binder/index.spec.ts
+++ b/packages/java-edition/test/json/binder/index.spec.ts
@@ -13,19 +13,16 @@ describe('dissectUri()', () => {
 		{ uri: 'file:///data/minecraft/tags/block/bar.json' },
 		{ uri: 'file:///data/minecraft/tags/block/bar.json', version: '1.21' },
 		{ uri: 'file:///data/qux/dimension/foo/baz.json', version: '1.16' },
-		{
-			uri: 'file:///data/minecraft/advancements/data/foo/predicates/bar.json',
-		},
+		{ uri: 'file:///data/minecraft/advancements/data/foo/predicates/bar.json' },
 		{ uri: 'file:///pack.mcmeta' },
 		{ uri: 'file:///data/loot_tables/foo.json' },
 		{ uri: 'file:///data/minecraft/entities/foo.json' },
 	]
 	for (const { uri, version } of suites) {
 		it(`Dissect Uri "${uri}"${version ? ' in ' + version : ''}`, () => {
-			const ctx = UriBinderContext.create(mockProjectData({
-				roots: ['file:///'],
-				ctx: { loadedVersion: version ?? '1.15' },
-			}))
+			const ctx = UriBinderContext.create(
+				mockProjectData({ roots: ['file:///'], ctx: { loadedVersion: version ?? '1.15' } }),
+			)
 			snapshot(dissectUri(uri, ctx) ?? 'undefined')
 		})
 	}

--- a/packages/java-edition/test/mcfunction/parser/argument.spec.ts
+++ b/packages/java-edition/test/mcfunction/parser/argument.spec.ts
@@ -368,8 +368,7 @@ describe('mcfunction argument parser', () => {
 							specName: `mcfunction argument ${parserName} ${itTitle}`,
 							uri: new URL(
 								`./argument/${
-									parserName.replace(/[:_](\w)/g, (_, c) =>
-										c.toUpperCase())
+									parserName.replace(/[:_](\w)/g, (_, c) => c.toUpperCase())
 								}.spec.js`,
 								import.meta.url,
 							),

--- a/packages/java-edition/test/mcfunction/parser/argument.spec.ts
+++ b/packages/java-edition/test/mcfunction/parser/argument.spec.ts
@@ -11,270 +11,147 @@ import * as nbt from '@spyglassmc/nbt'
 import { describe, it } from 'mocha'
 
 const Suites: Partial<
-	Record<
-		ArgumentTreeNode['parser'],
-		{ content: string[]; properties?: any; version?: string }[]
-	>
+	Record<ArgumentTreeNode['parser'], { content: string[]; properties?: any; version?: string }[]>
 > = {
 	'brigadier:bool': [{ content: ['false', 'true'] }],
-	'brigadier:double': [
-		{ content: ['0', '1.2', '.5', '-1', '-.5', '-1234.56'] },
-	],
-	'brigadier:float': [{
-		content: ['0', '1.2', '.5', '-1', '-.5', '-1234.56'],
-	}],
+	'brigadier:double': [{ content: ['0', '1.2', '.5', '-1', '-.5', '-1234.56'] }],
+	'brigadier:float': [{ content: ['0', '1.2', '.5', '-1', '-.5', '-1234.56'] }],
 	'brigadier:integer': [{ content: ['0', '123', '-123'] }],
 	'brigadier:long': [{ content: ['0', '123', '-123'] }],
 	'brigadier:string': [
-		{
-			properties: { type: 'word' },
-			content: ['word', 'word_with_underscores'],
-		},
-		{
-			properties: { type: 'phrase' },
-			content: ['"quoted phrase"', 'word', '""'],
-		},
-		{
-			properties: { type: 'greedy' },
-			content: ['word', 'words with spaces', '"and symbols"'],
-		},
+		{ properties: { type: 'word' }, content: ['word', 'word_with_underscores'] },
+		{ properties: { type: 'phrase' }, content: ['"quoted phrase"', 'word', '""'] },
+		{ properties: { type: 'greedy' }, content: ['word', 'words with spaces', '"and symbols"'] },
 	],
 	'minecraft:angle': [{ content: ['0', '~', '~-0.5', '^'] }],
-	'minecraft:block_pos': [
-		{
-			content: [
-				'0 0 0',
-				'~ ~ ~',
-				'^ ^ ^',
-				'^1 ^ ^-5',
-				'~0.5 ~1 ~-5',
-				'0.5 0 0.5',
-			],
-		},
-	],
-	'minecraft:block_predicate': [
-		{
-			content: [
-				'stone',
-				'minecraft:stone',
-				'stone[foo=bar]',
-				'#stone',
-				'#stone[foo=bar]{baz:nbt}',
-			],
-		},
-	],
-	'minecraft:block_state': [
-		{
-			content: [
-				'stone',
-				'minecraft:stone',
-				'stone[foo=bar]',
-				'foo{bar:baz}',
-			],
-		},
-	],
+	'minecraft:block_pos': [{
+		content: ['0 0 0', '~ ~ ~', '^ ^ ^', '^1 ^ ^-5', '~0.5 ~1 ~-5', '0.5 0 0.5'],
+	}],
+	'minecraft:block_predicate': [{
+		content: ['stone', 'minecraft:stone', 'stone[foo=bar]', '#stone', '#stone[foo=bar]{baz:nbt}'],
+	}],
+	'minecraft:block_state': [{
+		content: ['stone', 'minecraft:stone', 'stone[foo=bar]', 'foo{bar:baz}'],
+	}],
 	'minecraft:color': [{ content: ['red', 'green'] }],
 	'minecraft:column_pos': [{ content: ['0 0', '~ ~', '~1 ~-2'] }],
-	'minecraft:component': [
-		{
-			content: ['"hello world"', '""', '{"text":"hello world"}', '[""]'],
-		},
-	],
-	'minecraft:dimension': [
-		{ content: ['minecraft:overworld', 'minecraft:the_nether'] },
-	],
-	'minecraft:entity': [
-		{
-			properties: { amount: 'multiple', type: 'entities' },
-			content: [
-				'Player',
-				'0123',
-				'@e',
-				'@e[type=foo]',
-				'dd12be42-52a9-4a91-a8a1-11c01849e498',
-			],
-		},
-		{
-			properties: { amount: 'single', type: 'entities' },
-			content: [
-				'@n',
-				'@n[type=cow]',
-				'@n[distance=..5]',
-			],
-		},
-		{
-			properties: { amount: 'single', type: 'entities' },
-			content: [
-				'@n',
-				'@n[type=cow]',
-				'@n[distance=..5]',
-			],
-			version: '1.21',
-		},
-		{
-			properties: { amount: 'single', type: 'players' },
-			content: [
-				'Player',
-				'0123',
-				'@e',
-				'@e[limit=1]',
-				'@r',
-				'@a[limit=1]',
-				'dd12be42-52a9-4a91-a8a1-11c01849e498',
-			],
-		},
-		{
-			properties: { amount: 'multiple', type: 'entities' },
-			content: [
-				'this_is_a_super_long_player_name',
-				'@a[ ]',
-				'@a[ advancements = { minecraft:foo = true , minecraft:bar = { qux = true , } , } , ]',
-				'@a[ advancements = { } , advancements = { } , ]',
-				'@a[ distance = ..1 , ]',
-				'@a[ distance = ..-1 , distance = 1..0 , ]',
-				'@a[ gamemode = ! creative , gamemode = ! adventure , ]',
-				'@a[ gamemode = creative , gamemode = unknown , ]',
-				'@a[ limit = 1 , ]',
-				'@s[ limit = 0 , limit = 0 , ]',
-				'@a[ level = 1.. , ]',
-				'@a[ level = -1 , level = -1 , ]',
-				'@a[ name = ! "SPGoding" , "name" = ! Misode , \'name\' = ! , ]',
-				'@a[ name = "SPGoding" , "name" = Misode , \'name\' = , ]',
-				'@a[ nbt = {} , ]',
-				'@a[ predicate = spgoding:foo , predicate = ! spgoding:bar , ]',
-				// Another part of test cases for entity selector can be found under `minecraft:score_holder` below.
-			],
-		},
-	],
+	'minecraft:component': [{ content: ['"hello world"', '""', '{"text":"hello world"}', '[""]'] }],
+	'minecraft:dimension': [{ content: ['minecraft:overworld', 'minecraft:the_nether'] }],
+	'minecraft:entity': [{
+		properties: { amount: 'multiple', type: 'entities' },
+		content: ['Player', '0123', '@e', '@e[type=foo]', 'dd12be42-52a9-4a91-a8a1-11c01849e498'],
+	}, {
+		properties: { amount: 'single', type: 'entities' },
+		content: ['@n', '@n[type=cow]', '@n[distance=..5]'],
+	}, {
+		properties: { amount: 'single', type: 'entities' },
+		content: ['@n', '@n[type=cow]', '@n[distance=..5]'],
+		version: '1.21',
+	}, {
+		properties: { amount: 'single', type: 'players' },
+		content: [
+			'Player',
+			'0123',
+			'@e',
+			'@e[limit=1]',
+			'@r',
+			'@a[limit=1]',
+			'dd12be42-52a9-4a91-a8a1-11c01849e498',
+		],
+	}, {
+		properties: { amount: 'multiple', type: 'entities' },
+		content: [
+			'this_is_a_super_long_player_name',
+			'@a[ ]',
+			'@a[ advancements = { minecraft:foo = true , minecraft:bar = { qux = true , } , } , ]',
+			'@a[ advancements = { } , advancements = { } , ]',
+			'@a[ distance = ..1 , ]',
+			'@a[ distance = ..-1 , distance = 1..0 , ]',
+			'@a[ gamemode = ! creative , gamemode = ! adventure , ]',
+			'@a[ gamemode = creative , gamemode = unknown , ]',
+			'@a[ limit = 1 , ]',
+			'@s[ limit = 0 , limit = 0 , ]',
+			'@a[ level = 1.. , ]',
+			'@a[ level = -1 , level = -1 , ]',
+			'@a[ name = ! "SPGoding" , "name" = ! Misode , \'name\' = ! , ]',
+			'@a[ name = "SPGoding" , "name" = Misode , \'name\' = , ]',
+			'@a[ nbt = {} , ]',
+			'@a[ predicate = spgoding:foo , predicate = ! spgoding:bar , ]',
+			// Another part of test cases for entity selector can be found under `minecraft:score_holder` below.
+		],
+	}],
 	'minecraft:entity_anchor': [{ content: ['eyes', 'feet'] }],
 	'minecraft:entity_summon': [{ content: ['minecraft:pig', 'cow'] }],
-	'minecraft:float_range': [
-		{ content: ['0..5.2', '0', '-5.4', '-100.76..', '..100', '..'] },
-	],
+	'minecraft:float_range': [{ content: ['0..5.2', '0', '-5.4', '-100.76..', '..100', '..'] }],
 	'minecraft:function': [{ content: ['foo', 'foo:bar', '#foo'] }],
-	'minecraft:gamemode': [{
-		content: ['adventure', 'survival', 'spectator', 'creative'],
+	'minecraft:gamemode': [{ content: ['adventure', 'survival', 'spectator', 'creative'] }],
+	'minecraft:game_profile': [{
+		content: ['Player', '0123', 'dd12be42-52a9-4a91-a8a1-11c01849e498', '@e'],
 	}],
-	'minecraft:game_profile': [
-		{
-			content: [
-				'Player',
-				'0123',
-				'dd12be42-52a9-4a91-a8a1-11c01849e498',
-				'@e',
-			],
-		},
-	],
-	'minecraft:int_range': [
-		{ content: ['0..5', '0', '-5', '-100..', '..100', '..'] },
-	],
+	'minecraft:int_range': [{ content: ['0..5', '0', '-5', '-100..', '..100', '..'] }],
 	'minecraft:item_enchantment': [{ content: ['unbreaking', 'silk_touch'] }],
-	'minecraft:item_predicate': [
-		{
-			content: ['stick', 'minecraft:stick', '#stick', '#stick{foo:bar}'],
-		},
-	],
-	'minecraft:item_slot': [
-		{ content: ['container.5', 'weapon', 'contents'] },
-		{ content: ['contents', 'horse.armor'], version: '1.20.5' },
-	],
-	'minecraft:item_slots': [{
-		content: ['weapon', 'container.*', 'armor.head'],
+	'minecraft:item_predicate': [{
+		content: ['stick', 'minecraft:stick', '#stick', '#stick{foo:bar}'],
 	}],
-	'minecraft:item_stack': [
-		{
-			content: ['stick', 'minecraft:stick', 'stick{foo:bar}'],
-		},
-	],
-	'minecraft:loot_modifier': [
-		{ content: ['foo:bar', '[{function:"furnace_smelt"}]'] },
-	],
-	'minecraft:loot_predicate': [
-		{ content: ['custom:maybe', '{condition:"random_chance",chance:0.2}'] },
-	],
-	'minecraft:loot_table': [
-		{ content: ['minecraft:blocks/crafting_table', '{pools:[]}'] },
-	],
-	'minecraft:message': [
-		{ content: ['Hello world!', 'foo', '@e', 'Hello @p :)'] },
-	],
+	'minecraft:item_slot': [{ content: ['container.5', 'weapon', 'contents'] }, {
+		content: ['contents', 'horse.armor'],
+		version: '1.20.5',
+	}],
+	'minecraft:item_slots': [{ content: ['weapon', 'container.*', 'armor.head'] }],
+	'minecraft:item_stack': [{ content: ['stick', 'minecraft:stick', 'stick{foo:bar}'] }],
+	'minecraft:loot_modifier': [{ content: ['foo:bar', '[{function:"furnace_smelt"}]'] }],
+	'minecraft:loot_predicate': [{
+		content: ['custom:maybe', '{condition:"random_chance",chance:0.2}'],
+	}],
+	'minecraft:loot_table': [{ content: ['minecraft:blocks/crafting_table', '{pools:[]}'] }],
+	'minecraft:message': [{ content: ['Hello world!', 'foo', '@e', 'Hello @p :)'] }],
 	'minecraft:mob_effect': [{ content: ['spooky', 'effect'] }],
 	'minecraft:nbt_compound_tag': [{ content: ['{}', '{foo:bar}'] }],
-	'minecraft:nbt_tag': [
-		{ content: ['0', '0b', '0l', '0.0', '"foo"', '{foo:bar}'] },
-	],
+	'minecraft:nbt_tag': [{ content: ['0', '0b', '0l', '0.0', '"foo"', '{foo:bar}'] }],
 	'minecraft:objective': [{ content: ['foo', '012'] }],
-	'minecraft:objective_criteria': [
-		{
-			content: [
-				'dummy',
-				'used:spyglass',
-				'minecraft.used:minecraft.spyglass',
-			],
-		},
-	],
+	'minecraft:objective_criteria': [{
+		content: ['dummy', 'used:spyglass', 'minecraft.used:minecraft.spyglass'],
+	}],
 	'minecraft:operation': [{ content: ['=', '>', '<'] }],
-	'minecraft:particle': [
-		{
-			content: [
-				'block stone',
-				'cloud',
-				'dust 0.2 0.4 0.6 0.8',
-				'dust_color_transition 0.1 0.2 0.3 0.4 0.5 0.6 0.7',
-				'item carrot_on_a_stick',
-				'sculk_charge 4.2',
-				'shriek 20',
-				'vibration 0.1 0.2 0.3 40',
-				'block{block_state:"diamond_block"}',
-				'end_rod{}',
-			],
-		},
-		{
-			content: [
-				'block stone',
-				'dust 0.2 0.4 0.6 0.8',
-				'block{block_state:"diamond_block"}',
-				'end_rod',
-				'end_rod{}',
-			],
-			version: '1.20.5',
-		},
-	],
-	'minecraft:resource': [
-		{
-			properties: { registry: 'bossbar' },
-			content: ['foo', 'foo:bar', '012'],
-		},
-	],
-	'minecraft:resource_location': [
-		{ content: ['foo', 'foo:bar', '012'] },
-		{
-			properties: { category: 'bossbar' },
-			content: ['foo', 'foo:bar', '012'],
-		},
-	],
-	'minecraft:resource_or_tag': [
-		{
-			properties: { registry: 'bossbar' },
-			content: [
-				'foo',
-				'foo:bar',
-				'012',
-				'#skeletons',
-				'#minecraft:skeletons',
-			],
-		},
-	],
+	'minecraft:particle': [{
+		content: [
+			'block stone',
+			'cloud',
+			'dust 0.2 0.4 0.6 0.8',
+			'dust_color_transition 0.1 0.2 0.3 0.4 0.5 0.6 0.7',
+			'item carrot_on_a_stick',
+			'sculk_charge 4.2',
+			'shriek 20',
+			'vibration 0.1 0.2 0.3 40',
+			'block{block_state:"diamond_block"}',
+			'end_rod{}',
+		],
+	}, {
+		content: [
+			'block stone',
+			'dust 0.2 0.4 0.6 0.8',
+			'block{block_state:"diamond_block"}',
+			'end_rod',
+			'end_rod{}',
+		],
+		version: '1.20.5',
+	}],
+	'minecraft:resource': [{
+		properties: { registry: 'bossbar' },
+		content: ['foo', 'foo:bar', '012'],
+	}],
+	'minecraft:resource_location': [{ content: ['foo', 'foo:bar', '012'] }, {
+		properties: { category: 'bossbar' },
+		content: ['foo', 'foo:bar', '012'],
+	}],
+	'minecraft:resource_or_tag': [{
+		properties: { registry: 'bossbar' },
+		content: ['foo', 'foo:bar', '012', '#skeletons', '#minecraft:skeletons'],
+	}],
 	'minecraft:rotation': [{ content: ['0 0', '~ ~', '~-5 ~5'] }],
 	'minecraft:score_holder': [
-		{
-			properties: { amount: 'multiple' },
-			content: ['Player', '0123', '*', '@e'],
-		},
-		{
-			properties: { amount: 'single' },
-			content: ['Player', '0123', '*', '@e'],
-		},
+		{ properties: { amount: 'multiple' }, content: ['Player', '0123', '*', '@e'] },
+		{ properties: { amount: 'single' }, content: ['Player', '0123', '*', '@e'] },
 		{
 			properties: { amount: 'multiple' },
 			content: [
@@ -299,36 +176,23 @@ const Suites: Partial<
 			],
 		},
 	],
-	'minecraft:style': [{
-		content: ['{"bold": true}', '{ "color": "red", "italic": true }'],
-	}],
+	'minecraft:style': [{ content: ['{"bold": true}', '{ "color": "red", "italic": true }'] }],
 	'minecraft:swizzle': [{ content: ['xyz', 'x'] }],
 	'minecraft:team': [{ content: ['foo', '123'] }],
 	'minecraft:time': [{ content: ['0d', '0s', '0t', '0', '0foo'] }],
-	'minecraft:uuid': [
-		{
-			content: [
-				'dd12be42-52a9-4a91-a8a1-11c01849e498',
-				'1-1-1-1-1',
-				'42',
-				'ffffffffffffffff-1-1-1-1',
-				'fffffffffffffff-1-1-1-1',
-			],
-		},
-	],
+	'minecraft:uuid': [{
+		content: [
+			'dd12be42-52a9-4a91-a8a1-11c01849e498',
+			'1-1-1-1-1',
+			'42',
+			'ffffffffffffffff-1-1-1-1',
+			'fffffffffffffff-1-1-1-1',
+		],
+	}],
 	'minecraft:vec2': [{ content: ['0 0', '~ ~', '0.1 -0.5', '~1 ~-2'] }],
-	'minecraft:vec3': [
-		{
-			content: [
-				'0 0 0',
-				'~ ~ ~',
-				'^ ^ ^',
-				'^1 ^ ^-5',
-				'0.1 -0.5 .9',
-				'~0.5 ~1 ~-5',
-			],
-		},
-	],
+	'minecraft:vec3': [{
+		content: ['0 0 0', '~ ~ ~', '^ ^ ^', '^1 ^ ^-5', '0.1 -0.5 .9', '~0.5 ~1 ~-5'],
+	}],
 }
 
 const RemoveExtraChildren = new Set([
@@ -354,12 +218,8 @@ describe('mcfunction argument parser', () => {
 				nbt.initialize(project)
 
 				for (const string of content) {
-					const propertiesString = properties
-						? ` with ${JSON.stringify(properties)}`
-						: ''
-					const versionString = version !== '1.15'
-						? ` in version ${version}`
-						: ''
+					const propertiesString = properties ? ` with ${JSON.stringify(properties)}` : ''
+					const versionString = version !== '1.15' ? ` in version ${version}` : ''
 					const itTitle = `Parse "${
 						showWhitespaceGlyph(string)
 					}"${propertiesString}${versionString}`
@@ -374,9 +234,7 @@ describe('mcfunction argument parser', () => {
 							),
 							value: testParser(argument(treeNode)!, string, {
 								project,
-								removeTopLevelChildren: RemoveExtraChildren.has(
-									parserName,
-								),
+								removeTopLevelChildren: RemoveExtraChildren.has(parserName),
 							}),
 						})
 					})

--- a/packages/json/src/checker/index.ts
+++ b/packages/json/src/checker/index.ts
@@ -70,8 +70,8 @@ export function index(
 					node.typeDef = definition
 					// TODO: improve hover info
 					if (
-						node.parent && JsonPairNode?.is(node.parent) &&
-						node.parent.key
+						node.parent && JsonPairNode?.is(node.parent)
+						&& node.parent.key
 					) {
 						node.parent.key.hover =
 							`\`\`\`typescript\n${node.parent.key.value}: ${

--- a/packages/json/src/checker/index.ts
+++ b/packages/json/src/checker/index.ts
@@ -73,10 +73,9 @@ export function index(
 						node.parent && JsonPairNode?.is(node.parent)
 						&& node.parent.key
 					) {
-						node.parent.key.hover =
-							`\`\`\`typescript\n${node.parent.key.value}: ${
-								mcdoc.McdocType.toString(definition)
-							}\n\`\`\``
+						node.parent.key.hover = `\`\`\`typescript\n${node.parent.key.value}: ${
+							mcdoc.McdocType.toString(definition)
+						}\n\`\`\``
 					}
 				},
 				stringAttacher: (node, attacher) => {

--- a/packages/json/src/checker/index.ts
+++ b/packages/json/src/checker/index.ts
@@ -2,9 +2,7 @@ import * as core from '@spyglassmc/core'
 import * as mcdoc from '@spyglassmc/mcdoc'
 import { type JsonNode, JsonPairNode, JsonStringNode } from '../node/index.js'
 
-export function index(
-	type: mcdoc.McdocType,
-): core.SyncChecker<JsonNode> {
+export function index(type: mcdoc.McdocType): core.SyncChecker<JsonNode> {
 	return (node, ctx) => {
 		mcdoc.runtime.checker.typeDefinition<JsonNode>(
 			[{ originalNode: node, inferredType: inferType(node) }],
@@ -14,21 +12,16 @@ export function index(
 				isEquivalent: (inferred, def) => {
 					switch (inferred.kind) {
 						case 'list':
-							return [
-								'list',
-								'byte_array',
-								'int_array',
-								'long_array',
-								'tuple',
-							].includes(def.kind)
+							return ['list', 'byte_array', 'int_array', 'long_array', 'tuple'].includes(
+								def.kind,
+							)
 						case 'struct':
 							return def.kind === 'struct'
 						case 'byte':
 						case 'short':
 						case 'int':
 						case 'long':
-							return ['byte', 'short', 'int', 'long', 'float', 'double']
-								.includes(def.kind)
+							return ['byte', 'short', 'int', 'long', 'float', 'double'].includes(def.kind)
 						case 'float':
 						case 'double':
 							return ['float', 'double'].includes(def.kind)
@@ -38,25 +31,15 @@ export function index(
 				},
 				getChildren: node => {
 					if (node.type === 'json:array') {
-						return node.children.filter(n => n.value)
-							.map(
-								n => [{
-									originalNode: n.value!,
-									inferredType: inferType(n.value!),
-								}],
-							)
+						return node.children.filter(n => n.value).map(
+							n => [{ originalNode: n.value!, inferredType: inferType(n.value!) }],
+						)
 					}
 					if (node.type === 'json:object') {
 						return node.children.filter(kvp => kvp.key).map(kvp => ({
-							key: {
-								originalNode: kvp.key!,
-								inferredType: inferType(kvp.key!),
-							},
+							key: { originalNode: kvp.key!, inferredType: inferType(kvp.key!) },
 							possibleValues: kvp.value
-								? [{
-									originalNode: kvp.value,
-									inferredType: inferType(kvp.value),
-								}]
+								? [{ originalNode: kvp.value, inferredType: inferType(kvp.value) }]
 								: [],
 						}))
 					}
@@ -69,10 +52,7 @@ export function index(
 				attachTypeInfo: (node, definition) => {
 					node.typeDef = definition
 					// TODO: improve hover info
-					if (
-						node.parent && JsonPairNode?.is(node.parent)
-						&& node.parent.key
-					) {
+					if (node.parent && JsonPairNode?.is(node.parent) && node.parent.key) {
 						node.parent.key.hover = `\`\`\`typescript\n${node.parent.key.value}: ${
 							mcdoc.McdocType.toString(definition)
 						}\n\`\`\``
@@ -96,10 +76,7 @@ export function index(
 function inferType(node: JsonNode): Exclude<mcdoc.McdocType, mcdoc.UnionType> {
 	switch (node.type) {
 		case 'json:boolean':
-			return {
-				kind: 'literal',
-				value: { kind: 'boolean', value: node.value! },
-			}
+			return { kind: 'literal', value: { kind: 'boolean', value: node.value! } }
 		case 'json:number':
 			return {
 				kind: 'literal',
@@ -108,10 +85,7 @@ function inferType(node: JsonNode): Exclude<mcdoc.McdocType, mcdoc.UnionType> {
 		case 'json:null':
 			return { kind: 'any' } // null is always invalid?
 		case 'json:string':
-			return {
-				kind: 'literal',
-				value: { kind: 'string', value: node.value },
-			}
+			return { kind: 'literal', value: { kind: 'string', value: node.value } }
 		case 'json:array':
 			return { kind: 'list', item: { kind: 'any' } }
 		case 'json:object':

--- a/packages/json/src/completer/index.ts
+++ b/packages/json/src/completer/index.ts
@@ -71,8 +71,12 @@ const primitive: core.Completer<JsonPrimitiveNode> = (node, ctx) => {
 		return []
 	}
 	if (
-		node.children && node.children.length > 0 &&
-		core.Range.contains(core.Range.translate(node, 1, -1), ctx.offset, true)
+		node.children && node.children.length > 0
+		&& core.Range.contains(
+			core.Range.translate(node, 1, -1),
+			ctx.offset,
+			true,
+		)
 	) {
 		const child = node.children[0]
 		return ctx.meta.getCompleter(child.type)(child, ctx)

--- a/packages/json/src/completer/index.ts
+++ b/packages/json/src/completer/index.ts
@@ -18,9 +18,7 @@ const array: core.Completer<JsonArrayNode> = (node, ctx) => {
 	}
 	if (node.typeDef?.kind === 'list') {
 		const completions = getValues(node.typeDef.item, ctx.offset, ctx)
-		if (
-			ctx.offset < node.children[node.children.length - 1]?.range.start ?? 0
-		) {
+		if (ctx.offset < node.children[node.children.length - 1]?.range.start ?? 0) {
 			return completions.map(c => ({ ...c, insertText: c.insertText + ',' }))
 		}
 		return completions
@@ -34,14 +32,11 @@ const object = core.completer.record<JsonStringNode, JsonNode, JsonObjectNode>({
 			return []
 		}
 		const keySet = new Set(exitingKeys.map(n => n.value))
-		return mcdoc.runtime.completer.getFields(record.typeDef)
-			.filter(({ key }) => !keySet.has(key))
+		return mcdoc.runtime.completer.getFields(record.typeDef).filter(({ key }) => !keySet.has(key))
 			.map(({ key, field }) =>
 				core.CompletionItem.create(key, pair?.key ?? range, {
 					kind: core.CompletionKind.Field,
-					detail: mcdoc.McdocType.toString(
-						field.type as core.Mutable<mcdoc.McdocType>,
-					),
+					detail: mcdoc.McdocType.toString(field.type as core.Mutable<mcdoc.McdocType>),
 					deprecated: field.deprecated,
 					sortText: field.optional ? '$b' : '$a', // sort above hardcoded $schema
 					filterText: `"${key}"`,
@@ -55,9 +50,9 @@ const object = core.completer.record<JsonStringNode, JsonNode, JsonObjectNode>({
 		}
 		if (pair.key && record.typeDef) {
 			const pairKey = pair.key.value
-			const field = mcdoc.runtime.completer.getFields(record.typeDef)
-				.find(({ key }) => key === pairKey)
-				?.field.type
+			const field = mcdoc.runtime.completer.getFields(record.typeDef).find(({ key }) =>
+				key === pairKey
+			)?.field.type
 			if (field) {
 				return getValues(field, range, ctx)
 			}
@@ -72,11 +67,7 @@ const primitive: core.Completer<JsonPrimitiveNode> = (node, ctx) => {
 	}
 	if (
 		node.children && node.children.length > 0
-		&& core.Range.contains(
-			core.Range.translate(node, 1, -1),
-			ctx.offset,
-			true,
-		)
+		&& core.Range.contains(core.Range.translate(node, 1, -1), ctx.offset, true)
 	) {
 		const child = node.children[0]
 		return ctx.meta.getCompleter(child.type)(child, ctx)
@@ -90,15 +81,16 @@ function getValues(
 	range: core.RangeLike,
 	ctx: core.CompleterContext,
 ): core.CompletionItem[] {
-	return mcdoc.runtime.completer.getValues(typeDef, ctx)
-		.map(({ value, detail, kind, completionKind }) =>
-			core.CompletionItem.create(value, range, {
-				kind: completionKind ?? core.CompletionKind.Value,
-				detail,
-				filterText: kind === 'string' ? `"${value}"` : value,
-				insertText: kind === 'string' ? `"${value}"` : value,
-			})
-		)
+	return mcdoc.runtime.completer.getValues(typeDef, ctx).map((
+		{ value, detail, kind, completionKind },
+	) =>
+		core.CompletionItem.create(value, range, {
+			kind: completionKind ?? core.CompletionKind.Value,
+			detail,
+			filterText: kind === 'string' ? `"${value}"` : value,
+			insertText: kind === 'string' ? `"${value}"` : value,
+		})
+	)
 }
 
 export function register(meta: core.MetaRegistry): void {

--- a/packages/json/src/formatter/index.ts
+++ b/packages/json/src/formatter/index.ts
@@ -13,8 +13,8 @@ import type {
 const array: Formatter<JsonArrayNode> = (node, ctx) => {
 	if (node.children.length === 0) return '[]'
 	const values = node.children.map((child) => {
-		const value = child.value &&
-			ctx.meta.getFormatter(child.value.type)(
+		const value = child.value
+			&& ctx.meta.getFormatter(child.value.type)(
 				child.value,
 				indentFormatter(ctx),
 			)
@@ -27,8 +27,8 @@ const object: Formatter<JsonObjectNode> = (node, ctx) => {
 	if (node.children.length === 0) return '{}'
 	const fields = node.children.map((child) => {
 		const key = child.key && core.formatter.string(child.key, ctx)
-		const value = child.value &&
-			ctx.meta.getFormatter(child.value.type)(
+		const value = child.value
+			&& ctx.meta.getFormatter(child.value.type)(
 				child.value,
 				indentFormatter(ctx),
 			)

--- a/packages/json/src/formatter/index.ts
+++ b/packages/json/src/formatter/index.ts
@@ -14,10 +14,7 @@ const array: Formatter<JsonArrayNode> = (node, ctx) => {
 	if (node.children.length === 0) return '[]'
 	const values = node.children.map((child) => {
 		const value = child.value
-			&& ctx.meta.getFormatter(child.value.type)(
-				child.value,
-				indentFormatter(ctx),
-			)
+			&& ctx.meta.getFormatter(child.value.type)(child.value, indentFormatter(ctx))
 		return `${ctx.indent(1)}${value ?? ''}`
 	})
 	return `[\n${values.join(',\n')}\n${ctx.indent()}]`
@@ -28,10 +25,7 @@ const object: Formatter<JsonObjectNode> = (node, ctx) => {
 	const fields = node.children.map((child) => {
 		const key = child.key && core.formatter.string(child.key, ctx)
 		const value = child.value
-			&& ctx.meta.getFormatter(child.value.type)(
-				child.value,
-				indentFormatter(ctx),
-			)
+			&& ctx.meta.getFormatter(child.value.type)(child.value, indentFormatter(ctx))
 		return `${ctx.indent(1)}${key ?? ''}: ${value ?? ''}`
 	})
 	return `{\n${fields.join(',\n')}\n${ctx.indent()}}`
@@ -42,10 +36,7 @@ const number: Formatter<JsonNumberNode> = (node, ctx) =>
 
 export function register(meta: MetaRegistry): void {
 	meta.registerFormatter<JsonArrayNode>('json:array', array)
-	meta.registerFormatter<JsonBooleanNode>(
-		'json:boolean',
-		core.formatter.boolean,
-	)
+	meta.registerFormatter<JsonBooleanNode>('json:boolean', core.formatter.boolean)
 	meta.registerFormatter<JsonNullNode>('json:null', () => 'null')
 	meta.registerFormatter<JsonNumberNode>('json:number', number)
 	meta.registerFormatter<JsonObjectNode>('json:object', object)

--- a/packages/json/src/node/index.ts
+++ b/packages/json/src/node/index.ts
@@ -24,12 +24,12 @@ export type JsonNode =
 export namespace JsonNode {
 	export function is(node: core.AstNode): node is JsonNode {
 		return (
-			JsonObjectNode.is(node) ||
-			JsonArrayNode.is(node) ||
-			JsonStringNode.is(node) ||
-			JsonNumberNode.is(node) ||
-			JsonBooleanNode.is(node) ||
-			JsonNullNode.is(node)
+			JsonObjectNode.is(node)
+			|| JsonArrayNode.is(node)
+			|| JsonStringNode.is(node)
+			|| JsonNumberNode.is(node)
+			|| JsonBooleanNode.is(node)
+			|| JsonNullNode.is(node)
 		)
 	}
 }

--- a/packages/json/src/node/index.ts
+++ b/packages/json/src/node/index.ts
@@ -17,20 +17,15 @@ interface JsonBaseNode {
 	typeDef?: mcdoc.runtime.checker.SimplifiedMcdocType
 }
 
-export type JsonNode =
-	| JsonObjectNode
-	| JsonArrayNode
-	| JsonPrimitiveNode
+export type JsonNode = JsonObjectNode | JsonArrayNode | JsonPrimitiveNode
 export namespace JsonNode {
 	export function is(node: core.AstNode): node is JsonNode {
-		return (
-			JsonObjectNode.is(node)
+		return (JsonObjectNode.is(node)
 			|| JsonArrayNode.is(node)
 			|| JsonStringNode.is(node)
 			|| JsonNumberNode.is(node)
 			|| JsonBooleanNode.is(node)
-			|| JsonNullNode.is(node)
-		)
+			|| JsonNullNode.is(node))
 	}
 }
 
@@ -46,11 +41,7 @@ export namespace JsonObjectNode {
 	}
 
 	export function mock(range: core.RangeLike): JsonObjectNode {
-		return {
-			type: 'json:object',
-			range: core.Range.get(range),
-			children: [],
-		}
+		return { type: 'json:object', range: core.Range.get(range), children: [] }
 	}
 }
 export type JsonPairNode = core.PairNode<JsonStringNode, JsonNode>
@@ -70,19 +61,11 @@ export namespace JsonArrayNode {
 	}
 
 	export function mock(range: core.RangeLike): JsonArrayNode {
-		return {
-			type: 'json:array',
-			range: core.Range.get(range),
-			children: [],
-		}
+		return { type: 'json:array', range: core.Range.get(range), children: [] }
 	}
 }
 
-export type JsonPrimitiveNode =
-	| JsonStringNode
-	| JsonNumberNode
-	| JsonBooleanNode
-	| JsonNullNode
+export type JsonPrimitiveNode = JsonStringNode | JsonNumberNode | JsonBooleanNode | JsonNullNode
 
 export interface JsonStringNode extends core.StringBaseNode, JsonBaseNode {
 	readonly type: 'json:string'
@@ -94,10 +77,7 @@ export namespace JsonStringNode {
 	}
 
 	export function mock(range: core.RangeLike): JsonStringNode {
-		return {
-			...core.StringNode.mock(range, JsonStringOptions),
-			type: 'json:string',
-		}
+		return { ...core.StringNode.mock(range, JsonStringOptions), type: 'json:string' }
 	}
 }
 

--- a/packages/json/src/parser/array.ts
+++ b/packages/json/src/parser/array.ts
@@ -5,11 +5,5 @@ import { entry } from './entry.js'
 export const array: core.Parser<JsonArrayNode> = (ctx, src) =>
 	core.setType(
 		'json:array',
-		core.list({
-			start: '[',
-			value: entry,
-			sep: ',',
-			trailingSep: false,
-			end: ']',
-		}),
+		core.list({ start: '[', value: entry, sep: ',', trailingSep: false, end: ']' }),
 	)(ctx, src)

--- a/packages/json/src/parser/boolean.ts
+++ b/packages/json/src/parser/boolean.ts
@@ -5,18 +5,10 @@ import type { JsonBooleanNode } from '../node/index.js'
 export const boolean: core.Parser<JsonBooleanNode> = (src, _ctx) => {
 	const start = src.cursor
 	if (src.trySkip('false')) {
-		return {
-			type: 'json:boolean',
-			range: Range.create(start, src),
-			value: false,
-		}
+		return { type: 'json:boolean', range: Range.create(start, src), value: false }
 	}
 	if (src.trySkip('true')) {
-		return {
-			type: 'json:boolean',
-			range: Range.create(start, src),
-			value: true,
-		}
+		return { type: 'json:boolean', range: Range.create(start, src), value: true }
 	}
 	return core.Failure
 }

--- a/packages/json/src/parser/entry.ts
+++ b/packages/json/src/parser/entry.ts
@@ -7,31 +7,16 @@ import { number } from './number.js'
 import { object } from './object.js'
 import { string } from './string.js'
 
-const LegalNumberStart = new Set([
-	'0',
-	'1',
-	'2',
-	'3',
-	'4',
-	'5',
-	'6',
-	'7',
-	'8',
-	'9',
-	'-',
-])
+const LegalNumberStart = new Set(['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '-'])
 export const entry: core.Parser<JsonNode> = (src, ctx) =>
 	core.select([
 		{ predicate: (src) => src.tryPeek('['), parser: array },
-		{
-			predicate: (src) => src.tryPeek('false') || src.tryPeek('true'),
-			parser: boolean,
-		},
+		{ predicate: (src) => src.tryPeek('false') || src.tryPeek('true'), parser: boolean },
 		{ predicate: (src) => src.tryPeek('null'), parser: null_ },
+		{ predicate: (src) => LegalNumberStart.has(src.peek()), parser: number },
 		{
-			predicate: (src) => LegalNumberStart.has(src.peek()),
-			parser: number,
+			predicate: (src) => src.tryPeek('{'),
+			parser: object,
 		},
-		{ predicate: (src) => src.tryPeek('{'), parser: object },
 		{ parser: string },
 	])(src, ctx)

--- a/packages/json/src/parser/file.ts
+++ b/packages/json/src/parser/file.ts
@@ -4,9 +4,5 @@ import { entry } from './entry.js'
 
 export const file: core.Parser<JsonFileNode> = core.map(
 	core.dumpErrors(entry),
-	(res) => ({
-		type: 'json:file',
-		range: res.range,
-		children: [res],
-	}),
+	(res) => ({ type: 'json:file', range: res.range, children: [res] }),
 )

--- a/packages/json/src/parser/null.ts
+++ b/packages/json/src/parser/null.ts
@@ -5,10 +5,7 @@ import type { JsonNullNode } from '../node/index.js'
 export const null_: core.Parser<JsonNullNode> = (src, ctx) => {
 	const start = src.cursor
 	if (src.trySkip('null')) {
-		return {
-			type: 'json:null',
-			range: Range.create(start, src),
-		}
+		return { type: 'json:null', range: Range.create(start, src) }
 	}
 	return core.Failure
 }

--- a/packages/json/src/parser/number.ts
+++ b/packages/json/src/parser/number.ts
@@ -2,25 +2,15 @@ import * as core from '@spyglassmc/core'
 import type { JsonNumberNode } from '../node/index.js'
 
 export const number: core.Parser<JsonNumberNode> = (src, ctx) => {
-	const value = core.select([
-		{
-			regex: /^-?(?:0|[1-9]\d*)(?!\d|[.eE])/,
-			parser: core.long({
-				pattern: /^-?(?:0|[1-9]\d*)$/,
-			}),
-		},
-		{
-			parser: core.float({
-				// Regex form of the chart from https://www.json.org.
-				pattern: /^-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][-+]?\d+)?$/,
-			}),
-		},
-	])(src, ctx)
+	const value = core.select([{
+		regex: /^-?(?:0|[1-9]\d*)(?!\d|[.eE])/,
+		parser: core.long({ pattern: /^-?(?:0|[1-9]\d*)$/ }),
+	}, {
+		parser: core.float({
+			// Regex form of the chart from https://www.json.org.
+			pattern: /^-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][-+]?\d+)?$/,
+		}),
+	}])(src, ctx)
 
-	return {
-		type: 'json:number',
-		children: [value],
-		value,
-		range: value.range,
-	}
+	return { type: 'json:number', children: [value], value, range: value.range }
 }

--- a/packages/json/src/parser/object.ts
+++ b/packages/json/src/parser/object.ts
@@ -8,13 +8,7 @@ export const object: core.InfallibleParser<JsonObjectNode> = (src, ctx) =>
 		'json:object',
 		core.record({
 			start: '{',
-			pair: {
-				key: string,
-				sep: ':',
-				value: entry,
-				end: ',',
-				trailingEnd: false,
-			},
+			pair: { key: string, sep: ':', value: entry, end: ',', trailingEnd: false },
 			end: '}',
 		}),
 	)(src, ctx)

--- a/packages/json/src/parser/string.ts
+++ b/packages/json/src/parser/string.ts
@@ -2,15 +2,9 @@ import * as core from '@spyglassmc/core'
 import type { JsonStringNode } from '../node/index.js'
 
 export const JsonStringOptions: core.StringOptions = {
-	escapable: {
-		characters: ['b', 'f', 'n', 'r', 't'],
-		unicode: true,
-	},
+	escapable: { characters: ['b', 'f', 'n', 'r', 't'], unicode: true },
 	quotes: ['"'],
 }
 
 export const string: core.Parser<JsonStringNode> = (src, ctx) =>
-	core.setType(
-		'json:string',
-		core.string(JsonStringOptions),
-	)(src, ctx)
+	core.setType('json:string', core.string(JsonStringOptions))(src, ctx)

--- a/packages/json/test/parser/array.spec.ts
+++ b/packages/json/test/parser/array.spec.ts
@@ -1,8 +1,5 @@
 import type { LanguageError } from '@spyglassmc/core'
-import {
-	showWhitespaceGlyph,
-	testParser,
-} from '@spyglassmc/core/test-out/utils.js'
+import { showWhitespaceGlyph, testParser } from '@spyglassmc/core/test-out/utils.js'
 import assert from 'assert'
 import snapshot from 'snap-shot-it'
 import { array } from '../../lib/parser/array.js'

--- a/packages/json/test/parser/array.spec.ts
+++ b/packages/json/test/parser/array.spec.ts
@@ -25,40 +25,23 @@ describe('JSON array parser', () => {
 		}
 
 		describe('should absorb and output parse errors from child parsers', () => {
-			const cases: {
-				name: string
-				content: string
-				expectedErrors: LanguageError[]
-			}[] = [
-				{
-					name: 'invalid character escape',
-					content: '["\\z"]',
-					expectedErrors: [
-						{
-							range: {
-								start: 3,
-								end: 4,
-							},
-							message: 'Unexpected escape character “z”',
-							severity: 3,
-						},
-					],
-				},
-				{
-					name: 'invalid unicode escape',
-					content: '["\\u1z34"]',
-					expectedErrors: [
-						{
-							range: {
-								start: 4,
-								end: 8,
-							},
-							message: 'Hexadecimal digit expected',
-							severity: 3,
-						},
-					],
-				},
-			]
+			const cases: { name: string; content: string; expectedErrors: LanguageError[] }[] = [{
+				name: 'invalid character escape',
+				content: '["\\z"]',
+				expectedErrors: [{
+					range: { start: 3, end: 4 },
+					message: 'Unexpected escape character “z”',
+					severity: 3,
+				}],
+			}, {
+				name: 'invalid unicode escape',
+				content: '["\\u1z34"]',
+				expectedErrors: [{
+					range: { start: 4, end: 8 },
+					message: 'Hexadecimal digit expected',
+					severity: 3,
+				}],
+			}]
 			for (const { name, content, expectedErrors } of cases) {
 				it(name, () => {
 					const { errors } = testParser(array, content)

--- a/packages/json/test/parser/number.spec.ts
+++ b/packages/json/test/parser/number.spec.ts
@@ -1,7 +1,4 @@
-import {
-	showWhitespaceGlyph,
-	testParser,
-} from '@spyglassmc/core/test-out/utils.js'
+import { showWhitespaceGlyph, testParser } from '@spyglassmc/core/test-out/utils.js'
 import snapshot from 'snap-shot-it'
 import { number } from '../../lib/parser/number.js'
 

--- a/packages/json/test/parser/object.spec.ts
+++ b/packages/json/test/parser/object.spec.ts
@@ -1,8 +1,5 @@
 import type { LanguageError } from '@spyglassmc/core'
-import {
-	showWhitespaceGlyph,
-	testParser,
-} from '@spyglassmc/core/test-out/utils.js'
+import { showWhitespaceGlyph, testParser } from '@spyglassmc/core/test-out/utils.js'
 import assert from 'assert'
 import snapshot from 'snap-shot-it'
 import { object } from '../../lib/parser/object.js'

--- a/packages/json/test/parser/object.spec.ts
+++ b/packages/json/test/parser/object.spec.ts
@@ -25,41 +25,31 @@ describe('JSON object parser', () => {
 		}
 
 		describe('should absorb and output parse errors from child parsers', () => {
-			const cases: {
-				name: string
-				content: string
-				expectedErrors: LanguageError[]
-			}[] = [
-				{
-					name: 'invalid character escape (key + value)',
-					content: '{"\\z": "\\j"}',
-					expectedErrors: [{
-						range: { start: 3, end: 4 },
-						message: 'Unexpected escape character “z”',
-						severity: 3,
-					}, {
-						range: { start: 9, end: 10 },
-						message: 'Unexpected escape character “j”',
-						severity: 3,
-					}],
-				},
-				{
-					name: 'invalid unicode escape (key + value)',
-					content: '{"\\u1z34": "\\u123p"}',
-					expectedErrors: [
-						{
-							range: { start: 4, end: 8 },
-							message: 'Hexadecimal digit expected',
-							severity: 3,
-						},
-						{
-							range: { start: 14, end: 18 },
-							message: 'Hexadecimal digit expected',
-							severity: 3,
-						},
-					],
-				},
-			]
+			const cases: { name: string; content: string; expectedErrors: LanguageError[] }[] = [{
+				name: 'invalid character escape (key + value)',
+				content: '{"\\z": "\\j"}',
+				expectedErrors: [{
+					range: { start: 3, end: 4 },
+					message: 'Unexpected escape character “z”',
+					severity: 3,
+				}, {
+					range: { start: 9, end: 10 },
+					message: 'Unexpected escape character “j”',
+					severity: 3,
+				}],
+			}, {
+				name: 'invalid unicode escape (key + value)',
+				content: '{"\\u1z34": "\\u123p"}',
+				expectedErrors: [{
+					range: { start: 4, end: 8 },
+					message: 'Hexadecimal digit expected',
+					severity: 3,
+				}, {
+					range: { start: 14, end: 18 },
+					message: 'Hexadecimal digit expected',
+					severity: 3,
+				}],
+			}]
 			for (const { name, content, expectedErrors } of cases) {
 				it(name, () => {
 					const { errors } = testParser(object, content)

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -34,14 +34,10 @@ let progressReporter: ls.WorkDoneProgressReporter | undefined
 
 const externals = NodeJsExternals
 const logger: core.Logger = {
-	error: (msg: any, ...args: any[]): void =>
-		connection.console.error(util.format(msg, ...args)),
-	info: (msg: any, ...args: any[]): void =>
-		connection.console.info(util.format(msg, ...args)),
-	log: (msg: any, ...args: any[]): void =>
-		connection.console.log(util.format(msg, ...args)),
-	warn: (msg: any, ...args: any[]): void =>
-		connection.console.warn(util.format(msg, ...args)),
+	error: (msg: any, ...args: any[]): void => connection.console.error(util.format(msg, ...args)),
+	info: (msg: any, ...args: any[]): void => connection.console.info(util.format(msg, ...args)),
+	log: (msg: any, ...args: any[]): void => connection.console.log(util.format(msg, ...args)),
+	warn: (msg: any, ...args: any[]): void => connection.console.warn(util.format(msg, ...args)),
 }
 let service!: core.Service
 

--- a/packages/language-server/src/util/toLS.ts
+++ b/packages/language-server/src/util/toLS.ts
@@ -218,8 +218,8 @@ export function completionItem(
 	insertReplaceSupport: boolean | undefined,
 ): ls.CompletionItem {
 	const insertText = completion.insertText ?? completion.label
-	const canInsertReplace = insertReplaceSupport &&
-		![core.CR, core.LF, core.CRLF].includes(insertText)
+	const canInsertReplace = insertReplaceSupport
+		&& ![core.CR, core.LF, core.CRLF].includes(insertText)
 	const textEdit: ls.TextEdit | ls.InsertReplaceEdit = canInsertReplace
 		? ls.InsertReplaceEdit.create(
 			insertText,

--- a/packages/language-server/src/util/toLS.ts
+++ b/packages/language-server/src/util/toLS.ts
@@ -155,9 +155,7 @@ export function documentSymbols(
 				] as const,
 		)
 		.filter(([_s, l]) => !!l)
-		.map(([s, l]) =>
-			documentSymbol(s, l!, doc, hierarchicalSupport, supportedKinds)
-		)
+		.map(([s, l]) => documentSymbol(s, l!, doc, hierarchicalSupport, supportedKinds))
 }
 
 export function documentSymbolsFromTable(
@@ -178,9 +176,7 @@ export function documentSymbolsFromTables(
 	supportedKinds: ls.SymbolKind[] = [],
 ): ls.DocumentSymbol[] {
 	return tables
-		.map((t) =>
-			documentSymbolsFromTable(t, doc, hierarchicalSupport, supportedKinds)
-		)
+		.map((t) => documentSymbolsFromTable(t, doc, hierarchicalSupport, supportedKinds))
 		.flat()
 }
 

--- a/packages/language-server/src/util/toLS.ts
+++ b/packages/language-server/src/util/toLS.ts
@@ -16,10 +16,7 @@ export function color(color: core.Color): ls.Color {
 	return ls.Color.create(...color)
 }
 
-export function colorInformation(
-	info: core.ColorInfo,
-	doc: TextDocument,
-): ls.ColorInformation {
+export function colorInformation(info: core.ColorInfo, doc: TextDocument): ls.ColorInformation {
 	return ls.ColorInformation.create(range(info.range, doc), color(info.color!))
 }
 
@@ -34,10 +31,7 @@ export function colorPresentation(
 	presentation: core.ColorPresentation,
 	doc: TextDocument,
 ): ls.ColorPresentation {
-	const edit = ls.TextEdit.replace(
-		range(presentation.range, doc),
-		presentation.text,
-	)
+	const edit = ls.TextEdit.replace(range(presentation.range, doc), presentation.text)
 	return ls.ColorPresentation.create(presentation.label, edit)
 }
 
@@ -63,9 +57,7 @@ export function diagnostic(error: core.PosRangeLanguageError): ls.Diagnostic {
 		;(ans.tags ??= [])?.push(ls.DiagnosticTag.Unnecessary)
 	}
 	if (error.info?.codeAction) {
-		ans.data = {
-			codeAction: error.info?.codeAction,
-		}
+		ans.data = { codeAction: error.info?.codeAction }
 	}
 	if (error.info?.related) {
 		ans.relatedInformation = error.info?.related.map((v) => ({
@@ -76,15 +68,11 @@ export function diagnostic(error: core.PosRangeLanguageError): ls.Diagnostic {
 	return ans
 }
 
-export function diagnostics(
-	errors: readonly core.PosRangeLanguageError[],
-): ls.Diagnostic[] {
+export function diagnostics(errors: readonly core.PosRangeLanguageError[]): ls.Diagnostic[] {
 	return errors.map((e) => diagnostic(e))
 }
 
-export function diagnosticSeverity(
-	severity: core.ErrorSeverity,
-): ls.DiagnosticSeverity {
+export function diagnosticSeverity(severity: core.ErrorSeverity): ls.DiagnosticSeverity {
 	switch (severity) {
 		case core.ErrorSeverity.Hint:
 			return ls.DiagnosticSeverity.Hint
@@ -100,15 +88,13 @@ export function diagnosticSeverity(
 export function documentHighlight(
 	locations: core.SymbolLocations | undefined,
 ): ls.DocumentHighlight[] | undefined {
-	return locations?.locations
-		?.filter((loc) => loc.posRange)
-		?.map((loc) => ({ range: loc.posRange! }))
+	return locations?.locations?.filter((loc) => loc.posRange)?.map((loc) => ({
+		range: loc.posRange!,
+	}))
 }
 
 export function documentSelector(meta: core.MetaRegistry): ls.DocumentSelector {
-	const ans: ls.DocumentSelector = meta
-		.getLanguages()
-		.map((id) => ({ language: id }))
+	const ans: ls.DocumentSelector = meta.getLanguages().map((id) => ({ language: id }))
 	return ans
 }
 
@@ -125,12 +111,7 @@ export function documentSymbol(
 		range: symLoc.fullPosRange ?? symLoc.posRange ?? ZeroRange,
 		selectionRange: symLoc.posRange ?? ZeroRange,
 		children: hierarchicalSupport
-			? documentSymbols(
-				symbol.members,
-				doc,
-				hierarchicalSupport,
-				supportedKinds,
-			)
+			? documentSymbols(symbol.members, doc, hierarchicalSupport, supportedKinds)
 			: undefined,
 	}
 }
@@ -141,21 +122,19 @@ export function documentSymbols(
 	hierarchicalSupport: boolean | undefined,
 	supportedKinds: ls.SymbolKind[] = [],
 ): ls.DocumentSymbol[] {
-	return Object.values(map)
-		.map(
-			(s) =>
-				[
-					s,
-					[
-						...(s.declaration ?? []),
-						...(s.definition ?? []),
-						...(s.implementation ?? []),
-						...(s.typeDefinition ?? []),
-					].find((l) => l.uri === doc.uri),
-				] as const,
-		)
-		.filter(([_s, l]) => !!l)
-		.map(([s, l]) => documentSymbol(s, l!, doc, hierarchicalSupport, supportedKinds))
+	return Object.values(map).map((s) =>
+		[
+			s,
+			[
+				...(s.declaration ?? []),
+				...(s.definition ?? []),
+				...(s.implementation ?? []),
+				...(s.typeDefinition ?? []),
+			].find((l) => l.uri === doc.uri),
+		] as const
+	).filter(([_s, l]) => !!l).map(([s, l]) =>
+		documentSymbol(s, l!, doc, hierarchicalSupport, supportedKinds)
+	)
 }
 
 export function documentSymbolsFromTable(
@@ -164,9 +143,9 @@ export function documentSymbolsFromTable(
 	hierarchicalSupport: boolean | undefined,
 	supportedKinds: ls.SymbolKind[] = [],
 ): ls.DocumentSymbol[] {
-	return Object.values(table)
-		.map((m) => documentSymbols(m, doc, hierarchicalSupport, supportedKinds))
-		.flat()
+	return Object.values(table).map((m) =>
+		documentSymbols(m, doc, hierarchicalSupport, supportedKinds)
+	).flat()
 }
 
 export function documentSymbolsFromTables(
@@ -175,23 +154,16 @@ export function documentSymbolsFromTables(
 	hierarchicalSupport: boolean | undefined,
 	supportedKinds: ls.SymbolKind[] = [],
 ): ls.DocumentSymbol[] {
-	return tables
-		.map((t) => documentSymbolsFromTable(t, doc, hierarchicalSupport, supportedKinds))
+	return tables.map((t) => documentSymbolsFromTable(t, doc, hierarchicalSupport, supportedKinds))
 		.flat()
 }
 
 export function hover(hover: core.Hover, doc: TextDocument): ls.Hover {
-	const ans: ls.Hover = {
-		contents: markupContent(hover.markdown),
-		range: range(hover.range, doc),
-	}
+	const ans: ls.Hover = { contents: markupContent(hover.markdown), range: range(hover.range, doc) }
 	return ans
 }
 
-export function inlayHint(
-	hint: core.InlayHint,
-	doc: TextDocument,
-): ls.InlayHint {
+export function inlayHint(hint: core.InlayHint, doc: TextDocument): ls.InlayHint {
 	return {
 		position: doc.positionAt(hint.offset),
 		label: hint.label,
@@ -200,10 +172,7 @@ export function inlayHint(
 	}
 }
 
-export function inlayHints(
-	hints: core.InlayHint[],
-	doc: TextDocument,
-): ls.InlayHint[] {
+export function inlayHints(hints: core.InlayHint[], doc: TextDocument): ls.InlayHint[] {
 	return hints.map((h) => inlayHint(h, doc))
 }
 
@@ -219,10 +188,7 @@ export function completionItem(
 	const textEdit: ls.TextEdit | ls.InsertReplaceEdit = canInsertReplace
 		? ls.InsertReplaceEdit.create(
 			insertText,
-			/* insert  */ range(
-				core.Range.create(completion.range.start, requestedOffset),
-				doc,
-			),
+			/* insert  */ range(core.Range.create(completion.range.start, requestedOffset), doc),
 			/* replace */ range(completion.range, doc),
 		)
 		: ls.TextEdit.replace(range(completion.range, doc), insertText)
@@ -236,21 +202,13 @@ export function completionItem(
 		textEdit,
 		insertTextFormat: InsertTextFormat.Snippet,
 		insertTextMode: ls.InsertTextMode.adjustIndentation,
-		...(completion.deprecated
-			? { tags: [ls.CompletionItemTag.Deprecated] }
-			: {}),
+		...(completion.deprecated ? { tags: [ls.CompletionItemTag.Deprecated] } : {}),
 	}
 	return ans
 }
 
-export function location(location: {
-	uri: string
-	posRange: core.PositionRange
-}): ls.Location {
-	return {
-		uri: location.uri,
-		range: location.posRange,
-	}
+export function location(location: { uri: string; posRange: core.PositionRange }): ls.Location {
+	return { uri: location.uri, range: location.posRange }
 }
 
 export function locationLink(
@@ -283,10 +241,7 @@ export function locationLink(
 }
 
 export function markupContent(value: string): ls.MarkupContent {
-	return {
-		kind: ls.MarkupKind.Markdown,
-		value,
-	}
+	return { kind: ls.MarkupKind.Markdown, value }
 }
 
 export function position(offset: number, doc: TextDocument): ls.Position {
@@ -297,15 +252,11 @@ export function range(range: core.Range, doc: TextDocument): ls.Range {
 	return ls.Range.create(position(range.start, doc), position(range.end, doc))
 }
 
-export function semanticTokenModifier(
-	modifier: core.ColorTokenModifier,
-): number {
+export function semanticTokenModifier(modifier: core.ColorTokenModifier): number {
 	return core.ColorTokenModifiers.indexOf(modifier)
 }
 
-export function semanticTokenModifiers(
-	modifiers: readonly core.ColorTokenModifier[] = [],
-): number {
+export function semanticTokenModifiers(modifiers: readonly core.ColorTokenModifier[] = []): number {
 	let ans = 0
 	for (const modifier of modifiers) {
 		ans += 1 << semanticTokenModifier(modifier)
@@ -329,28 +280,14 @@ export function semanticTokens(
 			const length = token.range.end - token.range.start
 			builder.push(pos.line, pos.character, length, type, modifiers)
 		} else {
-			const firstLineRemainingLength = doc.getText(
-				ls.Range.create(
-					pos.line,
-					pos.character,
-					pos.line,
-					MaxCharacterNumber,
-				),
-			).length
-			const lastLineLeadingLength = doc.getText(
-				ls.Range.create(endPos.line, 0, endPos.line, endPos.character),
-			).length
-			builder.push(
-				pos.line,
-				pos.character,
-				firstLineRemainingLength,
-				type,
-				modifiers,
-			)
+			const firstLineRemainingLength =
+				doc.getText(ls.Range.create(pos.line, pos.character, pos.line, MaxCharacterNumber))
+					.length
+			const lastLineLeadingLength =
+				doc.getText(ls.Range.create(endPos.line, 0, endPos.line, endPos.character)).length
+			builder.push(pos.line, pos.character, firstLineRemainingLength, type, modifiers)
 			for (let i = pos.line + 1; i <= endPos.line - 1; i++) {
-				const lineLength = doc.getText(
-					ls.Range.create(i, 0, i, MaxCharacterNumber),
-				).length
+				const lineLength = doc.getText(ls.Range.create(i, 0, i, MaxCharacterNumber)).length
 				builder.push(i, 0, lineLength, type, modifiers)
 			}
 			builder.push(endPos.line, 0, lastLineLeadingLength, type, modifiers)
@@ -371,9 +308,7 @@ export function semanticTokenType(type: core.ColorTokenType): number {
 	return core.ColorTokenTypes.indexOf(type)
 }
 
-export function signatureHelp(
-	help: core.SignatureHelp | undefined,
-): ls.SignatureHelp | undefined {
+export function signatureHelp(help: core.SignatureHelp | undefined): ls.SignatureHelp | undefined {
 	if (!help || help.signatures.length === 0) {
 		return undefined
 	}
@@ -384,27 +319,19 @@ export function signatureHelp(
 	}
 }
 
-export function signatureInformation(
-	info: core.SignatureInfo,
-): ls.SignatureInformation {
+export function signatureInformation(info: core.SignatureInfo): ls.SignatureInformation {
 	return {
 		label: info.label,
 		activeParameter: info.activeParameter,
-		documentation: info.documentation
-			? markupContent(info.documentation)
-			: undefined,
+		documentation: info.documentation ? markupContent(info.documentation) : undefined,
 		parameters: info.parameters.map(parameterInformation),
 	}
 }
 
-export function parameterInformation(
-	info: core.ParameterInfo,
-): ls.ParameterInformation {
+export function parameterInformation(info: core.ParameterInfo): ls.ParameterInformation {
 	return {
 		label: info.label,
-		documentation: info.documentation
-			? markupContent(info.documentation)
-			: undefined,
+		documentation: info.documentation ? markupContent(info.documentation) : undefined,
 	}
 }
 
@@ -428,22 +355,17 @@ export function symbolInformationArray(
 	query: string,
 	supportedKinds: ls.SymbolKind[] = [],
 ): ls.SymbolInformation[] {
-	return Object.values(map)
-		.filter((s) => s.identifier.includes(query))
-		.map(
-			(s) =>
-				[
-					s,
-					[
-						...(s.declaration ?? []),
-						...(s.definition ?? []),
-						...(s.implementation ?? []),
-						...(s.typeDefinition ?? []),
-					][0],
-				] as const,
-		)
-		.filter(([_s, l]) => !!l)
-		.map(([s, l]) => symbolInformation(s, l, supportedKinds))
+	return Object.values(map).filter((s) => s.identifier.includes(query)).map((s) =>
+		[
+			s,
+			[
+				...(s.declaration ?? []),
+				...(s.definition ?? []),
+				...(s.implementation ?? []),
+				...(s.typeDefinition ?? []),
+			][0],
+		] as const
+	).filter(([_s, l]) => !!l).map(([s, l]) => symbolInformation(s, l, supportedKinds))
 }
 
 export function symbolInformationArrayFromTable(
@@ -451,9 +373,7 @@ export function symbolInformationArrayFromTable(
 	query: string,
 	supportedKinds: ls.SymbolKind[] = [],
 ): ls.SymbolInformation[] {
-	return Object.values(table)
-		.map((m) => symbolInformationArray(m, query, supportedKinds))
-		.flat()
+	return Object.values(table).map((m) => symbolInformationArray(m, query, supportedKinds)).flat()
 }
 
 export function symbolKind(
@@ -489,10 +409,6 @@ export function symbolKind(
 	return map.get(category) ?? UltimateFallback
 }
 
-export function textEdit(
-	editRange: core.Range,
-	text: string,
-	doc: TextDocument,
-) {
+export function textEdit(editRange: core.Range, text: string, doc: TextDocument) {
 	return ls.TextEdit.replace(range(editRange, doc), text)
 }

--- a/packages/language-server/test/util/toLS.spec.ts
+++ b/packages/language-server/test/util/toLS.spec.ts
@@ -17,9 +17,7 @@ interface DecodedSemanticToken {
 	tokenType: number
 	tokenModifiers: number
 }
-const decodeSemanticTokens = (
-	tokens: ls.SemanticTokens['data'],
-): DecodedSemanticToken[] => {
+const decodeSemanticTokens = (tokens: ls.SemanticTokens['data']): DecodedSemanticToken[] => {
 	if (tokens.length % 5 !== 0) {
 		throw new Error('Array of semantic tokens must be divisible by 5')
 	}
@@ -38,20 +36,10 @@ const decodeSemanticTokens = (
 }
 
 describe('semanticTokens', () => {
-	const tokens: core.ColorToken[] = [
-		{
-			range: {
-				start: 0,
-				end: 100,
-			},
-			type: 'comment',
-		},
-	]
-	const suites: { content: string }[] = [
-		{ content: 'foo' },
-		{ content: 'foo\nbar' },
-		{ content: 'foo\nbar\nqux' },
-	]
+	const tokens: core.ColorToken[] = [{ range: { start: 0, end: 100 }, type: 'comment' }]
+	const suites: { content: string }[] = [{ content: 'foo' }, { content: 'foo\nbar' }, {
+		content: 'foo\nbar\nqux',
+	}]
 	for (const hasMultilineTokenSupport of [true, false]) {
 		for (const { content } of suites) {
 			const doc = TextDocument.create('file:///test', '', 0, content)
@@ -60,11 +48,7 @@ describe('semanticTokens', () => {
 			} multiline token support`
 			const itTitle = `Tokenize "${showWhitespaceGlyph(content)}" ${multilineStr}`
 			it(itTitle, () => {
-				const { data } = semanticTokens(
-					tokens,
-					doc,
-					hasMultilineTokenSupport,
-				)
+				const { data } = semanticTokens(tokens, doc, hasMultilineTokenSupport)
 				snapshot(decodeSemanticTokens(data))
 			})
 		}

--- a/packages/language-server/test/util/toLS.spec.ts
+++ b/packages/language-server/test/util/toLS.spec.ts
@@ -58,9 +58,7 @@ describe('semanticTokens', () => {
 			const multilineStr = `${
 				hasMultilineTokenSupport ? 'with' : 'without'
 			} multiline token support`
-			const itTitle = `Tokenize "${
-				showWhitespaceGlyph(content)
-			}" ${multilineStr}`
+			const itTitle = `Tokenize "${showWhitespaceGlyph(content)}" ${multilineStr}`
 			it(itTitle, () => {
 				const { data } = semanticTokens(
 					tokens,

--- a/packages/locales/src/index.ts
+++ b/packages/locales/src/index.ts
@@ -5,9 +5,7 @@ import Fallback from './locales/en.js'
 
 type Locale = Record<string, string>
 
-const Locales: Record<string, Locale> = {
-	en: Fallback,
-}
+const Locales: Record<string, Locale> = { en: Fallback }
 
 let language = 'en'
 
@@ -74,10 +72,7 @@ function _resolveLocalePlaceholders(
 	return val?.replace(/%\d+%/g, (match) => {
 		const index = parseInt(match.slice(1, -1))
 		let param: Parameter | undefined = params[index]
-		if (
-			typeof param !== 'string'
-			&& (param as Iterable<string>)?.[Symbol.iterator]
-		) {
+		if (typeof param !== 'string' && (param as Iterable<string>)?.[Symbol.iterator]) {
 			param = arrayToMessage(param as Iterable<string>)
 		}
 		return `${param ?? match}`
@@ -116,9 +111,7 @@ export function arrayToMessage(
 	conjunction: 'and' | 'or' = 'or',
 ) {
 	const getPart = (str: string) => (quoted ? localeQuote(str) : str)
-	const arr = (typeof param === 'string' ? [param] : Array.from(param)).map(
-		getPart,
-	)
+	const arr = (typeof param === 'string' ? [param] : Array.from(param)).map(getPart)
 	switch (arr.length) {
 		case 0:
 			return localize('nothing')
@@ -127,14 +120,8 @@ export function arrayToMessage(
 		case 2:
 			return arr[0] + localize(`conjunction.${conjunction}_2`) + arr[1]
 		default:
-			return `${
-				arr
-					.slice(0, -1)
-					.join(localize(`conjunction.${conjunction}_3+_1`))
-			}${
-				localize(
-					`conjunction.${conjunction}_3+_2`,
-				)
+			return `${arr.slice(0, -1).join(localize(`conjunction.${conjunction}_3+_1`))}${
+				localize(`conjunction.${conjunction}_3+_2`)
 			}${arr[arr.length - 1]}`
 	}
 }

--- a/packages/locales/src/index.ts
+++ b/packages/locales/src/index.ts
@@ -75,8 +75,8 @@ function _resolveLocalePlaceholders(
 		const index = parseInt(match.slice(1, -1))
 		let param: Parameter | undefined = params[index]
 		if (
-			typeof param !== 'string' &&
-			(param as Iterable<string>)?.[Symbol.iterator]
+			typeof param !== 'string'
+			&& (param as Iterable<string>)?.[Symbol.iterator]
 		) {
 			param = arrayToMessage(param as Iterable<string>)
 		}

--- a/packages/mcdoc-cli/src/generate/index.ts
+++ b/packages/mcdoc-cli/src/generate/index.ts
@@ -36,26 +36,16 @@ export async function generate(
 
 	const doc_contents = await fs.readFile(doc_file.path, 'utf-8')
 
-	await service.project.onDidOpen(
-		DocumentUri,
-		'mcdoc',
-		0,
-		doc_contents,
-	)
+	await service.project.onDidOpen(DocumentUri, 'mcdoc', 0, doc_contents)
 
-	const check = await service.project.ensureClientManagedChecked(
-		DocumentUri,
-	)
+	const check = await service.project.ensureClientManagedChecked(DocumentUri)
 
 	if (check && check.doc && check.node) {
 		const { doc, node } = check
 
 		const path = parse(fileURLToPath(doc.uri))
 
-		let resource = join(
-			path.dir.replace(`${project_path}`, ''),
-			path.name,
-		).replace(/^[\/\\]/, '')
+		let resource = join(path.dir.replace(`${project_path}`, ''), path.name).replace(/^[\/\\]/, '')
 
 		// remove windows cruft
 		if (resource.includes('\\')) resource = resource.replaceAll('\\', '/')
@@ -86,18 +76,9 @@ export async function generate(
 
 				if (_child.children) {
 					child.children = []
-					for (
-						const [i, __child] of Object.entries(
-							_child.children,
-						)
-					) {
+					for (const [i, __child] of Object.entries(_child.children)) {
 						/* @ts-ignore */
-						child.children[Number(i)] = flattenChild(
-							self,
-							`${self}[${i}]`,
-							_child,
-							__child,
-						)
+						child.children[Number(i)] = flattenChild(self, `${self}[${i}]`, _child, __child)
 					}
 				}
 
@@ -123,16 +104,12 @@ export async function generate(
 				// if you want to keep your sanity, avoid looking at this function
 				function setLocale(end: string) {
 					let container
-					if (
-						doc_file.path.endsWith(
-							`${resource.split('/').slice(-1)[0]}.mcdoc`,
-						)
-					) {
+					if (doc_file.path.endsWith(`${resource.split('/').slice(-1)[0]}.mcdoc`)) {
 						const threeBack = _parent?.parent?.parent
 
 						if (threeBack?.type === 'mcdoc:struct') {
-							const identifierIndex = threeBack?.children?.findIndex(
-								child => child.type === 'mcdoc:identifier',
+							const identifierIndex = threeBack?.children?.findIndex(child =>
+								child.type === 'mcdoc:identifier'
 							)
 
 							if (identifierIndex && identifierIndex !== -1) {
@@ -145,8 +122,8 @@ export async function generate(
 								switch (fourBack?.type) {
 									case 'mcdoc:struct/field/pair':
 										{
-											const key = fourBack.children?.find(child =>
-												child.type === 'mcdoc:identifier'
+											const key = fourBack.children?.find(
+												child => child.type === 'mcdoc:identifier',
 												/* @ts-ignore */
 											)?.value
 											const sixBack = fourBack.parent?.parent
@@ -161,16 +138,13 @@ export async function generate(
 												} else {
 													// This is another nested anonymous struct
 													// TODO: Yeah this should be recursive and smarter but I'm lazy
-													const parentKey = sixBack?.parent
-														?.children?.find(child =>
-															child.type === 'mcdoc:identifier'
-															/* @ts-ignore */
-														)?.value
-													const actualRoot = sixBack?.parent
-														?.parent?.parent?.children?.find(
-															child =>
-																child.type
-																	=== 'mcdoc:identifier',
+													const parentKey = sixBack?.parent?.children?.find(
+														child => child.type === 'mcdoc:identifier',
+														/* @ts-ignore */
+													)?.value
+													const actualRoot = sixBack?.parent?.parent?.parent?.children
+														?.find(
+															child => child.type === 'mcdoc:identifier',
 															/* @ts-ignore */
 														)?.value
 
@@ -179,14 +153,13 @@ export async function generate(
 											} else {
 												// This is another nested anonymous struct
 												// TODO: Yeah this should be recursive and smarter but I'm lazy
-												const parentKey = sixBack?.parent?.children
-													?.find(child =>
-														child.type === 'mcdoc:identifier'
-														/* @ts-ignore */
-													)?.value
-												const actualRoot = sixBack?.parent?.parent
-													?.parent?.children?.find(child =>
-														child.type === 'mcdoc:identifier'
+												const parentKey = sixBack?.parent?.children?.find(
+													child => child.type === 'mcdoc:identifier',
+													/* @ts-ignore */
+												)?.value
+												const actualRoot = sixBack?.parent?.parent?.parent?.children
+													?.find(
+														child => child.type === 'mcdoc:identifier',
 														/* @ts-ignore */
 													)?.value
 
@@ -199,10 +172,9 @@ export async function generate(
 											switch (fourBack?.parent?.type) {
 												case 'mcdoc:struct/field/spread':
 													{
-														const root = fourBack?.parent?.parent
-															?.parent?.children?.find(child =>
-																child.type
-																	=== 'mcdoc:identifier'
+														const root = fourBack?.parent?.parent?.parent?.children
+															?.find(
+																child => child.type === 'mcdoc:identifier',
 																/* @ts-ignore */
 															)?.value
 
@@ -213,25 +185,20 @@ export async function generate(
 																self.split('][').slice(-4)[0]
 															}` // THIS IS REALLY REALLY BAD
 														} else {
-															logger.warn(
-																'Could not find root for union spread',
-															)
+															logger.warn('Could not find root for union spread')
 														}
 													}
 													break
 												case 'mcdoc:struct/field/pair':
 													{
-														const parentKey = fourBack?.parent
-															?.children?.find(child =>
-																child.type
-																	=== 'mcdoc:identifier'
-																/* @ts-ignore */
-															)?.value
+														const parentKey = fourBack?.parent?.children?.find(
+															child => child.type === 'mcdoc:identifier',
+															/* @ts-ignore */
+														)?.value
 
-														const root = fourBack?.parent?.parent
-															?.parent?.children?.find(child =>
-																child.type
-																	=== 'mcdoc:identifier'
+														const root = fourBack?.parent?.parent?.parent?.children
+															?.find(
+																child => child.type === 'mcdoc:identifier',
 																/* @ts-ignore */
 															)?.value
 
@@ -242,19 +209,15 @@ export async function generate(
 													break
 												case 'mcdoc:dispatch_statement':
 													{
-														const registry = fourBack.parent
-															.children?.find(child =>
-																child.type
-																	=== 'resource_location'
-																/* @ts-ignore */
-															)?.path?.join('_')
+														const registry = fourBack.parent.children?.find(
+															child => child.type === 'resource_location',
+															/* @ts-ignore */
+														)?.path?.join('_')
 
-														const key = fourBack.parent.children
-															?.find(child =>
-																child.type
-																	=== 'mcdoc:index_body'
-																/* @ts-ignore */
-															)?.children?.[0]?.value
+														const key = fourBack.parent.children?.find(
+															child => child.type === 'mcdoc:index_body',
+															/* @ts-ignore */
+														)?.children?.[0]?.value
 
 														const indexGuess = self.split('][').slice(-6)[0] // THIS IS REALLY REALLY BAD
 
@@ -271,12 +234,10 @@ export async function generate(
 													break
 												case 'mcdoc:type_alias':
 													{
-														container = fourBack?.parent?.children
-															?.find(child =>
-																child.type
-																	=== 'mcdoc:identifier'
-																/* @ts-ignore */
-															)?.value
+														container = fourBack?.parent?.children?.find(
+															child => child.type === 'mcdoc:identifier',
+															/* @ts-ignore */
+														)?.value
 													}
 													break
 												default: {
@@ -293,19 +254,14 @@ export async function generate(
 												case 'mcdoc:struct/field/pair':
 													{
 														const key = fiveBack.children?.find(
-															child =>
-																child.type
-																	=== 'mcdoc:identifier',
+															child => child.type === 'mcdoc:identifier',
 															/* @ts-ignore */
 														)?.value
-														const sevenBack = fiveBack.parent
-															?.parent
-														const foundRoot = sevenBack?.children
-															?.find(child =>
-																child.type
-																	=== 'mcdoc:identifier'
-																/* @ts-ignore */
-															)?.value
+														const sevenBack = fiveBack.parent?.parent
+														const foundRoot = sevenBack?.children?.find(
+															child => child.type === 'mcdoc:identifier',
+															/* @ts-ignore */
+														)?.value
 
 														if (foundRoot) {
 															container = `${foundRoot}.${key}.__struct_list`
@@ -314,23 +270,17 @@ export async function generate(
 															switch (sevenBack?.parent?.type) {
 																case 'mcdoc:type/list':
 																	{
-																		const nineBack = sevenBack
-																			.parent?.parent
+																		const nineBack = sevenBack.parent?.parent
 																		/* @ts-ignore */
-																		const parentKey = nineBack
-																			?.children?.find(
-																				child =>
-																					child.type
-																						=== 'mcdoc:identifier',
-																				/* @ts-ignore */
-																			)?.value
+																		const parentKey = nineBack?.children?.find(
+																			child => child.type === 'mcdoc:identifier',
+																			/* @ts-ignore */
+																		)?.value
 																		// Credits husk
-																		const actualRoot = nineBack?.parent
-																			?.parent?.parent
-																			?.parent?.children
-																			?.find(child =>
-																				child.type
-																					=== 'mcdoc:identifier'
+																		const actualRoot = nineBack?.parent?.parent
+																			?.parent?.parent?.children?.find(
+																				child =>
+																					child.type === 'mcdoc:identifier',
 																				/* @ts-ignore */
 																			)?.value
 																		if (actualRoot) {
@@ -344,11 +294,9 @@ export async function generate(
 																	}
 																	break
 																case 'mcdoc:type/union': {
-																	const actualRoot = sevenBack
-																		.parent?.parent?.children
-																		?.find(child =>
-																			child.type
-																				=== 'mcdoc:identifier'
+																	const actualRoot = sevenBack.parent?.parent
+																		?.children?.find(
+																			child => child.type === 'mcdoc:identifier',
 																			/* @ts-ignore */
 																		)?.value
 
@@ -370,9 +318,7 @@ export async function generate(
 												case 'mcdoc:type_alias':
 													{
 														const root = fiveBack?.children?.find(
-															child =>
-																child.type
-																	=== 'mcdoc:identifier',
+															child => child.type === 'mcdoc:identifier',
 															/* @ts-ignore */
 														)?.value
 
@@ -384,18 +330,15 @@ export async function generate(
 										break
 									case 'mcdoc:type_alias':
 										{
-											const root = fourBack?.children?.find(child =>
-												child.type === 'mcdoc:identifier'
+											const root = fourBack?.children?.find(
+												child => child.type === 'mcdoc:identifier',
 												/* @ts-ignore */
 											)?.value
 
 											if (root) {
 												container = root
 											} else {
-												logger.warn(
-													'Could not find root for type alias, hint:'
-														+ self,
-												)
+												logger.warn('Could not find root for type alias, hint:' + self)
 											}
 										}
 										break
@@ -410,8 +353,8 @@ export async function generate(
 								switch (fourBack?.type) {
 									case 'mcdoc:struct/field/pair':
 										{
-											const key = fourBack.children?.find(child =>
-												child.type === 'mcdoc:identifier'
+											const key = fourBack.children?.find(
+												child => child.type === 'mcdoc:identifier',
 												/* @ts-ignore */
 											)?.value
 											const sixBack = fourBack.parent?.parent
@@ -425,34 +368,30 @@ export async function generate(
 													container = `${parentKey}.${key}`
 												} else {
 													// memories
-													const actualParentKey = sixBack?.parent
-														?.children?.find(child =>
-															child.type === 'mcdoc:identifier'
-															/* @ts-ignore */
-														)?.value
+													const actualParentKey = sixBack?.parent?.children?.find(
+														child => child.type === 'mcdoc:identifier',
+														/* @ts-ignore */
+													)?.value
 
-													const root = sixBack?.parent?.parent
-														?.parent?.children?.find(child =>
-															child.type === 'mcdoc:identifier'
-															/* @ts-ignore */
-														)?.value
+													const root = sixBack?.parent?.parent?.parent?.children?.find(
+														child => child.type === 'mcdoc:identifier',
+														/* @ts-ignore */
+													)?.value
 
 													container = `${root}.${actualParentKey}.${key}`
 												}
 											} else {
 												// advancement criteria trigger
-												const sevenBack = fourBack?.parent?.parent
-													?.parent
+												const sevenBack = fourBack?.parent?.parent?.parent
 												const parentKey = sevenBack?.children?.find(
 													child => child.type === 'mcdoc:identifier',
 													/* @ts-ignore */
 												)?.value
 
-												const root = sevenBack?.parent?.parent
-													?.children?.find(child =>
-														child.type === 'mcdoc:identifier'
-														/* @ts-ignore */
-													)?.value
+												const root = sevenBack?.parent?.parent?.children?.find(
+													child => child.type === 'mcdoc:identifier',
+													/* @ts-ignore */
+												)?.value
 
 												container = `${root}.${parentKey}.__map_key.__struct`
 											}
@@ -464,12 +403,10 @@ export async function generate(
 												switch (fourBack?.parent?.type) {
 													case 'mcdoc:type_alias':
 														{
-															const root = fourBack?.parent
-																?.children?.find(child =>
-																	child.type
-																		=== 'mcdoc:identifier'
-																	/* @ts-ignore */
-																)?.value
+															const root = fourBack?.parent?.children?.find(
+																child => child.type === 'mcdoc:identifier',
+																/* @ts-ignore */
+															)?.value
 															container = `${root}.__union.__struct_${
 																self.split('][').slice(-4)[0]
 															}` // THIS IS REALLY REALLY BAD
@@ -477,18 +414,14 @@ export async function generate(
 														break
 													case 'mcdoc:struct/field/pair':
 														{
-															const parentKey = fourBack?.parent
-																.children?.find(child =>
-																	child.type
-																		=== 'mcdoc:identifier'
-																	/* @ts-ignore */
-																)?.value
+															const parentKey = fourBack?.parent.children?.find(
+																child => child.type === 'mcdoc:identifier',
+																/* @ts-ignore */
+															)?.value
 
-															const root = fourBack?.parent
-																?.parent?.parent?.children
-																?.find(child =>
-																	child.type
-																		=== 'mcdoc:identifier'
+															const root = fourBack?.parent?.parent?.parent?.children
+																?.find(
+																	child => child.type === 'mcdoc:identifier',
 																	/* @ts-ignore */
 																)?.value
 
@@ -502,9 +435,7 @@ export async function generate(
 															const indexGuess = self.split('][').slice(-6)[0]
 															if (indexGuess === '45') {
 																container = `__dispatch.__struct_${
-																	self.split('][').slice(
-																		-4,
-																	)[0]
+																	self.split('][').slice(-4)[0]
 																}`
 															} else {
 																container = `__dispatch.__struct_${indexGuess}` // THIS IS REALLY REALLY BAD
@@ -514,22 +445,16 @@ export async function generate(
 													case 'mcdoc:type/union':
 														{
 															// book lines
-															const sevenBack = fourBack?.parent
-																?.parent?.parent
-															const parentKey = sevenBack
-																?.children?.find(child =>
-																	child.type
-																		=== 'mcdoc:identifier'
-																	/* @ts-ignore */
-																)?.value
+															const sevenBack = fourBack?.parent?.parent?.parent
+															const parentKey = sevenBack?.children?.find(
+																child => child.type === 'mcdoc:identifier',
+																/* @ts-ignore */
+															)?.value
 
-															const root = sevenBack?.parent
-																?.parent?.children?.find(
-																	child =>
-																		child.type
-																			=== 'mcdoc:identifier',
-																	/* @ts-ignore */
-																)?.value
+															const root = sevenBack?.parent?.parent?.children?.find(
+																child => child.type === 'mcdoc:identifier',
+																/* @ts-ignore */
+															)?.value
 
 															container =
 																`${root}.${parentKey}.__union_list.__struct`
@@ -538,27 +463,21 @@ export async function generate(
 													case 'mcdoc:type/list':
 														{
 															// texture meta
-															const parentKey = fourBack?.parent
-																.parent?.children?.find(child =>
-																	child.type
-																		=== 'mcdoc:identifier'
+															const parentKey = fourBack?.parent.parent?.children
+																?.find(
+																	child => child.type === 'mcdoc:identifier',
 																	/* @ts-ignore */
 																)?.value
 
-															const rootKey = fourBack?.parent
-																?.parent?.parent?.parent?.parent
-																?.children?.find(child =>
-																	child.type
-																		=== 'mcdoc:identifier'
+															const rootKey = fourBack?.parent?.parent?.parent
+																?.parent?.parent?.children?.find(
+																	child => child.type === 'mcdoc:identifier',
 																	/* @ts-ignore */
 																)?.value
 
-															const root = fourBack?.parent
-																?.parent?.parent?.parent?.parent
-																?.parent?.parent?.children
-																?.find(child =>
-																	child.type
-																		=== 'mcdoc:identifier'
+															const root = fourBack?.parent?.parent?.parent?.parent
+																?.parent?.parent?.parent?.children?.find(
+																	child => child.type === 'mcdoc:identifier',
 																	/* @ts-ignore */
 																)?.value
 
@@ -577,8 +496,8 @@ export async function generate(
 							switch (threeBack?.type) {
 								case 'mcdoc:enum':
 									{
-										const root = threeBack?.children?.find(child =>
-											child.type === 'mcdoc:identifier'
+										const root = threeBack?.children?.find(
+											child => child.type === 'mcdoc:identifier',
 											/* @ts-ignore */
 										)?.value
 
@@ -586,29 +505,26 @@ export async function generate(
 											container = root
 										} else {
 											// inline enum
-											const parentKey = threeBack?.parent?.children
-												?.find(child =>
-													child.type === 'mcdoc:identifier'
-													/* @ts-ignore */
-												)?.value
-											const root = threeBack?.parent?.parent?.parent
-												?.children?.find(child =>
-													child.type === 'mcdoc:identifier'
-													/* @ts-ignore */
-												)?.value
+											const parentKey = threeBack?.parent?.children?.find(
+												child => child.type === 'mcdoc:identifier',
+												/* @ts-ignore */
+											)?.value
+											const root = threeBack?.parent?.parent?.parent?.children?.find(
+												child => child.type === 'mcdoc:identifier',
+												/* @ts-ignore */
+											)?.value
 
 											if (root) {
 												container = `${root}.${parentKey}`
 											} else {
-												const rootKey = threeBack?.parent?.parent
-													?.parent?.parent?.children?.find(child =>
-														child.type === 'mcdoc:identifier'
+												const rootKey = threeBack?.parent?.parent?.parent?.parent
+													?.children?.find(
+														child => child.type === 'mcdoc:identifier',
 														/* @ts-ignore */
 													)?.value
-												const root = threeBack?.parent?.parent
-													?.parent?.parent?.parent?.parent
-													?.children?.find(child =>
-														child.type === 'mcdoc:identifier'
+												const root = threeBack?.parent?.parent?.parent?.parent?.parent
+													?.parent?.children?.find(
+														child => child.type === 'mcdoc:identifier',
 														/* @ts-ignore */
 													)?.value
 
@@ -632,9 +548,7 @@ export async function generate(
 												{
 													if (_parent?.children) {
 														container = _parent?.children?.find(
-															child =>
-																child.type
-																	=== 'resource_location',
+															child => child.type === 'resource_location',
 															/* @ts-ignore */
 														)?.path?.join('_')
 													}
@@ -660,14 +574,14 @@ export async function generate(
 									}
 									break
 								case 'mcdoc:struct/field/pair': {
-									const key = threeBack.children?.find(child =>
+									const key = threeBack.children?.find(
+										child => child.type === 'mcdoc:identifier',
+										/* @ts-ignore */
+									)?.value
+									const root = threeBack.parent?.parent?.children?.find(child =>
 										child.type === 'mcdoc:identifier'
 										/* @ts-ignore */
 									)?.value
-									const root = threeBack.parent?.parent?.children
-										?.find(child => child.type === 'mcdoc:identifier')
-										/* @ts-ignore */
-										?.value
 
 									container = `${root}.${key}`
 								}
@@ -704,15 +618,12 @@ export async function generate(
 										setLocale(`__dispatch.${key}`)
 									} else {
 										/// anonymous struct
-										setLocale(
-											`__dispatch_${self.split('][').slice(-2)[0]}`,
-										) // THIS IS REALLY REALLY BAD
+										setLocale(`__dispatch_${self.split('][').slice(-2)[0]}`) // THIS IS REALLY REALLY BAD
 									}
 								} else {
 									const key = `${
 										/* @ts-ignore */
-										_parent?.children?.[3]?.children?.[0].value}`
-										.replace(/[\%\, ]/, '__') // should be sanitized enough
+										_parent?.children?.[3]?.children?.[0].value}`.replace(/[\%\, ]/, '__') // should be sanitized enough
 
 									setLocale(`__dispatch.${key}`)
 								}
@@ -725,22 +636,16 @@ export async function generate(
 					}
 				}
 
-				if (
-					child.type === 'mcdoc:struct/map_key'
-					&& internal_locales[parent]
-				) {
+				if (child.type === 'mcdoc:struct/map_key' && internal_locales[parent]) {
 					const attributes = _child.children?.[0]?.children?.[0]?.children
 					if (
-						attributes && attributes.length === 1
-						/* @ts-ignore */
+						attributes && attributes.length === 1 /* @ts-ignore */
 						&& !attributes[0].children && attributes[0].value === 'id'
 					) {
 						/* @ts-ignore */
 						setLocale(_child.children?.[0].children?.[1].value)
 					} else {
-						logger.warn(
-							'Could not find good path, using __map_key. hint: ' + self,
-						)
+						logger.warn('Could not find good path, using __map_key. hint: ' + self)
 						setLocale('__map_key')
 					}
 
@@ -752,10 +657,7 @@ export async function generate(
 					const comment: string = _child.comment
 					child.comment = comment
 
-					if (
-						!args.dry && args.locale
-						&& _parent?.type === 'mcdoc:doc_comments'
-					) {
+					if (!args.dry && args.locale && _parent?.type === 'mcdoc:doc_comments') {
 						const key = parent.replace(/\[\d+\]$/, '')
 
 						if (!internal_locales[key]) {
@@ -776,9 +678,7 @@ export async function generate(
 
 					const lc = lineColumn(doc_contents)
 
-					function range(
-						range: { start: number; end: number },
-					) {
+					function range(range: { start: number; end: number }) {
 						const start = lc.fromIndex(range.start)
 						const end = lc.fromIndex(range.end)
 
@@ -822,19 +722,10 @@ export async function generate(
 
 			children.forEach((child, i) => {
 				/* @ts-ignore */
-				children[i] = flattenChild(
-					resource,
-					`${resource}.[${i}]`,
-					undefined,
-					child,
-				)
+				children[i] = flattenChild(resource, `${resource}.[${i}]`, undefined, child)
 			})
 
-			const symbol = {
-				resource,
-
-				children,
-			}
+			const symbol = { resource, children }
 
 			symbols.push(symbol)
 
@@ -850,11 +741,7 @@ export async function generate(
 
 				if (args.pretty) {
 					await fs.writeFile(
-						join(
-							generated_path,
-							'module',
-							`${resource}.pretty.mcdoc.json`,
-						),
+						join(generated_path, 'module', `${resource}.pretty.mcdoc.json`),
 						JSON.stringify(symbol, undefined, 3),
 					)
 				}

--- a/packages/mcdoc-cli/src/generate/index.ts
+++ b/packages/mcdoc-cli/src/generate/index.ts
@@ -174,8 +174,7 @@ export async function generate(
 															/* @ts-ignore */
 														)?.value
 
-													container =
-														`${actualRoot}.${parentKey}.${key}`
+													container = `${actualRoot}.${parentKey}.${key}`
 												}
 											} else {
 												// This is another nested anonymous struct
@@ -191,8 +190,7 @@ export async function generate(
 														/* @ts-ignore */
 													)?.value
 
-												container =
-													`${actualRoot}.${parentKey}.__map_key.__struct`
+												container = `${actualRoot}.${parentKey}.__map_key.__struct`
 											}
 										}
 										break
@@ -211,10 +209,9 @@ export async function generate(
 														// java/server/world/entity/mob/breedable/llama.[0][2][4][2][9][0][0][1][0][0][0]
 														// java/server/world/entity/mob/breedable/llama.[0][2][4][2][9][0][1][1][0][0][0]
 														if (root) {
-															container =
-																`${root}.__spread.__union.__struct_${
-																	self.split('][').slice(-4)[0]
-																}` // THIS IS REALLY REALLY BAD
+															container = `${root}.__spread.__union.__struct_${
+																self.split('][').slice(-4)[0]
+															}` // THIS IS REALLY REALLY BAD
 														} else {
 															logger.warn(
 																'Could not find root for union spread',
@@ -238,10 +235,9 @@ export async function generate(
 																/* @ts-ignore */
 															)?.value
 
-														container =
-															`${root}.${parentKey}.__union.__struct_${
-																self.split('][').slice(-2)[0]
-															}` // THIS IS REALLY REALLY BAD
+														container = `${root}.${parentKey}.__union.__struct_${
+															self.split('][').slice(-2)[0]
+														}` // THIS IS REALLY REALLY BAD
 													}
 													break
 												case 'mcdoc:dispatch_statement':
@@ -260,8 +256,7 @@ export async function generate(
 																/* @ts-ignore */
 															)?.children?.[0]?.value
 
-														const indexGuess =
-															self.split('][').slice(-6)[0] // THIS IS REALLY REALLY BAD
+														const indexGuess = self.split('][').slice(-6)[0] // THIS IS REALLY REALLY BAD
 
 														if (indexGuess === '45') {
 															container =
@@ -313,8 +308,7 @@ export async function generate(
 															)?.value
 
 														if (foundRoot) {
-															container =
-																`${foundRoot}.${key}.__struct_list`
+															container = `${foundRoot}.${key}.__struct_list`
 														} else {
 															// This is another nested anonymous struct
 															switch (sevenBack?.parent?.type) {
@@ -331,15 +325,14 @@ export async function generate(
 																				/* @ts-ignore */
 																			)?.value
 																		// Credits husk
-																		const actualRoot =
-																			nineBack?.parent
-																				?.parent?.parent
-																				?.parent?.children
-																				?.find(child =>
-																					child.type
-																						=== 'mcdoc:identifier'
-																					/* @ts-ignore */
-																				)?.value
+																		const actualRoot = nineBack?.parent
+																			?.parent?.parent
+																			?.parent?.children
+																			?.find(child =>
+																				child.type
+																					=== 'mcdoc:identifier'
+																				/* @ts-ignore */
+																			)?.value
 																		if (actualRoot) {
 																			container =
 																				`${actualRoot}.__struct_list.${parentKey}.__struct_list.${key}.__struct_list`
@@ -409,9 +402,7 @@ export async function generate(
 									case 'mcdoc:dispatch_statement':
 										{
 											// anonymous struct
-											container = `__dispatch.__struct${
-												self.split('][').slice(-5)[0]
-											}` // THIS IS REALLY REALLY BAD
+											container = `__dispatch.__struct${self.split('][').slice(-5)[0]}` // THIS IS REALLY REALLY BAD
 										}
 										break
 								}
@@ -446,16 +437,14 @@ export async function generate(
 															/* @ts-ignore */
 														)?.value
 
-													container =
-														`${root}.${actualParentKey}.${key}`
+													container = `${root}.${actualParentKey}.${key}`
 												}
 											} else {
 												// advancement criteria trigger
 												const sevenBack = fourBack?.parent?.parent
 													?.parent
 												const parentKey = sevenBack?.children?.find(
-													child =>
-														child.type === 'mcdoc:identifier',
+													child => child.type === 'mcdoc:identifier',
 													/* @ts-ignore */
 												)?.value
 
@@ -465,8 +454,7 @@ export async function generate(
 														/* @ts-ignore */
 													)?.value
 
-												container =
-													`${root}.${parentKey}.__map_key.__struct`
+												container = `${root}.${parentKey}.__map_key.__struct`
 											}
 										}
 										break
@@ -482,10 +470,9 @@ export async function generate(
 																		=== 'mcdoc:identifier'
 																	/* @ts-ignore */
 																)?.value
-															container =
-																`${root}.__union.__struct_${
-																	self.split('][').slice(-4)[0]
-																}` // THIS IS REALLY REALLY BAD
+															container = `${root}.__union.__struct_${
+																self.split('][').slice(-4)[0]
+															}` // THIS IS REALLY REALLY BAD
 														}
 														break
 													case 'mcdoc:struct/field/pair':
@@ -512,18 +499,15 @@ export async function generate(
 														{
 															// kill
 
-															const indexGuess =
-																self.split('][').slice(-6)[0]
+															const indexGuess = self.split('][').slice(-6)[0]
 															if (indexGuess === '45') {
-																container =
-																	`__dispatch.__struct_${
-																		self.split('][').slice(
-																			-4,
-																		)[0]
-																	}`
+																container = `__dispatch.__struct_${
+																	self.split('][').slice(
+																		-4,
+																	)[0]
+																}`
 															} else {
-																container =
-																	`__dispatch.__struct_${indexGuess}` // THIS IS REALLY REALLY BAD
+																container = `__dispatch.__struct_${indexGuess}` // THIS IS REALLY REALLY BAD
 															}
 														}
 														break
@@ -628,8 +612,7 @@ export async function generate(
 														/* @ts-ignore */
 													)?.value
 
-												container =
-													`${root}.${rootKey}.${parentKey}`
+												container = `${root}.${rootKey}.${parentKey}`
 											}
 										}
 									}
@@ -640,8 +623,7 @@ export async function generate(
 											case 'mcdoc:struct':
 												{
 													container = _parent?.children?.find(
-														child =>
-															child.type === 'mcdoc:identifier',
+														child => child.type === 'mcdoc:identifier',
 														/* @ts-ignore */
 													)?.value
 												}
@@ -661,8 +643,7 @@ export async function generate(
 											case 'mcdoc:enum':
 												{
 													container = _parent?.children?.find(
-														child =>
-															child.type === 'mcdoc:identifier',
+														child => child.type === 'mcdoc:identifier',
 														/* @ts-ignore */
 													)?.value
 												}
@@ -670,8 +651,7 @@ export async function generate(
 											case 'mcdoc:type_alias':
 												{
 													container = _parent?.children?.find(
-														child =>
-															child.type === 'mcdoc:identifier',
+														child => child.type === 'mcdoc:identifier',
 														/* @ts-ignore */
 													)?.value
 												}
@@ -802,9 +782,9 @@ export async function generate(
 						const start = lc.fromIndex(range.start)
 						const end = lc.fromIndex(range.end)
 
-						return `L${start?.line}${
-							start?.col ? `:C${start?.col}` : ''
-						} -> L${end?.line}${end?.col ? `:C${end?.col}` : ''}`
+						return `L${start?.line}${start?.col ? `:C${start?.col}` : ''} -> L${end?.line}${
+							end?.col ? `:C${end?.col}` : ''
+						}`
 					}
 
 					if (!known_error) {

--- a/packages/mcdoc-cli/src/generate/index.ts
+++ b/packages/mcdoc-cli/src/generate/index.ts
@@ -169,8 +169,8 @@ export async function generate(
 													const actualRoot = sixBack?.parent
 														?.parent?.parent?.children?.find(
 															child =>
-																child.type ===
-																	'mcdoc:identifier',
+																child.type
+																	=== 'mcdoc:identifier',
 															/* @ts-ignore */
 														)?.value
 
@@ -203,8 +203,8 @@ export async function generate(
 													{
 														const root = fourBack?.parent?.parent
 															?.parent?.children?.find(child =>
-																child.type ===
-																	'mcdoc:identifier'
+																child.type
+																	=== 'mcdoc:identifier'
 																/* @ts-ignore */
 															)?.value
 
@@ -226,15 +226,15 @@ export async function generate(
 													{
 														const parentKey = fourBack?.parent
 															?.children?.find(child =>
-																child.type ===
-																	'mcdoc:identifier'
+																child.type
+																	=== 'mcdoc:identifier'
 																/* @ts-ignore */
 															)?.value
 
 														const root = fourBack?.parent?.parent
 															?.parent?.children?.find(child =>
-																child.type ===
-																	'mcdoc:identifier'
+																child.type
+																	=== 'mcdoc:identifier'
 																/* @ts-ignore */
 															)?.value
 
@@ -248,15 +248,15 @@ export async function generate(
 													{
 														const registry = fourBack.parent
 															.children?.find(child =>
-																child.type ===
-																	'resource_location'
+																child.type
+																	=== 'resource_location'
 																/* @ts-ignore */
 															)?.path?.join('_')
 
 														const key = fourBack.parent.children
 															?.find(child =>
-																child.type ===
-																	'mcdoc:index_body'
+																child.type
+																	=== 'mcdoc:index_body'
 																/* @ts-ignore */
 															)?.children?.[0]?.value
 
@@ -278,8 +278,8 @@ export async function generate(
 													{
 														container = fourBack?.parent?.children
 															?.find(child =>
-																child.type ===
-																	'mcdoc:identifier'
+																child.type
+																	=== 'mcdoc:identifier'
 																/* @ts-ignore */
 															)?.value
 													}
@@ -299,16 +299,16 @@ export async function generate(
 													{
 														const key = fiveBack.children?.find(
 															child =>
-																child.type ===
-																	'mcdoc:identifier',
+																child.type
+																	=== 'mcdoc:identifier',
 															/* @ts-ignore */
 														)?.value
 														const sevenBack = fiveBack.parent
 															?.parent
 														const foundRoot = sevenBack?.children
 															?.find(child =>
-																child.type ===
-																	'mcdoc:identifier'
+																child.type
+																	=== 'mcdoc:identifier'
 																/* @ts-ignore */
 															)?.value
 
@@ -326,8 +326,8 @@ export async function generate(
 																		const parentKey = nineBack
 																			?.children?.find(
 																				child =>
-																					child.type ===
-																						'mcdoc:identifier',
+																					child.type
+																						=== 'mcdoc:identifier',
 																				/* @ts-ignore */
 																			)?.value
 																		// Credits husk
@@ -336,8 +336,8 @@ export async function generate(
 																				?.parent?.parent
 																				?.parent?.children
 																				?.find(child =>
-																					child.type ===
-																						'mcdoc:identifier'
+																					child.type
+																						=== 'mcdoc:identifier'
 																					/* @ts-ignore */
 																				)?.value
 																		if (actualRoot) {
@@ -354,8 +354,8 @@ export async function generate(
 																	const actualRoot = sevenBack
 																		.parent?.parent?.children
 																		?.find(child =>
-																			child.type ===
-																				'mcdoc:identifier'
+																			child.type
+																				=== 'mcdoc:identifier'
 																			/* @ts-ignore */
 																		)?.value
 
@@ -378,8 +378,8 @@ export async function generate(
 													{
 														const root = fiveBack?.children?.find(
 															child =>
-																child.type ===
-																	'mcdoc:identifier',
+																child.type
+																	=== 'mcdoc:identifier',
 															/* @ts-ignore */
 														)?.value
 
@@ -400,8 +400,8 @@ export async function generate(
 												container = root
 											} else {
 												logger.warn(
-													'Could not find root for type alias, hint:' +
-														self,
+													'Could not find root for type alias, hint:'
+														+ self,
 												)
 											}
 										}
@@ -478,8 +478,8 @@ export async function generate(
 														{
 															const root = fourBack?.parent
 																?.children?.find(child =>
-																	child.type ===
-																		'mcdoc:identifier'
+																	child.type
+																		=== 'mcdoc:identifier'
 																	/* @ts-ignore */
 																)?.value
 															container =
@@ -492,16 +492,16 @@ export async function generate(
 														{
 															const parentKey = fourBack?.parent
 																.children?.find(child =>
-																	child.type ===
-																		'mcdoc:identifier'
+																	child.type
+																		=== 'mcdoc:identifier'
 																	/* @ts-ignore */
 																)?.value
 
 															const root = fourBack?.parent
 																?.parent?.parent?.children
 																?.find(child =>
-																	child.type ===
-																		'mcdoc:identifier'
+																	child.type
+																		=== 'mcdoc:identifier'
 																	/* @ts-ignore */
 																)?.value
 
@@ -534,16 +534,16 @@ export async function generate(
 																?.parent?.parent
 															const parentKey = sevenBack
 																?.children?.find(child =>
-																	child.type ===
-																		'mcdoc:identifier'
+																	child.type
+																		=== 'mcdoc:identifier'
 																	/* @ts-ignore */
 																)?.value
 
 															const root = sevenBack?.parent
 																?.parent?.children?.find(
 																	child =>
-																		child.type ===
-																			'mcdoc:identifier',
+																		child.type
+																			=== 'mcdoc:identifier',
 																	/* @ts-ignore */
 																)?.value
 
@@ -556,16 +556,16 @@ export async function generate(
 															// texture meta
 															const parentKey = fourBack?.parent
 																.parent?.children?.find(child =>
-																	child.type ===
-																		'mcdoc:identifier'
+																	child.type
+																		=== 'mcdoc:identifier'
 																	/* @ts-ignore */
 																)?.value
 
 															const rootKey = fourBack?.parent
 																?.parent?.parent?.parent?.parent
 																?.children?.find(child =>
-																	child.type ===
-																		'mcdoc:identifier'
+																	child.type
+																		=== 'mcdoc:identifier'
 																	/* @ts-ignore */
 																)?.value
 
@@ -573,8 +573,8 @@ export async function generate(
 																?.parent?.parent?.parent?.parent
 																?.parent?.parent?.children
 																?.find(child =>
-																	child.type ===
-																		'mcdoc:identifier'
+																	child.type
+																		=== 'mcdoc:identifier'
 																	/* @ts-ignore */
 																)?.value
 
@@ -651,8 +651,8 @@ export async function generate(
 													if (_parent?.children) {
 														container = _parent?.children?.find(
 															child =>
-																child.type ===
-																	'resource_location',
+																child.type
+																	=== 'resource_location',
 															/* @ts-ignore */
 														)?.path?.join('_')
 													}
@@ -746,14 +746,14 @@ export async function generate(
 				}
 
 				if (
-					child.type === 'mcdoc:struct/map_key' &&
-					internal_locales[parent]
+					child.type === 'mcdoc:struct/map_key'
+					&& internal_locales[parent]
 				) {
 					const attributes = _child.children?.[0]?.children?.[0]?.children
 					if (
-						attributes && attributes.length === 1 &&
+						attributes && attributes.length === 1
 						/* @ts-ignore */
-						!attributes[0].children && attributes[0].value === 'id'
+						&& !attributes[0].children && attributes[0].value === 'id'
 					) {
 						/* @ts-ignore */
 						setLocale(_child.children?.[0].children?.[1].value)
@@ -773,8 +773,8 @@ export async function generate(
 					child.comment = comment
 
 					if (
-						!args.dry && args.locale &&
-						_parent?.type === 'mcdoc:doc_comments'
+						!args.dry && args.locale
+						&& _parent?.type === 'mcdoc:doc_comments'
 					) {
 						const key = parent.replace(/\[\d+\]$/, '')
 

--- a/packages/mcdoc-cli/src/index.ts
+++ b/packages/mcdoc-cli/src/index.ts
@@ -32,192 +32,155 @@ export type Logger = {
 	trace: (message?: any, ...params: any) => void
 }
 
-await CLI.scriptName('mcdoc')
-	.command(
-		'generate [source]',
-		'Generate JSON files',
-		() =>
-			CLI.positional(
-				'source',
-				{
-					describe: 'path to directory containing mcdoc source.',
-					type: 'string',
-					default: '.',
-				},
-			).options({
-				'locale': {
-					alias: 'l',
-					description: 'en-us language key-value store of all doc comments.',
-					default: false,
-				},
-				'module': {
-					alias: 'm',
-					description: 'file tree mirroring definitions; to optimize for web.',
-					default: false,
-				},
-				'pretty': {
-					alias: 'p',
-					description: 'pretty printed variants.',
-					default: false,
-				},
-				'verbose': {
-					alias: 'v',
-					default: false,
-				},
-				'dry': {
-					alias: 'd',
-					description: 'will not write to disk.',
-					default: false,
-				},
-			}).boolean('locale').boolean('module').boolean('pretty').boolean(
-				'verbose',
-			).boolean('dry'),
-		async (args) => {
-			const include = []
+await CLI.scriptName('mcdoc').command(
+	'generate [source]',
+	'Generate JSON files',
+	() =>
+		CLI.positional('source', {
+			describe: 'path to directory containing mcdoc source.',
+			type: 'string',
+			default: '.',
+		}).options({
+			'locale': {
+				alias: 'l',
+				description: 'en-us language key-value store of all doc comments.',
+				default: false,
+			},
+			'module': {
+				alias: 'm',
+				description: 'file tree mirroring definitions; to optimize for web.',
+				default: false,
+			},
+			'pretty': { alias: 'p', description: 'pretty printed variants.', default: false },
+			'verbose': { alias: 'v', default: false },
+			'dry': { alias: 'd', description: 'will not write to disk.', default: false },
+		}).boolean('locale').boolean('module').boolean('pretty').boolean('verbose').boolean('dry'),
+	async (args) => {
+		const include = []
 
-			if (args.locale) include.push('locales')
-			if (args.module) include.push('modules')
+		if (args.locale) include.push('locales')
+		if (args.module) include.push('modules')
 
-			console.info(
-				`Generating JSON files${
-					args.locale || args.module
-						? `, including ${include.join(', ')}`
-						: ''
-				}`,
-			)
+		console.info(
+			`Generating JSON files${
+				args.locale || args.module ? `, including ${include.join(', ')}` : ''
+			}`,
+		)
 
-			const logger: Logger = {
-				log: (...log_args: any[]) => args.verbose ? console.log(...log_args) : false,
+		const logger: Logger = {
+			log: (...log_args: any[]) => args.verbose ? console.log(...log_args) : false,
 
-				warn: (...log_args: any[]) => console.warn(...log_args),
+			warn: (...log_args: any[]) => console.warn(...log_args),
 
-				error: (...log_args: any[]) => console.error(...log_args),
+			error: (...log_args: any[]) => console.error(...log_args),
 
-				info: (...log_args: any[]) => args.verbose ? console.info(...log_args) : false,
+			info: (...log_args: any[]) => args.verbose ? console.info(...log_args) : false,
 
-				trace: (message?: any, ...params: any) => console.trace(message, ...params),
+			trace: (message?: any, ...params: any) => console.trace(message, ...params),
+		}
+
+		const project_path = resolve(process.cwd(), args.source)
+
+		await fileUtil.ensureDir(NodeJsExternals, project_path)
+
+		const service = new Service({
+			logger,
+			project: {
+				cacheRoot: fileUtil.ensureEndingSlash(pathToFileURL(cache_root).toString()),
+				defaultConfig: ConfigService.merge(VanillaConfig, { env: { dependencies: [] } }),
+				externals: NodeJsExternals,
+				initializers: [mcdoc.initialize],
+				projectRoot: fileUtil.ensureEndingSlash(pathToFileURL(project_path).toString()),
+			},
+		})
+
+		await service.project.ready()
+		await service.project.cacheService.save()
+
+		const generated_path = join('out', 'generated')
+
+		if (args.dry !== true) {
+			await fs.ensureDir(generated_path)
+
+			if (args.module) {
+				await fs.ensureDir(join(generated_path, 'module'))
 			}
-
-			const project_path = resolve(process.cwd(), args.source)
-
-			await fileUtil.ensureDir(NodeJsExternals, project_path)
-
-			const service = new Service({
-				logger,
-				project: {
-					cacheRoot: fileUtil.ensureEndingSlash(
-						pathToFileURL(cache_root).toString(),
-					),
-					defaultConfig: ConfigService.merge(VanillaConfig, {
-						env: { dependencies: [] },
-					}),
-					externals: NodeJsExternals,
-					initializers: [mcdoc.initialize],
-					projectRoot: fileUtil.ensureEndingSlash(
-						pathToFileURL(project_path).toString(),
-					),
-				},
-			})
-
-			await service.project.ready()
-			await service.project.cacheService.save()
-
-			const generated_path = join('out', 'generated')
-
-			if (args.dry !== true) {
-				await fs.ensureDir(generated_path)
-
-				if (args.module) {
-					await fs.ensureDir(join(generated_path, 'module'))
-				}
-				if (args.locale) {
-					await fs.ensureDir(join('out', 'locale'))
-				}
+			if (args.locale) {
+				await fs.ensureDir(join('out', 'locale'))
 			}
+		}
 
-			const symbols: { resource: string; children: AstNode[] }[] = []
+		const symbols: { resource: string; children: AstNode[] }[] = []
 
-			let locales: Record<string, string> = {}
+		let locales: Record<string, string> = {}
 
-			let errors = 0
+		let errors = 0
 
-			for await (const doc_file of walk(project_path)) {
-				if (doc_file.path.endsWith('.mcdoc')) {
-					const response = await generate(
-						project_path,
-						generated_path,
-						args,
-						doc_file,
-						service,
-						logger,
-					)
-
-					symbols.push(...response[0])
-					locales = { ...locales, ...response[1] }
-					errors += response[2]
-				}
-			}
-
-			if (!args.dry) {
-				await fs.writeFile(
-					join(generated_path, 'generated.mcdoc.json'),
-					JSON.stringify(symbols),
+		for await (const doc_file of walk(project_path)) {
+			if (doc_file.path.endsWith('.mcdoc')) {
+				const response = await generate(
+					project_path,
+					generated_path,
+					args,
+					doc_file,
+					service,
+					logger,
 				)
 
-				if (args.pretty) {
-					await fs.writeFile(
-						join(generated_path, 'generated.pretty.mcdoc.json'),
-						JSON.stringify(symbols, undefined, 3),
-					)
-				}
+				symbols.push(...response[0])
+				locales = { ...locales, ...response[1] }
+				errors += response[2]
+			}
+		}
 
-				if (args.module) {
-					await fs.writeFile(
-						join(generated_path, 'module', 'index.json'),
-						JSON.stringify(symbols.map(symbol => symbol.resource)),
-					)
-				}
+		if (!args.dry) {
+			await fs.writeFile(join(generated_path, 'generated.mcdoc.json'), JSON.stringify(symbols))
 
-				if (args.locale) {
-					const locale_path = join('out', 'locale', 'en-us.json')
-					if (await fs.exists(locale_path)) {
-						const old_locales = JSON.parse(
-							await fs.readFile(locale_path, 'utf-8'),
-						)
-
-						await fs.ensureDir(join('out', 'meta'))
-
-						await fs.writeFile(
-							join('out', 'meta', 'locale.json'),
-							JSON.stringify(
-								{
-									old_keys: Object.keys(old_locales),
-									old_values: Object.values(old_locales),
-									new_keys: Object.keys(locales),
-									new_values: Object.values(locales),
-								},
-								undefined,
-								3,
-							),
-						)
-					}
-					await fs.writeFile(
-						join('out', 'locale', 'en-us.json'),
-						JSON.stringify(locales, undefined, 3),
-					)
-				}
+			if (args.pretty) {
+				await fs.writeFile(
+					join(generated_path, 'generated.pretty.mcdoc.json'),
+					JSON.stringify(symbols, undefined, 3),
+				)
 			}
 
-			console.log(`Generated JSON files with ${errors} errors.`)
+			if (args.module) {
+				await fs.writeFile(
+					join(generated_path, 'module', 'index.json'),
+					JSON.stringify(symbols.map(symbol => symbol.resource)),
+				)
+			}
 
-			await service.project.close()
-		},
-	)
-	.command(
-		'update_locales',
-		'Attempt automatic upgrade of locales.',
-		update_locales,
-	)
-	.strict()
-	.demandCommand(1)
-	.parse()
+			if (args.locale) {
+				const locale_path = join('out', 'locale', 'en-us.json')
+				if (await fs.exists(locale_path)) {
+					const old_locales = JSON.parse(await fs.readFile(locale_path, 'utf-8'))
+
+					await fs.ensureDir(join('out', 'meta'))
+
+					await fs.writeFile(
+						join('out', 'meta', 'locale.json'),
+						JSON.stringify(
+							{
+								old_keys: Object.keys(old_locales),
+								old_values: Object.values(old_locales),
+								new_keys: Object.keys(locales),
+								new_values: Object.values(locales),
+							},
+							undefined,
+							3,
+						),
+					)
+				}
+				await fs.writeFile(
+					join('out', 'locale', 'en-us.json'),
+					JSON.stringify(locales, undefined, 3),
+				)
+			}
+		}
+
+		console.log(`Generated JSON files with ${errors} errors.`)
+
+		await service.project.close()
+	},
+).command('update_locales', 'Attempt automatic upgrade of locales.', update_locales).strict()
+	.demandCommand(1).parse()

--- a/packages/mcdoc-cli/src/index.ts
+++ b/packages/mcdoc-cli/src/index.ts
@@ -7,12 +7,7 @@ import walk from 'klaw'
 import yargs from 'yargs'
 import { hideBin } from 'yargs/helpers'
 
-import {
-	ConfigService,
-	fileUtil,
-	Service,
-	VanillaConfig,
-} from '@spyglassmc/core'
+import { ConfigService, fileUtil, Service, VanillaConfig } from '@spyglassmc/core'
 import { NodeJsExternals } from '@spyglassmc/core/lib/nodejs.js'
 import * as mcdoc from '@spyglassmc/mcdoc'
 
@@ -52,14 +47,12 @@ await CLI.scriptName('mcdoc')
 			).options({
 				'locale': {
 					alias: 'l',
-					description:
-						'en-us language key-value store of all doc comments.',
+					description: 'en-us language key-value store of all doc comments.',
 					default: false,
 				},
 				'module': {
 					alias: 'm',
-					description:
-						'file tree mirroring definitions; to optimize for web.',
+					description: 'file tree mirroring definitions; to optimize for web.',
 					default: false,
 				},
 				'pretty': {
@@ -94,18 +87,15 @@ await CLI.scriptName('mcdoc')
 			)
 
 			const logger: Logger = {
-				log: (...log_args: any[]) =>
-					args.verbose ? console.log(...log_args) : false,
+				log: (...log_args: any[]) => args.verbose ? console.log(...log_args) : false,
 
 				warn: (...log_args: any[]) => console.warn(...log_args),
 
 				error: (...log_args: any[]) => console.error(...log_args),
 
-				info: (...log_args: any[]) =>
-					args.verbose ? console.info(...log_args) : false,
+				info: (...log_args: any[]) => args.verbose ? console.info(...log_args) : false,
 
-				trace: (message?: any, ...params: any) =>
-					console.trace(message, ...params),
+				trace: (message?: any, ...params: any) => console.trace(message, ...params),
 			}
 
 			const project_path = resolve(process.cwd(), args.source)

--- a/packages/mcdoc-cli/src/update_locales/index.ts
+++ b/packages/mcdoc-cli/src/update_locales/index.ts
@@ -63,8 +63,8 @@ export async function update_locales() {
 	}
 	for (let i = 0; i < locales.new_keys.length; i++) {
 		if (
-			!moved_keys[locales.new_keys[i]] &&
-			!locales.old_keys.includes(locales.new_keys[i])
+			!moved_keys[locales.new_keys[i]]
+			&& !locales.old_keys.includes(locales.new_keys[i])
 		) {
 			added_keys.push([locales.new_keys[i], locales.new_values[i]])
 		}

--- a/packages/mcdoc-cli/src/update_locales/index.ts
+++ b/packages/mcdoc-cli/src/update_locales/index.ts
@@ -41,10 +41,7 @@ export async function update_locales() {
 		if (keyRemoved && valueRemoved) {
 			removed_keys.push([locales.old_keys[i], locales.old_values[i]])
 		} else if (keyRemoved && !valueRemoved) {
-			if (
-				locales.new_values.filter(value => value === locales.old_values[i])
-					.length > 1
-			) {
+			if (locales.new_values.filter(value => value === locales.old_values[i]).length > 1) {
 				removed_keys.push([locales.old_keys[i], locales.old_values[i]])
 				console.log('Duplicate key removed:', locales.old_keys[i])
 			} else {
@@ -62,10 +59,7 @@ export async function update_locales() {
 		}
 	}
 	for (let i = 0; i < locales.new_keys.length; i++) {
-		if (
-			!moved_keys[locales.new_keys[i]]
-			&& !locales.old_keys.includes(locales.new_keys[i])
-		) {
+		if (!moved_keys[locales.new_keys[i]] && !locales.old_keys.includes(locales.new_keys[i])) {
 			added_keys.push([locales.new_keys[i], locales.new_values[i]])
 		}
 	}
@@ -77,9 +71,7 @@ export async function update_locales() {
 		console.log('Moving keys')
 		for await (const locale_file of walk(join('out', 'locale'))) {
 			if (!locale_file.path.endsWith('en-us.json')) {
-				const locale = JSON.parse(
-					await fs.readFile(locale_file.path, 'utf-8'),
-				)
+				const locale = JSON.parse(await fs.readFile(locale_file.path, 'utf-8'))
 
 				let have_moved = 0
 
@@ -92,10 +84,7 @@ export async function update_locales() {
 					}
 				}
 
-				await fs.writeFile(
-					locale_file.path,
-					JSON.stringify(locale, undefined, 3),
-				)
+				await fs.writeFile(locale_file.path, JSON.stringify(locale, undefined, 3))
 
 				if (have_moved > 0) {
 					console.log(`Moved ${have_moved} keys in ${locale_file.path}`)
@@ -122,13 +111,11 @@ export async function update_locales() {
 			method: 'POST',
 			body: {
 				content: '',
-				embeds: [
-					{
-						color: 1863349,
-						title: 'mcdoc translation key values changed in en-us.json',
-						description,
-					},
-				],
+				embeds: [{
+					color: 1863349,
+					title: 'mcdoc translation key values changed in en-us.json',
+					description,
+				}],
 			},
 		})
 	}

--- a/packages/mcdoc-cli/src/update_locales/index.ts
+++ b/packages/mcdoc-cli/src/update_locales/index.ts
@@ -114,8 +114,7 @@ export async function update_locales() {
 			const isPeriod = to.slice(-1)
 
 			if (isPeriod !== '.' && from.slice(0, -1) !== to) {
-				description +=
-					`- \`${key}\` changed, before/after:\n  - \`${from}\`\n  - \`${to}\`\n`
+				description += `- \`${key}\` changed, before/after:\n  - \`${from}\`\n  - \`${to}\`\n`
 			}
 		}
 

--- a/packages/mcdoc/src/binder/index.ts
+++ b/packages/mcdoc/src/binder/index.ts
@@ -258,9 +258,7 @@ function hoist(node: ModuleNode, ctx: McdocBinderContext): void {
 				'mcdoc',
 				`${ctx.moduleIdentifier}::${identifier.value}`,
 			)
-			.ifDeclared((symbol) =>
-				reportDuplicatedDeclaration(ctx, symbol, identifier)
-			)
+			.ifDeclared((symbol) => reportDuplicatedDeclaration(ctx, symbol, identifier))
 			.elseEnter({
 				data: {
 					subcategory: 'use_statement_binding',
@@ -291,9 +289,7 @@ function hoist(node: ModuleNode, ctx: McdocBinderContext): void {
 				'mcdoc',
 				`${ctx.moduleIdentifier}::${name}`,
 			)
-			.ifDeclared((symbol) =>
-				reportDuplicatedDeclaration(ctx, symbol, identifier ?? node)
-			)
+			.ifDeclared((symbol) => reportDuplicatedDeclaration(ctx, symbol, identifier ?? node))
 			.elseEnter({
 				data: {
 					data: getData(node),
@@ -357,9 +353,7 @@ function bindTypeParamBlock(
 			const paramPath = `${ctx.moduleIdentifier}::${paramIdentifier.value}`
 			ctx.symbols
 				.query({ doc: ctx.doc, node }, 'mcdoc', paramPath)
-				.ifDeclared((symbol) =>
-					reportDuplicatedDeclaration(ctx, symbol, paramIdentifier)
-				)
+				.ifDeclared((symbol) => reportDuplicatedDeclaration(ctx, symbol, paramIdentifier))
 				.elseEnter({
 					data: { visibility: SymbolVisibility.Block },
 					usage: {
@@ -382,8 +376,7 @@ async function bindDispatchStatement(
 	node: DispatchStatementNode,
 	ctx: McdocBinderContext,
 ): Promise<void> {
-	const { attributes, location, index, target, typeParams } =
-		DispatchStatementNode.destruct(node)
+	const { attributes, location, index, target, typeParams } = DispatchStatementNode.destruct(node)
 	if (!(location && index && target)) {
 		return
 	}
@@ -413,8 +406,7 @@ async function bindDispatchStatement(
 				.query(ctx.doc, 'mcdoc/dispatcher', locationStr, asString(key))
 				.ifDeclared((symbol) =>
 					reportDuplicatedDeclaration(ctx, symbol, key, {
-						localeString:
-							'mcdoc.binder.dispatcher-statement.duplicated-key',
+						localeString: 'mcdoc.binder.dispatcher-statement.duplicated-key',
 					})
 				)
 				.elseEnter({
@@ -583,9 +575,7 @@ function bindEnumBlock(
 		const { identifier } = EnumFieldNode.destruct(field)
 		query.member(identifier.value, (fieldQuery) =>
 			fieldQuery
-				.ifDeclared((symbol) =>
-					reportDuplicatedDeclaration(ctx, symbol, identifier)
-				)
+				.ifDeclared((symbol) => reportDuplicatedDeclaration(ctx, symbol, identifier))
 				.elseEnter({
 					usage: {
 						type: 'definition',
@@ -640,9 +630,7 @@ async function bindStructBlock(
 			if (!StructMapKeyNode.is(key)) {
 				query.member(key.value, (fieldQuery) =>
 					fieldQuery
-						.ifDeclared((symbol) =>
-							reportDuplicatedDeclaration(ctx, symbol, key)
-						)
+						.ifDeclared((symbol) => reportDuplicatedDeclaration(ctx, symbol, key))
 						.elseEnter({
 							usage: { type: 'definition', node: key, fullRange: field },
 						}))

--- a/packages/mcdoc/src/binder/index.ts
+++ b/packages/mcdoc/src/binder/index.ts
@@ -106,9 +106,9 @@ interface ModuleSymbolData {
 namespace ModuleSymbolData {
 	export function is(data: unknown): data is ModuleSymbolData {
 		return (
-			!!data &&
-			typeof data === 'object' &&
-			typeof (data as ModuleSymbolData).nextAnonymousIndex === 'number'
+			!!data
+			&& typeof data === 'object'
+			&& typeof (data as ModuleSymbolData).nextAnonymousIndex === 'number'
 		)
 	}
 }
@@ -119,9 +119,9 @@ export interface TypeDefSymbolData {
 export namespace TypeDefSymbolData {
 	export function is(data: unknown): data is TypeDefSymbolData {
 		return (
-			!!data &&
-			typeof data === 'object' &&
-			typeof (data as TypeDefSymbolData).typeDef === 'object'
+			!!data
+			&& typeof data === 'object'
+			&& typeof (data as TypeDefSymbolData).typeDef === 'object'
 		)
 	}
 }
@@ -799,8 +799,8 @@ function identifierToUri(
 function uriToIdentifier(uri: string, ctx: CheckerContext): string | undefined {
 	return Object.values(ctx.symbols.global.mcdoc ?? {}).find((symbol) => {
 		return (
-			symbol.subcategory === 'module' &&
-			symbol.definition?.some((loc) => loc.uri === uri)
+			symbol.subcategory === 'module'
+			&& symbol.definition?.some((loc) => loc.uri === uri)
 		)
 	})?.identifier
 }
@@ -1022,9 +1022,9 @@ function convertEnum(node: EnumNode, ctx: McdocBinderContext): McdocType {
 	// Shortcut if the typeDef has been added to the enum symbol.
 	const symbol = identifier?.symbol ?? node.symbol
 	if (
-		symbol &&
-		TypeDefSymbolData.is(symbol.data) &&
-		symbol.data.typeDef.kind === 'enum'
+		symbol
+		&& TypeDefSymbolData.is(symbol.data)
+		&& symbol.data.typeDef.kind === 'enum'
 	) {
 		return symbol.data.typeDef
 	}
@@ -1077,9 +1077,9 @@ function convertStruct(node: StructNode, ctx: McdocBinderContext): McdocType {
 	// Shortcut if the typeDef has been added to the struct symbol.
 	const symbol = identifier?.symbol ?? node.symbol
 	if (
-		symbol &&
-		TypeDefSymbolData.is(symbol.data) &&
-		symbol.data.typeDef.kind === 'struct'
+		symbol
+		&& TypeDefSymbolData.is(symbol.data)
+		&& symbol.data.typeDef.kind === 'struct'
 	) {
 		return symbol.data.typeDef
 	}
@@ -1253,8 +1253,8 @@ function convertLiteralValue(
 	} else if (TypedNumberNode.is(node)) {
 		const { suffix, value } = TypedNumberNode.destruct(node)
 		return {
-			kind: convertLiteralNumberSuffix(suffix, ctx) ??
-				(value.type === 'integer'
+			kind: convertLiteralNumberSuffix(suffix, ctx)
+				?? (value.type === 'integer'
 					? 'int'
 					: 'double'),
 			value: value.value,

--- a/packages/mcdoc/src/binder/index.ts
+++ b/packages/mcdoc/src/binder/index.ts
@@ -105,11 +105,9 @@ interface ModuleSymbolData {
 }
 namespace ModuleSymbolData {
 	export function is(data: unknown): data is ModuleSymbolData {
-		return (
-			!!data
+		return (!!data
 			&& typeof data === 'object'
-			&& typeof (data as ModuleSymbolData).nextAnonymousIndex === 'number'
-		)
+			&& typeof (data as ModuleSymbolData).nextAnonymousIndex === 'number')
 	}
 }
 
@@ -118,11 +116,9 @@ export interface TypeDefSymbolData {
 }
 export namespace TypeDefSymbolData {
 	export function is(data: unknown): data is TypeDefSymbolData {
-		return (
-			!!data
+		return (!!data
 			&& typeof data === 'object'
-			&& typeof (data as TypeDefSymbolData).typeDef === 'object'
-		)
+			&& typeof (data as TypeDefSymbolData).typeDef === 'object')
 	}
 }
 
@@ -137,21 +133,15 @@ export const fileModule = AsyncBinder.create<ModuleNode>(async (node, ctx) => {
 		return
 	}
 
-	const mcdocCtx: McdocBinderContext = {
-		...ctx,
-		moduleIdentifier,
-	}
+	const mcdocCtx: McdocBinderContext = { ...ctx, moduleIdentifier }
 	return module_(node, mcdocCtx)
 })
 
-export async function module_(
-	node: ModuleNode,
-	ctx: McdocBinderContext,
-): Promise<void> {
+export async function module_(node: ModuleNode, ctx: McdocBinderContext): Promise<void> {
 	const data: ModuleSymbolData = { nextAnonymousIndex: 0 }
-	ctx.symbols
-		.query({ doc: ctx.doc, node }, 'mcdoc', ctx.moduleIdentifier)
-		.amend({ data: { data } })
+	ctx.symbols.query({ doc: ctx.doc, node }, 'mcdoc', ctx.moduleIdentifier).amend({
+		data: { data },
+	})
 
 	hoist(node, ctx)
 
@@ -183,38 +173,29 @@ export async function module_(
  * Hoist enums, structs, type aliases, and use statements under the module scope.
  */
 function hoist(node: ModuleNode, ctx: McdocBinderContext): void {
-	traversePreOrder(
-		node,
-		() => true,
-		TopLevelNode.is,
-		(child) => {
-			switch (child.type) {
-				case 'mcdoc:enum':
-					hoistEnum(child)
-					break
-				case 'mcdoc:struct':
-					hoistStruct(child)
-					break
-				case 'mcdoc:type_alias':
-					hoistTypeAlias(child)
-					break
-				case 'mcdoc:use_statement':
-					hoistUseStatement(child)
-					break
-			}
-		},
-	)
+	traversePreOrder(node, () => true, TopLevelNode.is, (child) => {
+		switch (child.type) {
+			case 'mcdoc:enum':
+				hoistEnum(child)
+				break
+			case 'mcdoc:struct':
+				hoistStruct(child)
+				break
+			case 'mcdoc:type_alias':
+				hoistTypeAlias(child)
+				break
+			case 'mcdoc:use_statement':
+				hoistUseStatement(child)
+				break
+		}
+	})
 
 	function hoistEnum(node: EnumNode) {
-		hoistFor('enum', node, EnumNode.destruct, (n) => ({
-			typeDef: convertEnum(n, ctx),
-		}))
+		hoistFor('enum', node, EnumNode.destruct, (n) => ({ typeDef: convertEnum(n, ctx) }))
 	}
 
 	function hoistStruct(node: StructNode) {
-		hoistFor('struct', node, StructNode.destruct, (n) => ({
-			typeDef: convertStruct(n, ctx),
-		}))
+		hoistFor('struct', node, StructNode.destruct, (n) => ({ typeDef: convertStruct(n, ctx) }))
 	}
 
 	function hoistTypeAlias(node: TypeAliasNode) {
@@ -252,50 +233,34 @@ function hoist(node: ModuleNode, ctx: McdocBinderContext): void {
 		// they will go to the definition in the imported file.
 
 		const target = resolvePath(path, ctx)
-		ctx.symbols
-			.query(
-				{ doc: ctx.doc, node },
-				'mcdoc',
-				`${ctx.moduleIdentifier}::${identifier.value}`,
-			)
-			.ifDeclared((symbol) => reportDuplicatedDeclaration(ctx, symbol, identifier))
-			.elseEnter({
-				data: {
-					subcategory: 'use_statement_binding',
-					visibility: SymbolVisibility.File,
-					data: target
-						? { target } satisfies UseStatementBindingData
-						: undefined,
-				},
-				usage: { type: 'definition', node: identifier, fullRange: node },
-			})
+		ctx.symbols.query(
+			{ doc: ctx.doc, node },
+			'mcdoc',
+			`${ctx.moduleIdentifier}::${identifier.value}`,
+		).ifDeclared((symbol) => reportDuplicatedDeclaration(ctx, symbol, identifier)).elseEnter({
+			data: {
+				subcategory: 'use_statement_binding',
+				visibility: SymbolVisibility.File,
+				data: target ? { target } satisfies UseStatementBindingData : undefined,
+			},
+			usage: { type: 'definition', node: identifier, fullRange: node },
+		})
 	}
 
 	function hoistFor<N extends AstNode>(
 		subcategory: 'enum' | 'struct' | 'type_alias',
 		node: N,
-		destructor: (node: N) => {
-			docComments?: DocCommentsNode
-			keyword: LiteralNode
-			identifier?: IdentifierNode
-		},
+		destructor: (
+			node: N,
+		) => { docComments?: DocCommentsNode; keyword: LiteralNode; identifier?: IdentifierNode },
 		getData: (node: N) => unknown,
 	) {
 		const { docComments, identifier, keyword } = destructor(node)
 		const name = identifier?.value ?? nextAnonymousIdentifier(node, ctx)
-		ctx.symbols
-			.query(
-				{ doc: ctx.doc, node },
-				'mcdoc',
-				`${ctx.moduleIdentifier}::${name}`,
-			)
+		ctx.symbols.query({ doc: ctx.doc, node }, 'mcdoc', `${ctx.moduleIdentifier}::${name}`)
 			.ifDeclared((symbol) => reportDuplicatedDeclaration(ctx, symbol, identifier ?? node))
 			.elseEnter({
-				data: {
-					data: getData(node),
-					desc: DocCommentsNode.asText(docComments),
-					subcategory,
-				},
+				data: { data: getData(node), desc: DocCommentsNode.asText(docComments), subcategory },
 				// If the current syntax structure is named, then the identifier node is entered as a definition;
 				// otherwise, an anonymous identifier is generated for the symbol and the keyword node is entered as a definition.
 				usage: {
@@ -307,9 +272,9 @@ function hoist(node: ModuleNode, ctx: McdocBinderContext): void {
 	}
 
 	function nextAnonymousIndex(node: AstNode, ctx: McdocBinderContext): number {
-		const data = ctx.symbols
-			.query({ doc: ctx.doc, node }, 'mcdoc', ctx.moduleIdentifier)
-			.getData(ModuleSymbolData.is)
+		const data = ctx.symbols.query({ doc: ctx.doc, node }, 'mcdoc', ctx.moduleIdentifier).getData(
+			ModuleSymbolData.is,
+		)
 		if (!data) {
 			throw new Error(`No symbol data for module '${ctx.moduleIdentifier}'`)
 		}
@@ -317,10 +282,7 @@ function hoist(node: ModuleNode, ctx: McdocBinderContext): void {
 		return data.nextAnonymousIndex++
 	}
 
-	function nextAnonymousIdentifier(
-		node: AstNode,
-		ctx: McdocBinderContext,
-	): string {
+	function nextAnonymousIdentifier(node: AstNode, ctx: McdocBinderContext): string {
 		return `<anonymous ${nextAnonymousIndex(node, ctx)}>`
 	}
 }
@@ -339,11 +301,7 @@ function bindTypeParamBlock(
 	node.locals = Object.create(null)
 
 	// They are also added to the type definition.
-	data.typeDef = {
-		kind: 'template',
-		child: data.typeDef,
-		typeParams: [],
-	}
+	data.typeDef = { kind: 'template', child: data.typeDef, typeParams: [] }
 
 	const { params } = TypeParamBlockNode.destruct(typeParams)
 	for (const param of params) {
@@ -351,17 +309,12 @@ function bindTypeParamBlock(
 		if (paramIdentifier.value) {
 			// Add the type parameter as a local symbol.
 			const paramPath = `${ctx.moduleIdentifier}::${paramIdentifier.value}`
-			ctx.symbols
-				.query({ doc: ctx.doc, node }, 'mcdoc', paramPath)
-				.ifDeclared((symbol) => reportDuplicatedDeclaration(ctx, symbol, paramIdentifier))
-				.elseEnter({
-					data: { visibility: SymbolVisibility.Block },
-					usage: {
-						type: 'declaration',
-						node: paramIdentifier,
-						fullRange: param,
-					},
-				})
+			ctx.symbols.query({ doc: ctx.doc, node }, 'mcdoc', paramPath).ifDeclared((symbol) =>
+				reportDuplicatedDeclaration(ctx, symbol, paramIdentifier)
+			).elseEnter({
+				data: { visibility: SymbolVisibility.Block },
+				usage: { type: 'declaration', node: paramIdentifier, fullRange: param },
+			})
 
 			// Also add it to the type definition.
 			data.typeDef.typeParams.push({ path: paramPath })
@@ -388,9 +341,7 @@ async function bindDispatchStatement(
 
 	const { parallelIndices } = IndexBodyNode.destruct(index)
 	if (parallelIndices.length) {
-		const data: TypeDefSymbolData = {
-			typeDef: convertType(target, ctx),
-		}
+		const data: TypeDefSymbolData = { typeDef: convertType(target, ctx) }
 		if (typeParams) {
 			bindTypeParamBlock(node, typeParams, data, ctx)
 		}
@@ -402,27 +353,20 @@ async function bindDispatchStatement(
 				continue
 			}
 
-			ctx.symbols
-				.query(ctx.doc, 'mcdoc/dispatcher', locationStr, asString(key))
-				.ifDeclared((symbol) =>
-					reportDuplicatedDeclaration(ctx, symbol, key, {
-						localeString: 'mcdoc.binder.dispatcher-statement.duplicated-key',
-					})
-				)
-				.elseEnter({
-					data: { data },
-					usage: { type: 'definition', node: key, fullRange: node },
+			ctx.symbols.query(ctx.doc, 'mcdoc/dispatcher', locationStr, asString(key)).ifDeclared((
+				symbol,
+			) =>
+				reportDuplicatedDeclaration(ctx, symbol, key, {
+					localeString: 'mcdoc.binder.dispatcher-statement.duplicated-key',
 				})
+			).elseEnter({ data: { data }, usage: { type: 'definition', node: key, fullRange: node } })
 		}
 	}
 
 	await bindType(target, ctx)
 }
 
-async function bindType(
-	node: TypeNode,
-	ctx: McdocBinderContext,
-): Promise<void> {
+async function bindType(node: TypeNode, ctx: McdocBinderContext): Promise<void> {
 	if (DispatcherTypeNode.is(node)) {
 		await bindDispatcherType(node, ctx)
 	} else if (EnumNode.is(node)) {
@@ -464,9 +408,9 @@ async function bindDispatcherType(
 ): Promise<void> {
 	const { index, location } = DispatcherTypeNode.destruct(node)
 	const locationStr = ResourceLocationNode.toString(location, 'full')
-	ctx.symbols
-		.query(ctx.doc, 'mcdoc/dispatcher', locationStr)
-		.enter({ usage: { type: 'reference', node: location, fullRange: node } })
+	ctx.symbols.query(ctx.doc, 'mcdoc/dispatcher', locationStr).enter({
+		usage: { type: 'reference', node: location, fullRange: node },
+	})
 
 	const { parallelIndices } = IndexBodyNode.destruct(index)
 	for (const key of parallelIndices) {
@@ -476,22 +420,17 @@ async function bindDispatcherType(
 			continue
 		}
 
-		ctx.symbols
-			.query(ctx.doc, 'mcdoc/dispatcher', locationStr, asString(key))
-			.enter({ usage: { type: 'reference', node: key, fullRange: node } })
+		ctx.symbols.query(ctx.doc, 'mcdoc/dispatcher', locationStr, asString(key)).enter({
+			usage: { type: 'reference', node: key, fullRange: node },
+		})
 	}
 }
 
-async function bindPath(
-	node: PathNode,
-	ctx: McdocBinderContext,
-): Promise<void> {
+async function bindPath(node: PathNode, ctx: McdocBinderContext): Promise<void> {
 	for (
-		const { identifiers, node: identNode, indexRight } of resolvePathByStep(
-			node,
-			ctx,
-			{ reportErrors: true },
-		)
+		const { identifiers, node: identNode, indexRight } of resolvePathByStep(node, ctx, {
+			reportErrors: true,
+		})
 	) {
 		if (!identifiers?.length) {
 			continue
@@ -503,10 +442,7 @@ async function bindPath(
 			const referencedModuleUri = identifierToUri(referencedModuleFile, ctx)
 			if (!referencedModuleUri) {
 				ctx.err.report(
-					localize(
-						'mcdoc.binder.path.unknown-module',
-						localeQuote(referencedModuleFile),
-					),
+					localize('mcdoc.binder.path.unknown-module', localeQuote(referencedModuleFile)),
 					node,
 					ErrorSeverity.Warning,
 				)
@@ -516,12 +452,7 @@ async function bindPath(
 			await ctx.ensureBindingStarted(referencedModuleUri)
 		}
 
-		ctx.symbols
-			.query(
-				{ doc: ctx.doc, node: identNode },
-				'mcdoc',
-				pathArrayToString(identifiers),
-			)
+		ctx.symbols.query({ doc: ctx.doc, node: identNode }, 'mcdoc', pathArrayToString(identifiers))
 			.ifDeclared((_, query) =>
 				query.enter({
 					usage: {
@@ -531,8 +462,7 @@ async function bindPath(
 						skipRenaming: LiteralNode.is(identNode),
 					},
 				})
-			)
-			.else(() => {
+			).else(() => {
 				if (indexRight === 0) {
 					ctx.err.report(
 						localize(
@@ -555,11 +485,7 @@ function bindEnum(node: EnumNode, ctx: McdocBinderContext): void {
 		return
 	}
 
-	const query = ctx.symbols.query(
-		{ doc: ctx.doc, node },
-		'mcdoc',
-		...symbol.path,
-	)
+	const query = ctx.symbols.query({ doc: ctx.doc, node }, 'mcdoc', ...symbol.path)
 	Dev.assertDefined(query.symbol)
 	bindEnumBlock(block, ctx, query)
 }
@@ -573,23 +499,16 @@ function bindEnumBlock(
 	const { fields } = EnumBlockNode.destruct(node)
 	for (const field of fields) {
 		const { identifier } = EnumFieldNode.destruct(field)
-		query.member(identifier.value, (fieldQuery) =>
-			fieldQuery
-				.ifDeclared((symbol) => reportDuplicatedDeclaration(ctx, symbol, identifier))
-				.elseEnter({
-					usage: {
-						type: 'definition',
-						node: identifier,
-						fullRange: field,
-					},
-				}))
+		query.member(
+			identifier.value,
+			(fieldQuery) =>
+				fieldQuery.ifDeclared((symbol) => reportDuplicatedDeclaration(ctx, symbol, identifier))
+					.elseEnter({ usage: { type: 'definition', node: identifier, fullRange: field } }),
+		)
 	}
 }
 
-async function bindInjection(
-	node: InjectionNode,
-	ctx: McdocBinderContext,
-): Promise<void> {
+async function bindInjection(node: InjectionNode, ctx: McdocBinderContext): Promise<void> {
 	const { injection } = InjectionNode.destruct(node)
 	if (EnumInjectionNode.is(injection)) {
 		// TODO
@@ -598,21 +517,14 @@ async function bindInjection(
 	}
 }
 
-async function bindStruct(
-	node: StructNode,
-	ctx: McdocBinderContext,
-): Promise<void> {
+async function bindStruct(node: StructNode, ctx: McdocBinderContext): Promise<void> {
 	const { block, identifier, keyword } = StructNode.destruct(node)
 	const symbol = identifier?.symbol ?? keyword.symbol
 	if (symbol?.subcategory !== 'struct') {
 		return
 	}
 
-	const query = ctx.symbols.query(
-		{ doc: ctx.doc, node },
-		'mcdoc',
-		...symbol.path,
-	)
+	const query = ctx.symbols.query({ doc: ctx.doc, node }, 'mcdoc', ...symbol.path)
 	Dev.assertDefined(query.symbol)
 	await bindStructBlock(block, ctx, query)
 }
@@ -628,12 +540,12 @@ async function bindStructBlock(
 		if (StructPairFieldNode.is(field)) {
 			const { key, type } = StructPairFieldNode.destruct(field)
 			if (!StructMapKeyNode.is(key)) {
-				query.member(key.value, (fieldQuery) =>
-					fieldQuery
-						.ifDeclared((symbol) => reportDuplicatedDeclaration(ctx, symbol, key))
-						.elseEnter({
-							usage: { type: 'definition', node: key, fullRange: field },
-						}))
+				query.member(
+					key.value,
+					(fieldQuery) =>
+						fieldQuery.ifDeclared((symbol) => reportDuplicatedDeclaration(ctx, symbol, key))
+							.elseEnter({ usage: { type: 'definition', node: key, fullRange: field } }),
+				)
 			}
 			await bindType(type, ctx)
 		} else {
@@ -643,10 +555,7 @@ async function bindStructBlock(
 	}
 }
 
-async function bindTypeAlias(
-	node: TypeAliasNode,
-	ctx: McdocBinderContext,
-): Promise<void> {
+async function bindTypeAlias(node: TypeAliasNode, ctx: McdocBinderContext): Promise<void> {
 	const { identifier, rhs, typeParams } = TypeAliasNode.destruct(node)
 	if (!identifier?.value) {
 		return
@@ -657,10 +566,7 @@ async function bindTypeAlias(
 	}
 }
 
-async function bindUseStatement(
-	node: UseStatementNode,
-	ctx: McdocBinderContext,
-): Promise<void> {
+async function bindUseStatement(node: UseStatementNode, ctx: McdocBinderContext): Promise<void> {
 	const { path } = UseStatementNode.destruct(node)
 	if (!path) {
 		return
@@ -688,15 +594,10 @@ function reportDuplicatedDeclaration(
 		range,
 		ErrorSeverity.Warning,
 		{
-			related: [
-				{
-					location: SymbolUtil.getDeclaredLocation(symbol) as Location,
-					message: localize(
-						`${options.localeString}.related`,
-						localeQuote(symbol.identifier),
-					),
-				},
-			],
+			related: [{
+				location: SymbolUtil.getDeclaredLocation(symbol) as Location,
+				message: localize(`${options.localeString}.related`, localeQuote(symbol.identifier)),
+			}],
 		},
 	)
 }
@@ -705,16 +606,16 @@ function* resolvePathByStep(
 	path: PathNode,
 	ctx: McdocBinderContext,
 	options: { reportErrors?: boolean } = {},
-): Generator<{
-	identifiers: readonly string[]
-	node: IdentifierNode | LiteralNode
-	index: number
-	indexRight: number
-}> {
+): Generator<
+	{
+		identifiers: readonly string[]
+		node: IdentifierNode | LiteralNode
+		index: number
+		indexRight: number
+	}
+> {
 	const { children, isAbsolute } = PathNode.destruct(path)
-	let identifiers: string[] = isAbsolute
-		? []
-		: pathStringToArray(ctx.moduleIdentifier)
+	let identifiers: string[] = isAbsolute ? [] : pathStringToArray(ctx.moduleIdentifier)
 	for (const [i, child] of children.entries()) {
 		const indexRight = children.length - 1 - i
 		switch (child.type) {
@@ -728,16 +629,11 @@ function* resolvePathByStep(
 				identifiers.push(child.value)
 				if (indexRight === 0) {
 					ctx.symbols.query(
-						{
-							doc: ctx.doc,
-							node: child,
-						},
+						{ doc: ctx.doc, node: child },
 						'mcdoc',
 						pathArrayToString(identifiers),
 					).ifDeclared((symbol) => {
-						const data = symbol.data as
-							| UseStatementBindingData
-							| undefined
+						const data = symbol.data as UseStatementBindingData | undefined
 						if (data?.target) {
 							identifiers = [...data.target]
 						}
@@ -748,10 +644,7 @@ function* resolvePathByStep(
 				// super
 				if (identifiers.length === 0) {
 					if (options.reportErrors) {
-						ctx.err.report(
-							localize('mcdoc.binder.path.super-from-root'),
-							child,
-						)
+						ctx.err.report(localize('mcdoc.binder.path.super-from-root'), child)
 					}
 					return
 				}
@@ -760,12 +653,7 @@ function* resolvePathByStep(
 			default:
 				Dev.assertNever(child)
 		}
-		yield {
-			identifiers,
-			node: child,
-			index: i,
-			indexRight,
-		}
+		yield { identifiers, node: child, index: i, indexRight }
 	}
 }
 
@@ -777,29 +665,19 @@ function resolvePath(
 	return atArray([...resolvePathByStep(path, ctx, options)], -1)?.identifiers
 }
 
-function identifierToUri(
-	module: string,
-	ctx: McdocBinderContext,
-): string | undefined {
+function identifierToUri(module: string, ctx: McdocBinderContext): string | undefined {
 	return ctx.symbols.global.mcdoc?.[module]?.definition?.[0]?.uri
 }
 
 function uriToIdentifier(uri: string, ctx: CheckerContext): string | undefined {
 	return Object.values(ctx.symbols.global.mcdoc ?? {}).find((symbol) => {
-		return (
-			symbol.subcategory === 'module'
-			&& symbol.definition?.some((loc) => loc.uri === uri)
-		)
+		return (symbol.subcategory === 'module' && symbol.definition?.some((loc) => loc.uri === uri))
 	})?.identifier
 }
 
 function pathArrayToString(path: readonly string[]): string
-function pathArrayToString(
-	path: readonly string[] | undefined,
-): string | undefined
-function pathArrayToString(
-	path: readonly string[] | undefined,
-): string | undefined {
+function pathArrayToString(path: readonly string[] | undefined): string | undefined
+function pathArrayToString(path: readonly string[] | undefined): string | undefined {
 	return path ? `::${path.join('::')}` : undefined
 }
 
@@ -858,17 +736,9 @@ function wrapType(
 				continue
 			}
 
-			ans = {
-				kind: 'indexed',
-				child: ans,
-				parallelIndices: convertIndexBody(appendix, ctx),
-			}
+			ans = { kind: 'indexed', child: ans, parallelIndices: convertIndexBody(appendix, ctx) }
 		} else {
-			ans = {
-				kind: 'concrete',
-				child: ans,
-				typeArgs: convertTypeArgBlock(appendix, ctx),
-			}
+			ans = { kind: 'concrete', child: ans, typeArgs: convertTypeArgBlock(appendix, ctx) }
 		}
 	}
 	ans.attributes = convertAttributes(attributes, ctx)
@@ -900,35 +770,20 @@ function undefineEmptyArray<T>(array: T[]): T[] | undefined {
 	return array.length ? array : undefined
 }
 
-function convertAttribute(
-	node: AttributeNode,
-	ctx: McdocBinderContext,
-): Attribute {
+function convertAttribute(node: AttributeNode, ctx: McdocBinderContext): Attribute {
 	const { name, value } = AttributeNode.destruct(node)
-	return {
-		name: name.value,
-		value: value && convertAttributeValue(value, ctx),
-	}
+	return { name: name.value, value: value && convertAttributeValue(value, ctx) }
 }
 
-function convertAttributeValue(
-	node: AttributeValueNode,
-	ctx: McdocBinderContext,
-): AttributeValue {
+function convertAttributeValue(node: AttributeValueNode, ctx: McdocBinderContext): AttributeValue {
 	if (node.type === 'mcdoc:attribute/tree') {
-		return {
-			kind: 'tree',
-			values: convertAttributeTree(node, ctx),
-		}
+		return { kind: 'tree', values: convertAttributeTree(node, ctx) }
 	} else {
 		return convertType(node, ctx)
 	}
 }
 
-function convertAttributeTree(
-	node: AttributeTreeNode,
-	ctx: McdocBinderContext,
-): AttributeTree {
+function convertAttributeTree(node: AttributeTreeNode, ctx: McdocBinderContext): AttributeTree {
 	const ans: AttributeTree = {}
 	const { named, positional } = AttributeTreeNode.destruct(node)
 
@@ -956,34 +811,20 @@ function convertIndexBodies(
 	return undefineEmptyArray(nodes.map((n) => convertIndexBody(n, ctx)))
 }
 
-function convertIndexBody(
-	node: IndexBodyNode,
-	ctx: McdocBinderContext,
-): ParallelIndices {
+function convertIndexBody(node: IndexBodyNode, ctx: McdocBinderContext): ParallelIndices {
 	const { parallelIndices } = IndexBodyNode.destruct(node)
 	return parallelIndices.map((n) => convertIndex(n, ctx))
 }
 
 function convertIndex(node: IndexNode, ctx: McdocBinderContext): Index {
-	return StaticIndexNode.is(node)
-		? convertStaticIndex(node, ctx)
-		: convertDynamicIndex(node, ctx)
+	return StaticIndexNode.is(node) ? convertStaticIndex(node, ctx) : convertDynamicIndex(node, ctx)
 }
 
-function convertStaticIndex(
-	node: StaticIndexNode,
-	ctx: McdocBinderContext,
-): StaticIndex {
-	return {
-		kind: 'static',
-		value: asString(node),
-	}
+function convertStaticIndex(node: StaticIndexNode, ctx: McdocBinderContext): StaticIndex {
+	return { kind: 'static', value: asString(node) }
 }
 
-function convertDynamicIndex(
-	node: DynamicIndexNode,
-	ctx: McdocBinderContext,
-): DynamicIndex {
+function convertDynamicIndex(node: DynamicIndexNode, ctx: McdocBinderContext): DynamicIndex {
 	const { keys } = DynamicIndexNode.destruct(node)
 	return {
 		kind: 'dynamic',
@@ -996,10 +837,7 @@ function convertDynamicIndex(
 	}
 }
 
-function convertTypeArgBlock(
-	node: TypeArgBlockNode,
-	ctx: McdocBinderContext,
-): McdocType[] {
+function convertTypeArgBlock(node: TypeArgBlockNode, ctx: McdocBinderContext): McdocType[] {
 	const { args } = TypeArgBlockNode.destruct(node)
 	return args.map((a) => convertType(a, ctx))
 }
@@ -1009,37 +847,19 @@ function convertEnum(node: EnumNode, ctx: McdocBinderContext): McdocType {
 
 	// Shortcut if the typeDef has been added to the enum symbol.
 	const symbol = identifier?.symbol ?? node.symbol
-	if (
-		symbol
-		&& TypeDefSymbolData.is(symbol.data)
-		&& symbol.data.typeDef.kind === 'enum'
-	) {
+	if (symbol && TypeDefSymbolData.is(symbol.data) && symbol.data.typeDef.kind === 'enum') {
 		return symbol.data.typeDef
 	}
 
-	return wrapType(
-		node,
-		{
-			kind: 'enum',
-			enumKind,
-			values: convertEnumBlock(block, ctx),
-		},
-		ctx,
-	)
+	return wrapType(node, { kind: 'enum', enumKind, values: convertEnumBlock(block, ctx) }, ctx)
 }
 
-function convertEnumBlock(
-	node: EnumBlockNode,
-	ctx: McdocBinderContext,
-): EnumTypeField[] {
+function convertEnumBlock(node: EnumBlockNode, ctx: McdocBinderContext): EnumTypeField[] {
 	const { fields } = EnumBlockNode.destruct(node)
 	return fields.map((n) => convertEnumField(n, ctx))
 }
 
-function convertEnumField(
-	node: EnumFieldNode,
-	ctx: McdocBinderContext,
-): EnumTypeField {
+function convertEnumField(node: EnumFieldNode, ctx: McdocBinderContext): EnumTypeField {
 	const { attributes, identifier, value } = EnumFieldNode.destruct(node)
 	return {
 		attributes: convertAttributes(attributes, ctx),
@@ -1048,10 +868,7 @@ function convertEnumField(
 	}
 }
 
-function convertEnumValue(
-	node: EnumValueNode,
-	ctx: McdocBinderContext,
-): string | number {
+function convertEnumValue(node: EnumValueNode, ctx: McdocBinderContext): string | number {
 	if (TypedNumberNode.is(node)) {
 		const { value } = TypedNumberNode.destruct(node)
 		return value.value
@@ -1064,36 +881,19 @@ function convertStruct(node: StructNode, ctx: McdocBinderContext): McdocType {
 
 	// Shortcut if the typeDef has been added to the struct symbol.
 	const symbol = identifier?.symbol ?? node.symbol
-	if (
-		symbol
-		&& TypeDefSymbolData.is(symbol.data)
-		&& symbol.data.typeDef.kind === 'struct'
-	) {
+	if (symbol && TypeDefSymbolData.is(symbol.data) && symbol.data.typeDef.kind === 'struct') {
 		return symbol.data.typeDef
 	}
 
-	return wrapType(
-		node,
-		{
-			kind: 'struct',
-			fields: convertStructBlock(block, ctx),
-		},
-		ctx,
-	)
+	return wrapType(node, { kind: 'struct', fields: convertStructBlock(block, ctx) }, ctx)
 }
 
-function convertStructBlock(
-	node: StructBlockNode,
-	ctx: McdocBinderContext,
-): StructTypeField[] {
+function convertStructBlock(node: StructBlockNode, ctx: McdocBinderContext): StructTypeField[] {
 	const { fields } = StructBlockNode.destruct(node)
 	return fields.map((n) => convertStructField(n, ctx))
 }
 
-function convertStructField(
-	node: StructFieldNode,
-	ctx: McdocBinderContext,
-): StructTypeField {
+function convertStructField(node: StructFieldNode, ctx: McdocBinderContext): StructTypeField {
 	return StructPairFieldNode.is(node)
 		? convertStructPairField(node, ctx)
 		: convertStructSpreadField(node, ctx)
@@ -1103,9 +903,7 @@ function convertStructPairField(
 	node: StructPairFieldNode,
 	ctx: McdocBinderContext,
 ): StructTypePairField {
-	const { attributes, key, type, isOptional } = StructPairFieldNode.destruct(
-		node,
-	)
+	const { attributes, key, type, isOptional } = StructPairFieldNode.destruct(node)
 	return {
 		kind: 'pair',
 		attributes: convertAttributes(attributes, ctx),
@@ -1115,10 +913,7 @@ function convertStructPairField(
 	}
 }
 
-function convertStructKey(
-	node: StructKeyNode,
-	ctx: McdocBinderContext,
-): string | McdocType {
+function convertStructKey(node: StructKeyNode, ctx: McdocBinderContext): string | McdocType {
 	if (StructMapKeyNode.is(node)) {
 		const { type } = StructMapKeyNode.destruct(node)
 		return convertType(type, ctx)
@@ -1140,32 +935,14 @@ function convertStructSpreadField(
 }
 
 function convertAny(node: AnyTypeNode, ctx: McdocBinderContext): McdocType {
-	return wrapType(
-		node,
-		{
-			kind: 'any',
-		},
-		ctx,
-	)
+	return wrapType(node, { kind: 'any' }, ctx)
 }
 
-function convertBoolean(
-	node: BooleanTypeNode,
-	ctx: McdocBinderContext,
-): McdocType {
-	return wrapType(
-		node,
-		{
-			kind: 'boolean',
-		},
-		ctx,
-	)
+function convertBoolean(node: BooleanTypeNode, ctx: McdocBinderContext): McdocType {
+	return wrapType(node, { kind: 'boolean' }, ctx)
 }
 
-function convertDispatcher(
-	node: DispatcherTypeNode,
-	ctx: McdocBinderContext,
-): McdocType {
+function convertDispatcher(node: DispatcherTypeNode, ctx: McdocBinderContext): McdocType {
 	const { index, location } = DispatcherTypeNode.destruct(node)
 	return wrapType(
 		node,
@@ -1181,21 +958,14 @@ function convertDispatcher(
 
 function convertList(node: ListTypeNode, ctx: McdocBinderContext): McdocType {
 	const { item, lengthRange } = ListTypeNode.destruct(node)
-	return wrapType(
-		node,
-		{
-			kind: 'list',
-			item: convertType(item, ctx),
-			lengthRange: convertRange(lengthRange, ctx),
-		},
-		ctx,
-	)
+	return wrapType(node, {
+		kind: 'list',
+		item: convertType(item, ctx),
+		lengthRange: convertRange(lengthRange, ctx),
+	}, ctx)
 }
 
-function convertRange(
-	node: FloatRangeNode | IntRangeNode,
-	ctx: McdocBinderContext,
-): NumericRange
+function convertRange(node: FloatRangeNode | IntRangeNode, ctx: McdocBinderContext): NumericRange
 function convertRange(
 	node: FloatRangeNode | IntRangeNode | undefined,
 	ctx: McdocBinderContext,
@@ -1214,44 +984,23 @@ function convertRange(
 	return { kind, min: min?.value, max: max?.value }
 }
 
-function convertLiteral(
-	node: LiteralTypeNode,
-	ctx: McdocBinderContext,
-): McdocType {
+function convertLiteral(node: LiteralTypeNode, ctx: McdocBinderContext): McdocType {
 	const { value } = LiteralTypeNode.destruct(node)
-	return wrapType(
-		node,
-		{
-			kind: 'literal',
-			value: convertLiteralValue(value, ctx),
-		},
-		ctx,
-	)
+	return wrapType(node, { kind: 'literal', value: convertLiteralValue(value, ctx) }, ctx)
 }
 
-function convertLiteralValue(
-	node: LiteralTypeValueNode,
-	ctx: McdocBinderContext,
-): LiteralValue {
+function convertLiteralValue(node: LiteralTypeValueNode, ctx: McdocBinderContext): LiteralValue {
 	if (LiteralNode.is(node)) {
-		return {
-			kind: 'boolean',
-			value: node.value === 'true',
-		}
+		return { kind: 'boolean', value: node.value === 'true' }
 	} else if (TypedNumberNode.is(node)) {
 		const { suffix, value } = TypedNumberNode.destruct(node)
 		return {
 			kind: convertLiteralNumberSuffix(suffix, ctx)
-				?? (value.type === 'integer'
-					? 'int'
-					: 'double'),
+				?? (value.type === 'integer' ? 'int' : 'double'),
 			value: value.value,
 		}
 	} else {
-		return {
-			kind: 'string',
-			value: node.value,
-		}
+		return { kind: 'string', value: node.value }
 	}
 }
 
@@ -1276,95 +1025,48 @@ function convertLiteralNumberSuffix(
 	}
 }
 
-function convertNumericType(
-	node: NumericTypeNode,
-	ctx: McdocBinderContext,
-): McdocType {
+function convertNumericType(node: NumericTypeNode, ctx: McdocBinderContext): McdocType {
 	const { numericKind, valueRange } = NumericTypeNode.destruct(node)
-	return wrapType(
-		node,
-		{
-			kind: numericKind.value as NumericTypeKind,
-			valueRange: convertRange(valueRange, ctx),
-		},
-		ctx,
-	)
+	return wrapType(node, {
+		kind: numericKind.value as NumericTypeKind,
+		valueRange: convertRange(valueRange, ctx),
+	}, ctx)
 }
 
-function convertPrimitiveArray(
-	node: PrimitiveArrayTypeNode,
-	ctx: McdocBinderContext,
-): McdocType {
-	const { arrayKind, lengthRange, valueRange } = PrimitiveArrayTypeNode
-		.destruct(node)
-	return wrapType(
-		node,
-		{
-			kind: `${arrayKind.value as PrimitiveArrayValueKind}_array`,
-			lengthRange: convertRange(lengthRange, ctx),
-			valueRange: convertRange(valueRange, ctx),
-		},
-		ctx,
-	)
+function convertPrimitiveArray(node: PrimitiveArrayTypeNode, ctx: McdocBinderContext): McdocType {
+	const { arrayKind, lengthRange, valueRange } = PrimitiveArrayTypeNode.destruct(node)
+	return wrapType(node, {
+		kind: `${arrayKind.value as PrimitiveArrayValueKind}_array`,
+		lengthRange: convertRange(lengthRange, ctx),
+		valueRange: convertRange(valueRange, ctx),
+	}, ctx)
 }
 
-function convertString(
-	node: StringTypeNode,
-	ctx: McdocBinderContext,
-): McdocType {
+function convertString(node: StringTypeNode, ctx: McdocBinderContext): McdocType {
 	const { lengthRange } = StringTypeNode.destruct(node)
-	return wrapType(
-		node,
-		{
-			kind: 'string',
-			lengthRange: convertRange(lengthRange, ctx),
-		},
-		ctx,
-	)
+	return wrapType(node, { kind: 'string', lengthRange: convertRange(lengthRange, ctx) }, ctx)
 }
 
-function convertReference(
-	node: ReferenceTypeNode,
-	ctx: McdocBinderContext,
-): McdocType {
+function convertReference(node: ReferenceTypeNode, ctx: McdocBinderContext): McdocType {
 	const { path } = ReferenceTypeNode.destruct(node)
 	return wrapType(
 		node,
-		{
-			kind: 'reference',
-			path: pathArrayToString(resolvePath(path, ctx)),
-		},
+		{ kind: 'reference', path: pathArrayToString(resolvePath(path, ctx)) },
 		ctx,
 	)
 }
 
 function convertTuple(node: TupleTypeNode, ctx: McdocBinderContext): McdocType {
 	const { items } = TupleTypeNode.destruct(node)
-	return wrapType(
-		node,
-		{
-			kind: 'tuple',
-			items: items.map((n) => convertType(n, ctx)),
-		},
-		ctx,
-	)
+	return wrapType(node, { kind: 'tuple', items: items.map((n) => convertType(n, ctx)) }, ctx)
 }
 
 function convertUnion(node: UnionTypeNode, ctx: McdocBinderContext): McdocType {
 	const { members } = UnionTypeNode.destruct(node)
-	return wrapType(
-		node,
-		{
-			kind: 'union',
-			members: members.map((n) => convertType(n, ctx)),
-		},
-		ctx,
-	)
+	return wrapType(node, { kind: 'union', members: members.map((n) => convertType(n, ctx)) }, ctx)
 }
 
-function asString(
-	node: IdentifierNode | LiteralNode | StringNode | ResourceLocationNode,
-): string {
+function asString(node: IdentifierNode | LiteralNode | StringNode | ResourceLocationNode): string {
 	if (ResourceLocationNode.is(node)) {
 		return ResourceLocationNode.toString(node, 'short')
 	}

--- a/packages/mcdoc/src/index.ts
+++ b/packages/mcdoc/src/index.ts
@@ -15,10 +15,7 @@ export * from './uri_processors.js'
 
 /* istanbul ignore next */
 export const initialize = ({ meta }: { meta: core.MetaRegistry }): void => {
-	meta.registerLanguage('mcdoc', {
-		extensions: ['.mcdoc'],
-		parser: parser.module_,
-	})
+	meta.registerLanguage('mcdoc', { extensions: ['.mcdoc'], parser: parser.module_ })
 
 	registerBuiltinAttributes(meta)
 

--- a/packages/mcdoc/src/node/index.ts
+++ b/packages/mcdoc/src/node/index.ts
@@ -442,9 +442,7 @@ export namespace TypedNumberNode {
 	}
 }
 
-export interface NumericTypeNode
-	extends TypeBaseNode<LiteralNode | FloatRangeNode | IntRangeNode>
-{
+export interface NumericTypeNode extends TypeBaseNode<LiteralNode | FloatRangeNode | IntRangeNode> {
 	type: 'mcdoc:type/numeric_type'
 }
 export namespace NumericTypeNode {
@@ -552,9 +550,7 @@ export namespace FloatRangeNode {
 	}
 }
 
-export interface PrimitiveArrayTypeNode
-	extends TypeBaseNode<LiteralNode | IntRangeNode>
-{
+export interface PrimitiveArrayTypeNode extends TypeBaseNode<LiteralNode | IntRangeNode> {
 	type: 'mcdoc:type/primitive_array'
 }
 export namespace PrimitiveArrayTypeNode {
@@ -611,9 +607,7 @@ export namespace ListTypeNode {
 	}
 }
 
-export interface StringTypeNode
-	extends TypeBaseNode<LiteralNode | IntRangeNode>
-{
+export interface StringTypeNode extends TypeBaseNode<LiteralNode | IntRangeNode> {
 	type: 'mcdoc:type/string'
 }
 export namespace StringTypeNode {
@@ -993,9 +987,7 @@ export namespace StructSpreadFieldNode {
 	}
 }
 
-export interface DispatcherTypeNode
-	extends TypeBaseNode<ResourceLocationNode | IndexBodyNode>
-{
+export interface DispatcherTypeNode extends TypeBaseNode<ResourceLocationNode | IndexBodyNode> {
 	type: 'mcdoc:type/dispatcher'
 }
 export namespace DispatcherTypeNode {

--- a/packages/mcdoc/src/node/index.ts
+++ b/packages/mcdoc/src/node/index.ts
@@ -29,13 +29,13 @@ export type TopLevelNode =
 export namespace TopLevelNode {
 	export function is(node: AstNode | undefined): node is TopLevelNode {
 		return (
-			CommentNode.is(node) ||
-			DispatchStatementNode.is(node) ||
-			EnumNode.is(node) ||
-			InjectionNode.is(node) ||
-			StructNode.is(node) ||
-			TypeAliasNode.is(node) ||
-			UseStatementNode.is(node)
+			CommentNode.is(node)
+			|| DispatchStatementNode.is(node)
+			|| EnumNode.is(node)
+			|| InjectionNode.is(node)
+			|| StructNode.is(node)
+			|| TypeAliasNode.is(node)
+			|| UseStatementNode.is(node)
 		)
 	}
 }
@@ -72,8 +72,8 @@ export namespace DispatchStatementNode {
 		node: AstNode | undefined,
 	): node is DispatchStatementNode {
 		return (
-			(node as DispatchStatementNode | undefined)?.type ===
-				'mcdoc:dispatch_statement'
+			(node as DispatchStatementNode | undefined)?.type
+				=== 'mcdoc:dispatch_statement'
 		)
 	}
 }
@@ -121,10 +121,10 @@ export type StaticIndexNode =
 export namespace StaticIndexNode {
 	export function is(node: AstNode | undefined): node is StaticIndexNode {
 		return (
-			LiteralNode.is(node) ||
-			IdentifierNode.is(node) ||
-			StringNode.is(node) ||
-			ResourceLocationNode.is(node)
+			LiteralNode.is(node)
+			|| IdentifierNode.is(node)
+			|| StringNode.is(node)
+			|| ResourceLocationNode.is(node)
 		)
 	}
 }
@@ -183,19 +183,19 @@ export type TypeNode =
 export namespace TypeNode {
 	export function is(node: AstNode | undefined): node is TypeNode {
 		return (
-			AnyTypeNode.is(node) ||
-			BooleanTypeNode.is(node) ||
-			StringTypeNode.is(node) ||
-			LiteralTypeNode.is(node) ||
-			NumericTypeNode.is(node) ||
-			PrimitiveArrayTypeNode.is(node) ||
-			ListTypeNode.is(node) ||
-			TupleTypeNode.is(node) ||
-			EnumNode.is(node) ||
-			StructNode.is(node) ||
-			ReferenceTypeNode.is(node) ||
-			DispatcherTypeNode.is(node) ||
-			UnionTypeNode.is(node)
+			AnyTypeNode.is(node)
+			|| BooleanTypeNode.is(node)
+			|| StringTypeNode.is(node)
+			|| LiteralTypeNode.is(node)
+			|| NumericTypeNode.is(node)
+			|| PrimitiveArrayTypeNode.is(node)
+			|| ListTypeNode.is(node)
+			|| TupleTypeNode.is(node)
+			|| EnumNode.is(node)
+			|| StructNode.is(node)
+			|| ReferenceTypeNode.is(node)
+			|| DispatcherTypeNode.is(node)
+			|| UnionTypeNode.is(node)
 		)
 	}
 }
@@ -272,8 +272,8 @@ export namespace AttributeTreeNode {
 	}
 	export function is(node: AstNode | undefined): node is AttributeTreeNode {
 		return (
-			(node as AttributeTreeNode | undefined)?.type ===
-				'mcdoc:attribute/tree'
+			(node as AttributeTreeNode | undefined)?.type
+				=== 'mcdoc:attribute/tree'
 		)
 	}
 }
@@ -294,8 +294,8 @@ export namespace AttributeTreePosValuesNode {
 		node: AstNode | undefined,
 	): node is AttributeTreePosValuesNode {
 		return (
-			(node as AttributeTreePosValuesNode | undefined)?.type ===
-				'mcdoc:attribute/tree/pos'
+			(node as AttributeTreePosValuesNode | undefined)?.type
+				=== 'mcdoc:attribute/tree/pos'
 		)
 	}
 }
@@ -330,8 +330,8 @@ export namespace AttributeTreeNamedValuesNode {
 		node: AstNode | undefined,
 	): node is AttributeTreeNamedValuesNode {
 		return (
-			(node as AttributeTreeNamedValuesNode | undefined)?.type ===
-				'mcdoc:attribute/tree/named'
+			(node as AttributeTreeNamedValuesNode | undefined)?.type
+				=== 'mcdoc:attribute/tree/named'
 		)
 	}
 }
@@ -373,8 +373,8 @@ export interface BooleanTypeNode extends TypeBaseNode<LiteralNode> {
 }
 export namespace BooleanTypeNode {
 	export function is(node: AstNode | undefined): node is BooleanTypeNode {
-		return (node as BooleanTypeNode | undefined)?.type ===
-			'mcdoc:type/boolean'
+		return (node as BooleanTypeNode | undefined)?.type
+			=== 'mcdoc:type/boolean'
 	}
 }
 
@@ -407,8 +407,8 @@ export namespace LiteralTypeNode {
 		}
 	}
 	export function is(node: AstNode | undefined): node is LiteralTypeNode {
-		return (node as LiteralTypeNode | undefined)?.type ===
-			'mcdoc:type/literal'
+		return (node as LiteralTypeNode | undefined)?.type
+			=== 'mcdoc:type/literal'
 	}
 }
 
@@ -431,14 +431,14 @@ export namespace TypedNumberNode {
 		suffix?: LiteralNode
 	} {
 		return {
-			value: node.children.find(FloatNode.is) ??
-				node.children.find(IntegerNode.is)!,
+			value: node.children.find(FloatNode.is)
+				?? node.children.find(IntegerNode.is)!,
 			suffix: node.children.find(LiteralNode.is),
 		}
 	}
 	export function is(node: AstNode | undefined): node is TypedNumberNode {
-		return (node as TypedNumberNode | undefined)?.type ===
-			'mcdoc:typed_number'
+		return (node as TypedNumberNode | undefined)?.type
+			=== 'mcdoc:typed_number'
 	}
 }
 
@@ -454,14 +454,14 @@ export namespace NumericTypeNode {
 	} {
 		return {
 			numericKind: node.children.find(LiteralNode.is)!,
-			valueRange: node.children.find(FloatRangeNode.is) ||
-				node.children.find(IntRangeNode.is),
+			valueRange: node.children.find(FloatRangeNode.is)
+				|| node.children.find(IntRangeNode.is),
 		}
 	}
 	export function is(node: AstNode | undefined): node is NumericTypeNode {
 		return (
-			(node as NumericTypeNode | undefined)?.type ===
-				'mcdoc:type/numeric_type'
+			(node as NumericTypeNode | undefined)?.type
+				=== 'mcdoc:type/numeric_type'
 		)
 	}
 }
@@ -587,8 +587,8 @@ export namespace PrimitiveArrayTypeNode {
 		node: AstNode | undefined,
 	): node is PrimitiveArrayTypeNode {
 		return (
-			(node as PrimitiveArrayTypeNode | undefined)?.type ===
-				'mcdoc:type/primitive_array'
+			(node as PrimitiveArrayTypeNode | undefined)?.type
+				=== 'mcdoc:type/primitive_array'
 		)
 	}
 }
@@ -723,8 +723,8 @@ export namespace DocCommentsNode {
 		return comments.join('\n')
 	}
 	export function is(node: AstNode | undefined): node is DocCommentsNode {
-		return (node as DocCommentsNode | undefined)?.type ===
-			'mcdoc:doc_comments'
+		return (node as DocCommentsNode | undefined)?.type
+			=== 'mcdoc:doc_comments'
 	}
 }
 
@@ -819,8 +819,8 @@ export namespace ReferenceTypeNode {
 	}
 	export function is(node: AstNode | undefined): node is ReferenceTypeNode {
 		return (
-			(node as ReferenceTypeNode | undefined)?.type ===
-				'mcdoc:type/reference'
+			(node as ReferenceTypeNode | undefined)?.type
+				=== 'mcdoc:type/reference'
 		)
 	}
 }
@@ -839,8 +839,8 @@ export namespace TypeParamBlockNode {
 	}
 	export function is(node: AstNode | undefined): node is TypeParamBlockNode {
 		return (
-			(node as TypeParamBlockNode | undefined)?.type ===
-				'mcdoc:type_param_block'
+			(node as TypeParamBlockNode | undefined)?.type
+				=== 'mcdoc:type_param_block'
 		)
 	}
 }
@@ -900,8 +900,8 @@ export namespace StructBlockNode {
 		}
 	}
 	export function is(node: AstNode | undefined): node is StructBlockNode {
-		return (node as StructBlockNode | undefined)?.type ===
-			'mcdoc:struct/block'
+		return (node as StructBlockNode | undefined)?.type
+			=== 'mcdoc:struct/block'
 	}
 }
 
@@ -933,8 +933,8 @@ export namespace StructPairFieldNode {
 	}
 	export function is(node: AstNode | undefined): node is StructPairFieldNode {
 		return (
-			(node as StructPairFieldNode | undefined)?.type ===
-				'mcdoc:struct/field/pair'
+			(node as StructPairFieldNode | undefined)?.type
+				=== 'mcdoc:struct/field/pair'
 		)
 	}
 }
@@ -943,9 +943,9 @@ export type StructKeyNode = StringNode | IdentifierNode | StructMapKeyNode
 export namespace StructKeyNode {
 	export function is(node: AstNode | undefined): node is StructKeyNode {
 		return (
-			StringNode.is(node) ||
-			IdentifierNode.is(node) ||
-			StructMapKeyNode.is(node)
+			StringNode.is(node)
+			|| IdentifierNode.is(node)
+			|| StructMapKeyNode.is(node)
 		)
 	}
 }
@@ -987,8 +987,8 @@ export namespace StructSpreadFieldNode {
 		node: AstNode | undefined,
 	): node is StructSpreadFieldNode {
 		return (
-			(node as StructSpreadFieldNode | undefined)?.type ===
-				'mcdoc:struct/field/spread'
+			(node as StructSpreadFieldNode | undefined)?.type
+				=== 'mcdoc:struct/field/spread'
 		)
 	}
 }
@@ -1010,8 +1010,8 @@ export namespace DispatcherTypeNode {
 	}
 	export function is(node: AstNode | undefined): node is DispatcherTypeNode {
 		return (
-			(node as DispatcherTypeNode | undefined)?.type ===
-				'mcdoc:type/dispatcher'
+			(node as DispatcherTypeNode | undefined)?.type
+				=== 'mcdoc:type/dispatcher'
 		)
 	}
 }
@@ -1063,8 +1063,8 @@ export interface EnumInjectionNode extends AstNode {
 export namespace EnumInjectionNode {
 	export function is(node: AstNode | undefined): node is EnumInjectionNode {
 		return (
-			(node as EnumInjectionNode | undefined)?.type ===
-				'mcdoc:injection/enum'
+			(node as EnumInjectionNode | undefined)?.type
+				=== 'mcdoc:injection/enum'
 		)
 	}
 }
@@ -1076,8 +1076,8 @@ export interface StructInjectionNode extends AstNode {
 export namespace StructInjectionNode {
 	export function is(node: AstNode | undefined): node is StructInjectionNode {
 		return (
-			(node as StructInjectionNode | undefined)?.type ===
-				'mcdoc:injection/struct'
+			(node as StructInjectionNode | undefined)?.type
+				=== 'mcdoc:injection/struct'
 		)
 	}
 }

--- a/packages/mcdoc/src/node/index.ts
+++ b/packages/mcdoc/src/node/index.ts
@@ -28,15 +28,13 @@ export type TopLevelNode =
 	| UseStatementNode
 export namespace TopLevelNode {
 	export function is(node: AstNode | undefined): node is TopLevelNode {
-		return (
-			CommentNode.is(node)
+		return (CommentNode.is(node)
 			|| DispatchStatementNode.is(node)
 			|| EnumNode.is(node)
 			|| InjectionNode.is(node)
 			|| StructNode.is(node)
 			|| TypeAliasNode.is(node)
-			|| UseStatementNode.is(node)
-		)
+			|| UseStatementNode.is(node))
 	}
 }
 
@@ -53,7 +51,9 @@ export interface DispatchStatementNode extends AstNode {
 	)[]
 }
 export namespace DispatchStatementNode {
-	export function destruct(node: DispatchStatementNode): {
+	export function destruct(
+		node: DispatchStatementNode,
+	): {
 		attributes: AttributeNode[]
 		location?: ResourceLocationNode
 		index?: IndexBodyNode
@@ -68,13 +68,8 @@ export namespace DispatchStatementNode {
 			typeParams: node.children.find(TypeParamBlockNode.is),
 		}
 	}
-	export function is(
-		node: AstNode | undefined,
-	): node is DispatchStatementNode {
-		return (
-			(node as DispatchStatementNode | undefined)?.type
-				=== 'mcdoc:dispatch_statement'
-		)
+	export function is(node: AstNode | undefined): node is DispatchStatementNode {
+		return ((node as DispatchStatementNode | undefined)?.type === 'mcdoc:dispatch_statement')
 	}
 }
 
@@ -94,12 +89,8 @@ export interface IndexBodyNode extends AstNode {
 	children: (CommentNode | IndexNode)[]
 }
 export namespace IndexBodyNode {
-	export function destruct(node: IndexBodyNode): {
-		parallelIndices: IndexNode[]
-	} {
-		return {
-			parallelIndices: node.children.filter(IndexNode.is),
-		}
+	export function destruct(node: IndexBodyNode): { parallelIndices: IndexNode[] } {
+		return { parallelIndices: node.children.filter(IndexNode.is) }
 	}
 	export function is(node: AstNode | undefined): node is IndexBodyNode {
 		return (node as IndexBodyNode | undefined)?.type === 'mcdoc:index_body'
@@ -113,19 +104,13 @@ export namespace IndexNode {
 	}
 }
 
-export type StaticIndexNode =
-	| LiteralNode
-	| IdentifierNode
-	| StringNode
-	| ResourceLocationNode
+export type StaticIndexNode = LiteralNode | IdentifierNode | StringNode | ResourceLocationNode
 export namespace StaticIndexNode {
 	export function is(node: AstNode | undefined): node is StaticIndexNode {
-		return (
-			LiteralNode.is(node)
+		return (LiteralNode.is(node)
 			|| IdentifierNode.is(node)
 			|| StringNode.is(node)
-			|| ResourceLocationNode.is(node)
-		)
+			|| ResourceLocationNode.is(node))
 	}
 }
 
@@ -143,26 +128,18 @@ export interface DynamicIndexNode extends AstNode {
 	children: (CommentNode | AccessorKeyNode)[]
 }
 export namespace DynamicIndexNode {
-	export function destruct(node: DynamicIndexNode): {
-		keys: AccessorKeyNode[]
-	} {
-		return {
-			keys: node.children.filter(AccessorKeyNode.is),
-		}
+	export function destruct(node: DynamicIndexNode): { keys: AccessorKeyNode[] } {
+		return { keys: node.children.filter(AccessorKeyNode.is) }
 	}
 	export function is(node: AstNode | undefined): node is DynamicIndexNode {
-		return (
-			(node as DynamicIndexNode | undefined)?.type === 'mcdoc:dynamic_index'
-		)
+		return ((node as DynamicIndexNode | undefined)?.type === 'mcdoc:dynamic_index')
 	}
 }
 
 export type AccessorKeyNode = LiteralNode | IdentifierNode | StringNode
 export namespace AccessorKeyNode {
 	export function is(node: AstNode | undefined): node is AccessorKeyNode {
-		return (
-			LiteralNode.is(node) || IdentifierNode.is(node) || StringNode.is(node)
-		)
+		return (LiteralNode.is(node) || IdentifierNode.is(node) || StringNode.is(node))
 	}
 }
 
@@ -182,8 +159,7 @@ export type TypeNode =
 	| UnionTypeNode
 export namespace TypeNode {
 	export function is(node: AstNode | undefined): node is TypeNode {
-		return (
-			AnyTypeNode.is(node)
+		return (AnyTypeNode.is(node)
 			|| BooleanTypeNode.is(node)
 			|| StringTypeNode.is(node)
 			|| LiteralTypeNode.is(node)
@@ -195,30 +171,21 @@ export namespace TypeNode {
 			|| StructNode.is(node)
 			|| ReferenceTypeNode.is(node)
 			|| DispatcherTypeNode.is(node)
-			|| UnionTypeNode.is(node)
-		)
+			|| UnionTypeNode.is(node))
 	}
 }
 
 export interface TypeBaseNode<CN extends AstNode> extends AstNode {
 	type: `mcdoc:${string}`
-	children: (
-		| CommentNode
-		| AttributeNode
-		| IndexBodyNode
-		| TypeArgBlockNode
-		| CN
-	)[]
+	children: (CommentNode | AttributeNode | IndexBodyNode | TypeArgBlockNode | CN)[]
 }
 export namespace TypeBaseNode {
-	export function destruct(node: TypeBaseNode<any>): {
-		appendixes: (IndexBodyNode | TypeArgBlockNode)[]
-		attributes: AttributeNode[]
-	} {
+	export function destruct(
+		node: TypeBaseNode<any>,
+	): { appendixes: (IndexBodyNode | TypeArgBlockNode)[]; attributes: AttributeNode[] } {
 		return {
-			appendixes: node.children.filter(
-				(n): n is IndexBodyNode | TypeArgBlockNode =>
-					IndexBodyNode.is(n) || TypeArgBlockNode.is(n),
+			appendixes: node.children.filter((n): n is IndexBodyNode | TypeArgBlockNode =>
+				IndexBodyNode.is(n) || TypeArgBlockNode.is(n)
 			),
 			attributes: node.children.filter(AttributeNode.is),
 		}
@@ -230,10 +197,9 @@ export interface AttributeNode extends AstNode {
 	children: (CommentNode | IdentifierNode | AttributeValueNode)[]
 }
 export namespace AttributeNode {
-	export function destruct(node: AttributeNode): {
-		name: IdentifierNode
-		value: AttributeValueNode | undefined
-	} {
+	export function destruct(
+		node: AttributeNode,
+	): { name: IdentifierNode; value: AttributeValueNode | undefined } {
 		return {
 			name: node.children.find(IdentifierNode.is)!,
 			value: node.children.find(AttributeValueNode.is),
@@ -253,28 +219,20 @@ export namespace AttributeValueNode {
 
 export interface AttributeTreeNode extends AstNode {
 	type: 'mcdoc:attribute/tree'
-	children: (
-		| CommentNode
-		| AttributeTreePosValuesNode
-		| AttributeTreeNamedValuesNode
-	)[]
+	children: (CommentNode | AttributeTreePosValuesNode | AttributeTreeNamedValuesNode)[]
 	delim: '(' | '[' | '{'
 }
 export namespace AttributeTreeNode {
-	export function destruct(node: AttributeTreeNode): {
-		positional?: AttributeTreePosValuesNode
-		named?: AttributeTreeNamedValuesNode
-	} {
+	export function destruct(
+		node: AttributeTreeNode,
+	): { positional?: AttributeTreePosValuesNode; named?: AttributeTreeNamedValuesNode } {
 		return {
 			positional: node.children.find(AttributeTreePosValuesNode.is),
 			named: node.children.find(AttributeTreeNamedValuesNode.is),
 		}
 	}
 	export function is(node: AstNode | undefined): node is AttributeTreeNode {
-		return (
-			(node as AttributeTreeNode | undefined)?.type
-				=== 'mcdoc:attribute/tree'
-		)
+		return ((node as AttributeTreeNode | undefined)?.type === 'mcdoc:attribute/tree')
 	}
 }
 
@@ -283,20 +241,11 @@ export interface AttributeTreePosValuesNode extends AstNode {
 	children: (CommentNode | AttributeValueNode)[]
 }
 export namespace AttributeTreePosValuesNode {
-	export function destruct(node: AttributeTreePosValuesNode): {
-		values: AttributeValueNode[]
-	} {
-		return {
-			values: node.children.filter(AttributeValueNode.is),
-		}
+	export function destruct(node: AttributeTreePosValuesNode): { values: AttributeValueNode[] } {
+		return { values: node.children.filter(AttributeValueNode.is) }
 	}
-	export function is(
-		node: AstNode | undefined,
-	): node is AttributeTreePosValuesNode {
-		return (
-			(node as AttributeTreePosValuesNode | undefined)?.type
-				=== 'mcdoc:attribute/tree/pos'
-		)
+	export function is(node: AstNode | undefined): node is AttributeTreePosValuesNode {
+		return ((node as AttributeTreePosValuesNode | undefined)?.type === 'mcdoc:attribute/tree/pos')
 	}
 }
 
@@ -305,12 +254,10 @@ export interface AttributeTreeNamedValuesNode extends AstNode {
 	children: (CommentNode | IdentifierNode | StringNode | AttributeValueNode)[]
 }
 export namespace AttributeTreeNamedValuesNode {
-	export function destruct(node: AttributeTreeNamedValuesNode): {
-		values: AttributeTreeNamedKeyValuePair[]
-	} {
-		const ans: { values: AttributeTreeNamedKeyValuePair[] } = {
-			values: [],
-		}
+	export function destruct(
+		node: AttributeTreeNamedValuesNode,
+	): { values: AttributeTreeNamedKeyValuePair[] } {
+		const ans: { values: AttributeTreeNamedKeyValuePair[] } = { values: [] }
 		let key: IdentifierNode | StringNode | undefined
 		for (const child of node.children) {
 			if (CommentNode.is(child)) {
@@ -326,13 +273,9 @@ export namespace AttributeTreeNamedValuesNode {
 		}
 		return ans
 	}
-	export function is(
-		node: AstNode | undefined,
-	): node is AttributeTreeNamedValuesNode {
-		return (
-			(node as AttributeTreeNamedValuesNode | undefined)?.type
-				=== 'mcdoc:attribute/tree/named'
-		)
+	export function is(node: AstNode | undefined): node is AttributeTreeNamedValuesNode {
+		return ((node as AttributeTreeNamedValuesNode | undefined)?.type
+			=== 'mcdoc:attribute/tree/named')
 	}
 }
 export interface AttributeTreeNamedKeyValuePair {
@@ -345,17 +288,11 @@ export interface TypeArgBlockNode extends AstNode {
 	children: (CommentNode | TypeNode)[]
 }
 export namespace TypeArgBlockNode {
-	export function destruct(node: TypeArgBlockNode): {
-		args: TypeNode[]
-	} {
-		return {
-			args: node.children.filter(TypeNode.is),
-		}
+	export function destruct(node: TypeArgBlockNode): { args: TypeNode[] } {
+		return { args: node.children.filter(TypeNode.is) }
 	}
 	export function is(node: AstNode | undefined): node is TypeArgBlockNode {
-		return (
-			(node as TypeArgBlockNode | undefined)?.type === 'mcdoc:type_arg_block'
-		)
+		return ((node as TypeArgBlockNode | undefined)?.type === 'mcdoc:type_arg_block')
 	}
 }
 
@@ -373,8 +310,7 @@ export interface BooleanTypeNode extends TypeBaseNode<LiteralNode> {
 }
 export namespace BooleanTypeNode {
 	export function is(node: AstNode | undefined): node is BooleanTypeNode {
-		return (node as BooleanTypeNode | undefined)?.type
-			=== 'mcdoc:type/boolean'
+		return (node as BooleanTypeNode | undefined)?.type === 'mcdoc:type/boolean'
 	}
 }
 
@@ -383,11 +319,9 @@ export interface IntRangeNode extends AstNode {
 	children: (IntegerNode | LiteralNode)[]
 }
 export namespace IntRangeNode {
-	export function destruct(node: IntRangeNode): {
-		kind: RangeKind
-		min?: IntegerNode
-		max?: IntegerNode
-	} {
+	export function destruct(
+		node: IntRangeNode,
+	): { kind: RangeKind; min?: IntegerNode; max?: IntegerNode } {
 		return destructRangeNode(node)
 	}
 	export function is(node: AstNode | undefined): node is IntRangeNode {
@@ -399,25 +333,18 @@ export interface LiteralTypeNode extends TypeBaseNode<LiteralTypeValueNode> {
 	type: 'mcdoc:type/literal'
 }
 export namespace LiteralTypeNode {
-	export function destruct(node: LiteralTypeNode): {
-		value: LiteralTypeValueNode
-	} {
-		return {
-			value: node.children.find(LiteralTypeValueNode.is)!,
-		}
+	export function destruct(node: LiteralTypeNode): { value: LiteralTypeValueNode } {
+		return { value: node.children.find(LiteralTypeValueNode.is)! }
 	}
 	export function is(node: AstNode | undefined): node is LiteralTypeNode {
-		return (node as LiteralTypeNode | undefined)?.type
-			=== 'mcdoc:type/literal'
+		return (node as LiteralTypeNode | undefined)?.type === 'mcdoc:type/literal'
 	}
 }
 
 export type LiteralTypeValueNode = LiteralNode | TypedNumberNode | StringNode
 export namespace LiteralTypeValueNode {
 	export function is(node: AstNode | undefined): node is LiteralTypeValueNode {
-		return (
-			LiteralNode.is(node) || TypedNumberNode.is(node) || StringNode.is(node)
-		)
+		return (LiteralNode.is(node) || TypedNumberNode.is(node) || StringNode.is(node))
 	}
 }
 
@@ -426,19 +353,16 @@ export interface TypedNumberNode extends AstNode {
 	children: (FloatNode | IntegerNode | LiteralNode)[]
 }
 export namespace TypedNumberNode {
-	export function destruct(node: TypedNumberNode): {
-		value: FloatNode | IntegerNode
-		suffix?: LiteralNode
-	} {
+	export function destruct(
+		node: TypedNumberNode,
+	): { value: FloatNode | IntegerNode; suffix?: LiteralNode } {
 		return {
-			value: node.children.find(FloatNode.is)
-				?? node.children.find(IntegerNode.is)!,
+			value: node.children.find(FloatNode.is) ?? node.children.find(IntegerNode.is)!,
 			suffix: node.children.find(LiteralNode.is),
 		}
 	}
 	export function is(node: AstNode | undefined): node is TypedNumberNode {
-		return (node as TypedNumberNode | undefined)?.type
-			=== 'mcdoc:typed_number'
+		return (node as TypedNumberNode | undefined)?.type === 'mcdoc:typed_number'
 	}
 }
 
@@ -446,21 +370,16 @@ export interface NumericTypeNode extends TypeBaseNode<LiteralNode | FloatRangeNo
 	type: 'mcdoc:type/numeric_type'
 }
 export namespace NumericTypeNode {
-	export function destruct(node: NumericTypeNode): {
-		numericKind: LiteralNode
-		valueRange?: FloatRangeNode | IntRangeNode
-	} {
+	export function destruct(
+		node: NumericTypeNode,
+	): { numericKind: LiteralNode; valueRange?: FloatRangeNode | IntRangeNode } {
 		return {
 			numericKind: node.children.find(LiteralNode.is)!,
-			valueRange: node.children.find(FloatRangeNode.is)
-				|| node.children.find(IntRangeNode.is),
+			valueRange: node.children.find(FloatRangeNode.is) || node.children.find(IntRangeNode.is),
 		}
 	}
 	export function is(node: AstNode | undefined): node is NumericTypeNode {
-		return (
-			(node as NumericTypeNode | undefined)?.type
-				=== 'mcdoc:type/numeric_type'
-		)
+		return ((node as NumericTypeNode | undefined)?.type === 'mcdoc:type/numeric_type')
 	}
 }
 
@@ -515,11 +434,7 @@ function destructRangeNode<N extends FloatRangeNode | IntRangeNode>(
 		kind = getKind(node.children[1] as LiteralNode)
 		min = node.children[0] as FloatNode & IntegerNode
 	}
-	return {
-		kind,
-		min,
-		max,
-	}
+	return { kind, min, max }
 
 	function getKind(delimiter: LiteralNode): RangeKind {
 		let ans: number = 0b00
@@ -538,11 +453,9 @@ export interface FloatRangeNode extends AstNode {
 	children: (FloatNode | LiteralNode)[]
 }
 export namespace FloatRangeNode {
-	export function destruct(node: FloatRangeNode): {
-		kind: RangeKind
-		min?: FloatNode
-		max?: FloatNode
-	} {
+	export function destruct(
+		node: FloatRangeNode,
+	): { kind: RangeKind; min?: FloatNode; max?: FloatNode } {
 		return destructRangeNode(node)
 	}
 	export function is(node: AstNode | undefined): node is FloatRangeNode {
@@ -554,11 +467,9 @@ export interface PrimitiveArrayTypeNode extends TypeBaseNode<LiteralNode | IntRa
 	type: 'mcdoc:type/primitive_array'
 }
 export namespace PrimitiveArrayTypeNode {
-	export function destruct(node: PrimitiveArrayTypeNode): {
-		arrayKind: LiteralNode
-		lengthRange?: IntRangeNode
-		valueRange?: IntRangeNode
-	} {
+	export function destruct(
+		node: PrimitiveArrayTypeNode,
+	): { arrayKind: LiteralNode; lengthRange?: IntRangeNode; valueRange?: IntRangeNode } {
 		let lengthRange: IntRangeNode | undefined
 		let valueRange: IntRangeNode | undefined
 		let afterBrackets = false
@@ -573,19 +484,10 @@ export namespace PrimitiveArrayTypeNode {
 				}
 			}
 		}
-		return {
-			arrayKind: node.children.find(LiteralNode.is)!,
-			lengthRange,
-			valueRange,
-		}
+		return { arrayKind: node.children.find(LiteralNode.is)!, lengthRange, valueRange }
 	}
-	export function is(
-		node: AstNode | undefined,
-	): node is PrimitiveArrayTypeNode {
-		return (
-			(node as PrimitiveArrayTypeNode | undefined)?.type
-				=== 'mcdoc:type/primitive_array'
-		)
+	export function is(node: AstNode | undefined): node is PrimitiveArrayTypeNode {
+		return ((node as PrimitiveArrayTypeNode | undefined)?.type === 'mcdoc:type/primitive_array')
 	}
 }
 
@@ -593,10 +495,7 @@ export interface ListTypeNode extends TypeBaseNode<TypeNode | IntRangeNode> {
 	type: 'mcdoc:type/list'
 }
 export namespace ListTypeNode {
-	export function destruct(node: ListTypeNode): {
-		item: TypeNode
-		lengthRange?: IntRangeNode
-	} {
+	export function destruct(node: ListTypeNode): { item: TypeNode; lengthRange?: IntRangeNode } {
 		return {
 			item: node.children.find(TypeNode.is)!,
 			lengthRange: node.children.find(IntRangeNode.is),
@@ -611,12 +510,8 @@ export interface StringTypeNode extends TypeBaseNode<LiteralNode | IntRangeNode>
 	type: 'mcdoc:type/string'
 }
 export namespace StringTypeNode {
-	export function destruct(node: StringTypeNode): {
-		lengthRange?: IntRangeNode
-	} {
-		return {
-			lengthRange: node.children.find(IntRangeNode.is),
-		}
+	export function destruct(node: StringTypeNode): { lengthRange?: IntRangeNode } {
+		return { lengthRange: node.children.find(IntRangeNode.is) }
 	}
 	export function is(node: AstNode | undefined): node is StringTypeNode {
 		return (node as StringTypeNode | undefined)?.type === 'mcdoc:type/string'
@@ -627,39 +522,27 @@ export interface TupleTypeNode extends TypeBaseNode<TypeNode> {
 	type: 'mcdoc:type/tuple'
 }
 export namespace TupleTypeNode {
-	export function destruct(node: TupleTypeNode): {
-		items: TypeNode[]
-	} {
-		return {
-			items: node.children.filter(TypeNode.is),
-		}
+	export function destruct(node: TupleTypeNode): { items: TypeNode[] } {
+		return { items: node.children.filter(TypeNode.is) }
 	}
 	export function is(node: AstNode | undefined): node is TupleTypeNode {
 		return (node as TupleTypeNode | undefined)?.type === 'mcdoc:type/tuple'
 	}
 }
 
-export interface EnumNode extends
-	TypeBaseNode<
-		DocCommentsNode | LiteralNode | IdentifierNode | EnumBlockNode
-	>
+export interface EnumNode
+	extends TypeBaseNode<DocCommentsNode | LiteralNode | IdentifierNode | EnumBlockNode>
 {
 	type: 'mcdoc:enum'
 }
 export type EnumKind = typeof EnumNode.Kinds extends Set<infer V> ? V : never
 export namespace EnumNode {
 	export const Kinds = new Set(
-		[
-			'byte',
-			'short',
-			'int',
-			'long',
-			'float',
-			'double',
-			'string',
-		] as const,
+		['byte', 'short', 'int', 'long', 'float', 'double', 'string'] as const,
 	)
-	export function destruct(node: EnumNode): {
+	export function destruct(
+		node: EnumNode,
+	): {
 		block: EnumBlockNode
 		docComments?: DocCommentsNode
 		enumKind?: EnumKind
@@ -696,9 +579,7 @@ export namespace DocCommentsNode {
 	/**
 	 * @returns The text content of this doc comment block.
 	 */
-	export function asText(
-		node: DocCommentsNode | undefined,
-	): string | undefined {
+	export function asText(node: DocCommentsNode | undefined): string | undefined {
 		if (!node) {
 			return undefined
 		}
@@ -717,8 +598,7 @@ export namespace DocCommentsNode {
 		return comments.join('\n')
 	}
 	export function is(node: AstNode | undefined): node is DocCommentsNode {
-		return (node as DocCommentsNode | undefined)?.type
-			=== 'mcdoc:doc_comments'
+		return (node as DocCommentsNode | undefined)?.type === 'mcdoc:doc_comments'
 	}
 }
 
@@ -727,12 +607,8 @@ export interface EnumBlockNode extends AstNode {
 	children: (CommentNode | EnumFieldNode)[]
 }
 export namespace EnumBlockNode {
-	export function destruct(node: EnumBlockNode): {
-		fields: EnumFieldNode[]
-	} {
-		return {
-			fields: node.children.filter(EnumFieldNode.is),
-		}
+	export function destruct(node: EnumBlockNode): { fields: EnumFieldNode[] } {
+		return { fields: node.children.filter(EnumFieldNode.is) }
 	}
 	export function is(node: AstNode | undefined): node is EnumBlockNode {
 		return (node as EnumBlockNode | undefined)?.type === 'mcdoc:enum/block'
@@ -744,11 +620,9 @@ export interface EnumFieldNode extends AstNode {
 	children: (CommentNode | PrelimNode | IdentifierNode | EnumValueNode)[]
 }
 export namespace EnumFieldNode {
-	export function destruct(node: EnumFieldNode): {
-		attributes: AttributeNode[]
-		identifier: IdentifierNode
-		value: EnumValueNode
-	} {
+	export function destruct(
+		node: EnumFieldNode,
+	): { attributes: AttributeNode[]; identifier: IdentifierNode; value: EnumValueNode } {
 		return {
 			attributes: node.children.filter(AttributeNode.is),
 			identifier: node.children.find(IdentifierNode.is)!,
@@ -774,15 +648,15 @@ export namespace PrelimNode {
 	}
 }
 
-export interface StructNode extends
-	TypeBaseNode<
-		DocCommentsNode | LiteralNode | IdentifierNode | StructBlockNode
-	>
+export interface StructNode
+	extends TypeBaseNode<DocCommentsNode | LiteralNode | IdentifierNode | StructBlockNode>
 {
 	type: 'mcdoc:struct'
 }
 export namespace StructNode {
-	export function destruct(node: StructNode): {
+	export function destruct(
+		node: StructNode,
+	): {
 		block: StructBlockNode
 		docComments?: DocCommentsNode
 		identifier?: IdentifierNode
@@ -804,18 +678,11 @@ export interface ReferenceTypeNode extends TypeBaseNode<PathNode> {
 	type: 'mcdoc:type/reference'
 }
 export namespace ReferenceTypeNode {
-	export function destruct(node: ReferenceTypeNode): {
-		path: PathNode
-	} {
-		return {
-			path: node.children.find(PathNode.is)!,
-		}
+	export function destruct(node: ReferenceTypeNode): { path: PathNode } {
+		return { path: node.children.find(PathNode.is)! }
 	}
 	export function is(node: AstNode | undefined): node is ReferenceTypeNode {
-		return (
-			(node as ReferenceTypeNode | undefined)?.type
-				=== 'mcdoc:type/reference'
-		)
+		return ((node as ReferenceTypeNode | undefined)?.type === 'mcdoc:type/reference')
 	}
 }
 
@@ -824,18 +691,11 @@ export interface TypeParamBlockNode extends AstNode {
 	children: (CommentNode | TypeParamNode)[]
 }
 export namespace TypeParamBlockNode {
-	export function destruct(node: TypeParamBlockNode): {
-		params: TypeParamNode[]
-	} {
-		return {
-			params: node.children.filter(TypeParamNode.is),
-		}
+	export function destruct(node: TypeParamBlockNode): { params: TypeParamNode[] } {
+		return { params: node.children.filter(TypeParamNode.is) }
 	}
 	export function is(node: AstNode | undefined): node is TypeParamBlockNode {
-		return (
-			(node as TypeParamBlockNode | undefined)?.type
-				=== 'mcdoc:type_param_block'
-		)
+		return ((node as TypeParamBlockNode | undefined)?.type === 'mcdoc:type_param_block')
 	}
 }
 
@@ -864,7 +724,9 @@ export interface PathNode extends AstNode {
 	isAbsolute?: boolean
 }
 export namespace PathNode {
-	export function destruct(node: PathNode | undefined): {
+	export function destruct(
+		node: PathNode | undefined,
+	): {
 		children: (LiteralNode | IdentifierNode)[]
 		isAbsolute?: boolean
 		lastIdentifier?: IdentifierNode
@@ -886,16 +748,11 @@ export interface StructBlockNode extends AstNode {
 	children: (CommentNode | StructFieldNode)[]
 }
 export namespace StructBlockNode {
-	export function destruct(node: StructBlockNode): {
-		fields: StructFieldNode[]
-	} {
-		return {
-			fields: node.children.filter(StructFieldNode.is),
-		}
+	export function destruct(node: StructBlockNode): { fields: StructFieldNode[] } {
+		return { fields: node.children.filter(StructFieldNode.is) }
 	}
 	export function is(node: AstNode | undefined): node is StructBlockNode {
-		return (node as StructBlockNode | undefined)?.type
-			=== 'mcdoc:struct/block'
+		return (node as StructBlockNode | undefined)?.type === 'mcdoc:struct/block'
 	}
 }
 
@@ -912,12 +769,9 @@ export interface StructPairFieldNode extends AstNode {
 	isOptional?: boolean
 }
 export namespace StructPairFieldNode {
-	export function destruct(node: StructPairFieldNode): {
-		attributes: AttributeNode[]
-		key: StructKeyNode
-		type: TypeNode
-		isOptional?: boolean
-	} {
+	export function destruct(
+		node: StructPairFieldNode,
+	): { attributes: AttributeNode[]; key: StructKeyNode; type: TypeNode; isOptional?: boolean } {
 		return {
 			attributes: node.children.filter(AttributeNode.is),
 			key: node.children.find(StructKeyNode.is)!,
@@ -926,21 +780,14 @@ export namespace StructPairFieldNode {
 		}
 	}
 	export function is(node: AstNode | undefined): node is StructPairFieldNode {
-		return (
-			(node as StructPairFieldNode | undefined)?.type
-				=== 'mcdoc:struct/field/pair'
-		)
+		return ((node as StructPairFieldNode | undefined)?.type === 'mcdoc:struct/field/pair')
 	}
 }
 
 export type StructKeyNode = StringNode | IdentifierNode | StructMapKeyNode
 export namespace StructKeyNode {
 	export function is(node: AstNode | undefined): node is StructKeyNode {
-		return (
-			StringNode.is(node)
-			|| IdentifierNode.is(node)
-			|| StructMapKeyNode.is(node)
-		)
+		return (StringNode.is(node) || IdentifierNode.is(node) || StructMapKeyNode.is(node))
 	}
 }
 
@@ -949,17 +796,11 @@ export interface StructMapKeyNode extends AstNode {
 	children: (CommentNode | TypeNode)[]
 }
 export namespace StructMapKeyNode {
-	export function destruct(node: StructMapKeyNode): {
-		type: TypeNode
-	} {
-		return {
-			type: node.children.find(TypeNode.is)!,
-		}
+	export function destruct(node: StructMapKeyNode): { type: TypeNode } {
+		return { type: node.children.find(TypeNode.is)! }
 	}
 	export function is(node: AstNode | undefined): node is StructMapKeyNode {
-		return (
-			(node as StructMapKeyNode | undefined)?.type === 'mcdoc:struct/map_key'
-		)
+		return ((node as StructMapKeyNode | undefined)?.type === 'mcdoc:struct/map_key')
 	}
 }
 
@@ -968,22 +809,16 @@ export interface StructSpreadFieldNode extends AstNode {
 	children: (CommentNode | AttributeNode | TypeNode)[]
 }
 export namespace StructSpreadFieldNode {
-	export function destruct(node: StructSpreadFieldNode): {
-		attributes: AttributeNode[]
-		type: TypeNode
-	} {
+	export function destruct(
+		node: StructSpreadFieldNode,
+	): { attributes: AttributeNode[]; type: TypeNode } {
 		return {
 			attributes: node.children.filter(AttributeNode.is),
 			type: node.children.find(TypeNode.is)!,
 		}
 	}
-	export function is(
-		node: AstNode | undefined,
-	): node is StructSpreadFieldNode {
-		return (
-			(node as StructSpreadFieldNode | undefined)?.type
-				=== 'mcdoc:struct/field/spread'
-		)
+	export function is(node: AstNode | undefined): node is StructSpreadFieldNode {
+		return ((node as StructSpreadFieldNode | undefined)?.type === 'mcdoc:struct/field/spread')
 	}
 }
 
@@ -991,20 +826,16 @@ export interface DispatcherTypeNode extends TypeBaseNode<ResourceLocationNode | 
 	type: 'mcdoc:type/dispatcher'
 }
 export namespace DispatcherTypeNode {
-	export function destruct(node: DispatcherTypeNode): {
-		location: ResourceLocationNode
-		index: IndexBodyNode
-	} {
+	export function destruct(
+		node: DispatcherTypeNode,
+	): { location: ResourceLocationNode; index: IndexBodyNode } {
 		return {
 			location: node.children.find(ResourceLocationNode.is)!,
 			index: node.children.find(IndexBodyNode.is)!,
 		}
 	}
 	export function is(node: AstNode | undefined): node is DispatcherTypeNode {
-		return (
-			(node as DispatcherTypeNode | undefined)?.type
-				=== 'mcdoc:type/dispatcher'
-		)
+		return ((node as DispatcherTypeNode | undefined)?.type === 'mcdoc:type/dispatcher')
 	}
 }
 
@@ -1012,12 +843,8 @@ export interface UnionTypeNode extends TypeBaseNode<TypeNode> {
 	type: 'mcdoc:type/union'
 }
 export namespace UnionTypeNode {
-	export function destruct(node: UnionTypeNode): {
-		members: TypeNode[]
-	} {
-		return {
-			members: node.children.filter(TypeNode.is),
-		}
+	export function destruct(node: UnionTypeNode): { members: TypeNode[] } {
+		return { members: node.children.filter(TypeNode.is) }
 	}
 	export function is(node: AstNode | undefined): node is UnionTypeNode {
 		return (node as UnionTypeNode | undefined)?.type === 'mcdoc:type/union'
@@ -1029,12 +856,8 @@ export interface InjectionNode extends AstNode {
 	children: (CommentNode | LiteralNode | InjectionContentNode)[]
 }
 export namespace InjectionNode {
-	export function destruct(node: InjectionNode): {
-		injection: InjectionContentNode
-	} {
-		return {
-			injection: node.children.find(InjectionContentNode.is)!,
-		}
+	export function destruct(node: InjectionNode): { injection: InjectionContentNode } {
+		return { injection: node.children.find(InjectionContentNode.is)! }
 	}
 	export function is(node: AstNode | undefined): node is InjectionNode {
 		return (node as InjectionNode | undefined)?.type === 'mcdoc:injection'
@@ -1054,10 +877,7 @@ export interface EnumInjectionNode extends AstNode {
 }
 export namespace EnumInjectionNode {
 	export function is(node: AstNode | undefined): node is EnumInjectionNode {
-		return (
-			(node as EnumInjectionNode | undefined)?.type
-				=== 'mcdoc:injection/enum'
-		)
+		return ((node as EnumInjectionNode | undefined)?.type === 'mcdoc:injection/enum')
 	}
 }
 
@@ -1067,26 +887,19 @@ export interface StructInjectionNode extends AstNode {
 }
 export namespace StructInjectionNode {
 	export function is(node: AstNode | undefined): node is StructInjectionNode {
-		return (
-			(node as StructInjectionNode | undefined)?.type
-				=== 'mcdoc:injection/struct'
-		)
+		return ((node as StructInjectionNode | undefined)?.type === 'mcdoc:injection/struct')
 	}
 }
 
 export interface TypeAliasNode extends AstNode {
 	type: 'mcdoc:type_alias'
-	children: (
-		| CommentNode
-		| PrelimNode
-		| LiteralNode
-		| IdentifierNode
-		| TypeParamBlockNode
-		| TypeNode
-	)[]
+	children:
+		(CommentNode | PrelimNode | LiteralNode | IdentifierNode | TypeParamBlockNode | TypeNode)[]
 }
 export namespace TypeAliasNode {
-	export function destruct(node: TypeAliasNode): {
+	export function destruct(
+		node: TypeAliasNode,
+	): {
 		attributes: AttributeNode[]
 		docComments?: DocCommentsNode
 		identifier: IdentifierNode
@@ -1113,18 +926,13 @@ export interface UseStatementNode extends AstNode {
 	children: (CommentNode | LiteralNode | PathNode | IdentifierNode)[]
 }
 export namespace UseStatementNode {
-	export function destruct(node: UseStatementNode): {
-		binding?: IdentifierNode
-		path?: PathNode
-	} {
+	export function destruct(node: UseStatementNode): { binding?: IdentifierNode; path?: PathNode } {
 		return {
 			binding: node.children.find(IdentifierNode.is),
 			path: node.children.find(PathNode.is),
 		}
 	}
 	export function is(node: AstNode | undefined): node is UseStatementNode {
-		return (
-			(node as UseStatementNode | undefined)?.type === 'mcdoc:use_statement'
-		)
+		return ((node as UseStatementNode | undefined)?.type === 'mcdoc:use_statement')
 	}
 }

--- a/packages/mcdoc/src/parser/index.ts
+++ b/packages/mcdoc/src/parser/index.ts
@@ -192,8 +192,7 @@ function syntaxRepeat<P extends Parser<AstNode | SyntaxUtil<AstNode>>>(
 	parser: P,
 	delegatesDocComments?: boolean,
 ): P extends InfallibleParser ? { _inputParserIsInfallible: never } & void
-	: P extends Parser<infer V | SyntaxUtil<infer V>>
-		? InfallibleParser<SyntaxUtil<V>>
+	: P extends Parser<infer V | SyntaxUtil<infer V>> ? InfallibleParser<SyntaxUtil<V>>
 	: never
 function syntaxRepeat<CN extends AstNode>(
 	parser: Parser<CN | SyntaxUtil<CN>>,
@@ -328,8 +327,7 @@ export const string: InfallibleParser<StringNode> = stopBefore(
 export const identifier: InfallibleParser<IdentifierNode> = (src, ctx) => {
 	// https://spyglassmc.com/user/mcdoc/#identifier
 	const IdentifierStart = /^[\p{L}\p{Nl}]$/u
-	const IdentifierContinue =
-		/^[\p{L}\p{Nl}\u200C\u200D\p{Mn}\p{Mc}\p{Nd}\p{Pc}]$/u
+	const IdentifierContinue = /^[\p{L}\p{Nl}\u200C\u200D\p{Mn}\p{Mc}\p{Nd}\p{Pc}]$/u
 	const ReservedWords = new Set([
 		'any',
 		'boolean',
@@ -485,23 +483,22 @@ export const path: InfallibleParser<PathNode> = (src, ctx) => {
 	)(src, ctx)
 }
 
-const attributeTreePosValues: InfallibleParser<AttributeTreePosValuesNode> =
-	setType(
-		'mcdoc:attribute/tree/pos',
-		syntax(
-			[
-				{ get: () => attributeValue },
-				syntaxRepeat(
-					syntax(
-						[marker(','), { get: () => failOnEmpty(attributeValue) }],
-						true,
-					),
+const attributeTreePosValues: InfallibleParser<AttributeTreePosValuesNode> = setType(
+	'mcdoc:attribute/tree/pos',
+	syntax(
+		[
+			{ get: () => attributeValue },
+			syntaxRepeat(
+				syntax(
+					[marker(','), { get: () => failOnEmpty(attributeValue) }],
 					true,
 				),
-			],
-			true,
-		),
-	)
+				true,
+			),
+		],
+		true,
+	),
+)
 
 const attributeNamedValue: Parser<
 	SyntaxUtil<StringNode | IdentifierNode | AttributeValueNode>
@@ -658,11 +655,15 @@ export const docComments: InfallibleParser<DocCommentsNode> = setType(
 	}),
 )
 
-const prelim: InfallibleParser<SyntaxUtil<DocCommentsNode | AttributeNode>> =
-	syntax([optional(failOnEmpty(docComments)), attributes])
+const prelim: InfallibleParser<SyntaxUtil<DocCommentsNode | AttributeNode>> = syntax([
+	optional(failOnEmpty(docComments)),
+	attributes,
+])
 
-const optionalTypeParamBlock: InfallibleParser<TypeParamBlockNode | undefined> =
-	select([{ prefix: '<', parser: typeParamBlock }, { parser: noop }])
+const optionalTypeParamBlock: InfallibleParser<TypeParamBlockNode | undefined> = select([{
+	prefix: '<',
+	parser: typeParamBlock,
+}, { parser: noop }])
 
 export const dispatchStatement: Parser<DispatchStatementNode> = setType(
 	'mcdoc:dispatch_statement',
@@ -689,8 +690,7 @@ const enumType: InfallibleParser<LiteralNode> = literal(
 )
 
 export const float: InfallibleParser<FloatNode> = core.float({
-	pattern:
-		/^[-+]?(?:[0-9]+(?:[eE][-+]?[0-9]+)?|[0-9]*\.[0-9]+(?:[eE][-+]?[0-9]+)?)$/,
+	pattern: /^[-+]?(?:[0-9]+(?:[eE][-+]?[0-9]+)?|[0-9]*\.[0-9]+(?:[eE][-+]?[0-9]+)?)$/,
 })
 
 export const integer: InfallibleParser<IntegerNode> = core.integer({
@@ -712,8 +712,7 @@ export const LiteralIntCaseInsensitiveSuffixes = Object.freeze(
 		'L',
 	] as const,
 )
-export type LiteralIntCaseInsensitiveSuffix =
-	(typeof LiteralIntCaseInsensitiveSuffixes)[number]
+export type LiteralIntCaseInsensitiveSuffix = (typeof LiteralIntCaseInsensitiveSuffixes)[number]
 export const LiteralFloatSuffixes = Object.freeze(
 	[
 		'f',
@@ -728,8 +727,7 @@ export const LiteralFloatCaseInsensitiveSuffixes = Object.freeze(
 		'D',
 	] as const,
 )
-export type LiteralFloatCaseInsensitiveSuffix =
-	(typeof LiteralFloatCaseInsensitiveSuffixes)[number]
+export type LiteralFloatCaseInsensitiveSuffix = (typeof LiteralFloatCaseInsensitiveSuffixes)[number]
 export const LiteralNumberSuffixes = Object.freeze(
 	[
 		...LiteralIntSuffixes,
@@ -1026,8 +1024,7 @@ function typeBase<
 >(
 	type: T,
 	parser: P,
-): P extends InfallibleParser<AstNode | SyntaxUtil<AstNode>>
-	? InfallibleParser<GetTypeNode<T, P>>
+): P extends InfallibleParser<AstNode | SyntaxUtil<AstNode>> ? InfallibleParser<GetTypeNode<T, P>>
 	: Parser<GetTypeNode<T, P>>
 /* eslint-enable @typescript-eslint/indent */
 function typeBase<T extends string>(

--- a/packages/mcdoc/src/parser/index.ts
+++ b/packages/mcdoc/src/parser/index.ts
@@ -118,9 +118,9 @@ function syntaxGap(
 		src.skipWhitespace()
 
 		while (
-			src.canRead() &&
-			src.peek(2) === '//' &&
-			(!delegatesDocComments || src.peek(3) !== '///')
+			src.canRead()
+			&& src.peek(2) === '//'
+			&& (!delegatesDocComments || src.peek(3) !== '///')
 		) {
 			const result = comment(src, ctx) as CommentNode
 			ans.push(result)
@@ -219,8 +219,8 @@ export function literal(
 		}
 		ans.value = src.readIf(
 			(c) =>
-				options?.allowedChars?.has(c) ??
-					(options?.specialChars?.has(c) || /[a-z]/i.test(c)),
+				options?.allowedChars?.has(c)
+					?? (options?.specialChars?.has(c) || /[a-z]/i.test(c)),
 		)
 		ans.range.end = src.cursor
 		if (Arrayable.toArray(literal).every((l) => l !== ans.value)) {

--- a/packages/mcdoc/src/runtime/attribute/builtin.ts
+++ b/packages/mcdoc/src/runtime/attribute/builtin.ts
@@ -63,8 +63,8 @@ export function registerBuiltinAttributes(meta: core.MetaRegistry) {
 				const idAttr = inferred.attributes?.find(a => a.name === 'id')
 				if (idAttr) {
 					const inferredConfig = idValidator(idAttr.value, ctx)
-					return inferredConfig === core.Failure ||
-						inferredConfig.prefix === config.prefix
+					return inferredConfig === core.Failure
+						|| inferredConfig.prefix === config.prefix
 					// Prefix doesn't match
 				}
 			}
@@ -79,8 +79,8 @@ export function registerBuiltinAttributes(meta: core.MetaRegistry) {
 			}
 			if (!inferred.value.value.includes(':')) {
 				if (config.prefix) {
-					inferred.value.value = config.prefix + 'minecraft:' +
-						inferred.value.value.slice(config.prefix.length)
+					inferred.value.value = config.prefix + 'minecraft:'
+						+ inferred.value.value.slice(config.prefix.length)
 				} else {
 					inferred.value.value = 'minecraft:' + inferred.value.value
 				}

--- a/packages/mcdoc/src/runtime/attribute/builtin.ts
+++ b/packages/mcdoc/src/runtime/attribute/builtin.ts
@@ -10,21 +10,12 @@ interface IdConfig {
 }
 
 const idValidator = validator.alternatives<IdConfig>(
-	validator.map(
-		validator.string,
-		v => ({ registry: v }),
-	),
+	validator.map(validator.string, v => ({ registry: v })),
 	validator.tree({
 		registry: validator.string,
-		tags: validator.optional(
-			validator.options('allowed', 'implicit', 'required'),
-		),
-		definition: validator.optional(
-			validator.boolean,
-		),
-		prefix: validator.optional(
-			validator.options('!'),
-		),
+		tags: validator.optional(validator.options('allowed', 'implicit', 'required')),
+		definition: validator.optional(validator.boolean),
+		prefix: validator.optional(validator.options('!')),
 	}),
 	() => ({}),
 )
@@ -46,10 +37,7 @@ function getResourceLocationOptions(
 			return { category: registry, allowTag: true }
 		}
 	} else if (core.ResourceLocationCategory.is(registry)) {
-		return {
-			category: registry,
-			usageType: definition ? 'definition' : 'reference',
-		}
+		return { category: registry, usageType: definition ? 'definition' : 'reference' }
 	}
 	ctx.logger.warn(`[mcdoc id] Unhandled registry ${registry}`)
 	return undefined
@@ -63,8 +51,7 @@ export function registerBuiltinAttributes(meta: core.MetaRegistry) {
 				const idAttr = inferred.attributes?.find(a => a.name === 'id')
 				if (idAttr) {
 					const inferredConfig = idValidator(idAttr.value, ctx)
-					return inferredConfig === core.Failure
-						|| inferredConfig.prefix === config.prefix
+					return inferredConfig === core.Failure || inferredConfig.prefix === config.prefix
 					// Prefix doesn't match
 				}
 			}
@@ -95,17 +82,10 @@ export function registerBuiltinAttributes(meta: core.MetaRegistry) {
 			return (src, ctx) => {
 				const start = src.cursor
 				if (config.prefix && !src.trySkip(config.prefix)) {
-					ctx.err.report(
-						localize('expected', localeQuote(config.prefix)),
-						src,
-					)
+					ctx.err.report(localize('expected', localeQuote(config.prefix)), src)
 				} else if (!config.prefix && src.trySkip('!')) {
 					ctx.err.report(
-						localize(
-							'expected-got',
-							localize('resource-location'),
-							localeQuote('!'),
-						),
+						localize('expected-got', localize('resource-location'), localeQuote('!')),
 						core.Range.create(start, src),
 					)
 				}

--- a/packages/mcdoc/src/runtime/attribute/index.ts
+++ b/packages/mcdoc/src/runtime/attribute/index.ts
@@ -22,10 +22,7 @@ export interface McdocAttribute<C = unknown> {
 		config: C,
 		ctx: core.CheckerContext,
 	) => core.InfallibleParser<core.AstNode | undefined> | undefined
-	stringMocker?: (
-		config: C,
-		ctx: core.CompleterContext,
-	) => core.AstNode | undefined
+	stringMocker?: (config: C, ctx: core.CompleterContext) => core.AstNode | undefined
 }
 
 export function registerAttribute<C extends core.Returnable>(
@@ -42,10 +39,7 @@ interface AttributeInfo {
 	attribute: McdocAttribute
 }
 
-export function getAttribute(
-	meta: core.MetaRegistry,
-	name: string,
-) {
+export function getAttribute(meta: core.MetaRegistry, name: string) {
 	return meta.getCustom<AttributeInfo>('mcdoc:attribute')?.get(name)
 }
 

--- a/packages/mcdoc/src/runtime/attribute/validator.ts
+++ b/packages/mcdoc/src/runtime/attribute/validator.ts
@@ -39,9 +39,7 @@ export const boolean: McdocAttributeValidator<boolean> = (value) => {
 	return core.Failure
 }
 
-export function options<C extends string>(
-	...options: C[]
-): McdocAttributeValidator<C> {
+export function options<C extends string>(...options: C[]): McdocAttributeValidator<C> {
 	return (value, ctx) => {
 		const stringValue = string(value, ctx)
 		if (stringValue === core.Failure) {

--- a/packages/mcdoc/src/runtime/checker/index.ts
+++ b/packages/mcdoc/src/runtime/checker/index.ts
@@ -416,14 +416,13 @@ export function typeDefinition<T>(
 					)
 
 				for (const definitionGroup of definitionGroups) {
-					const { definitions, condensedErrors } =
-						condenseErrorsAndFilterSiblings(
-							definitionGroup.children.map(c => ({
-								definition: c,
-								errors: childErrors.filter(e => e.definitionNode === c)
-									.map(e => e.error),
-							})),
-						)
+					const { definitions, condensedErrors } = condenseErrorsAndFilterSiblings(
+						definitionGroup.children.map(c => ({
+							definition: c,
+							errors: childErrors.filter(e => e.definitionNode === c)
+								.map(e => e.error),
+						})),
+					)
 
 					definitionGroup.children = definitions
 					stillValidDefintions.push(...definitions)
@@ -453,9 +452,7 @@ export function typeDefinition<T>(
 						for (const child of children) {
 							for (const childValue of child.possibleValues) {
 								childValue.validDefinitions = childValue
-									.validDefinitions.filter(d =>
-										parentDefs.includes(d.parent!)
-									)
+									.validDefinitions.filter(d => parentDefs.includes(d.parent!))
 								filterChildDefinitions(
 									childValue.validDefinitions,
 									childValue.children,
@@ -477,9 +474,7 @@ export function typeDefinition<T>(
 
 						let children = [v]
 						for (let i = 0; i < depth; i++) {
-							children = children.flatMap(v => v.children).flatMap(v =>
-								v.possibleValues
-							)
+							children = children.flatMap(v => v.children).flatMap(v => v.possibleValues)
 						}
 						return children.length > 0
 					})
@@ -576,9 +571,7 @@ function condenseErrorsAndFilterSiblings<T>(
 	}
 
 	let validDefinitions = definitions
-	const errors = validDefinitions[0].errors.filter(e =>
-		e.kind === 'duplicate_key'
-	)
+	const errors = validDefinitions[0].errors.filter(e => e.kind === 'duplicate_key')
 
 	const alwaysMismatch: TypeMismatchError<T>[] = (validDefinitions[0].errors
 		.filter(e =>
@@ -599,9 +592,7 @@ function condenseErrorsAndFilterSiblings<T>(
 					) as TypeMismatchError<T>).expected
 				)
 				.flatMap(t => t.kind === 'union' ? t.members : [t])
-				.filter((d, i, arr) =>
-					arr.findIndex(od => od.kind === d.kind) === i
-				)
+				.filter((d, i, arr) => arr.findIndex(od => od.kind === d.kind) === i)
 			return {
 				...e,
 				expected: expected.length === 1
@@ -614,9 +605,8 @@ function condenseErrorsAndFilterSiblings<T>(
 	const onlyCommonTypeMismatches = definitions.filter(d =>
 		!d.errors.some(e =>
 			e.kind === 'sometimes_type_mismatch'
-			|| (e.kind === 'type_mismatch' && !alwaysMismatch.some(oe =>
-				oe.node.originalNode === e.node.originalNode
-			))
+			|| (e.kind === 'type_mismatch'
+				&& !alwaysMismatch.some(oe => oe.node.originalNode === e.node.originalNode))
 		)
 	)
 	if (onlyCommonTypeMismatches.length !== 0) {
@@ -629,9 +619,8 @@ function condenseErrorsAndFilterSiblings<T>(
 			.flatMap(d =>
 				d.errors
 					.filter(e =>
-						e.kind === 'type_mismatch' && !alwaysMismatch.some(oe =>
-							oe.node.originalNode === e.node.originalNode
-						)
+						e.kind === 'type_mismatch'
+						&& !alwaysMismatch.some(oe => oe.node.originalNode === e.node.originalNode)
 					)
 			)
 			.map(e => e.node as RuntimeNode<T>)
@@ -640,9 +629,7 @@ function condenseErrorsAndFilterSiblings<T>(
 					e.kind === 'sometimes_type_mismatch'
 				).map(e => e.node as RuntimeNode<T>),
 			)
-			.filter((v, i, arr) =>
-				arr.findIndex(o => o.originalNode === v.originalNode) === i
-			)
+			.filter((v, i, arr) => arr.findIndex(o => o.originalNode === v.originalNode) === i)
 			.map(n => ({ kind: 'sometimes_type_mismatch', node: n }))
 
 		errors.push(...typeMismatches)
@@ -665,9 +652,7 @@ function condenseErrorsAndFilterSiblings<T>(
 			!d.errors.some(e =>
 				e.kind === 'invalid_key_combination'
 				|| (e.kind === 'unknown_key'
-					&& !alwaysUnknown.some(oe =>
-						oe.node.originalNode === e.node.originalNode
-					))
+					&& !alwaysUnknown.some(oe => oe.node.originalNode === e.node.originalNode))
 			)
 		)
 	if (onlyCommonUnknownKeys.length !== 0) {
@@ -677,9 +662,8 @@ function condenseErrorsAndFilterSiblings<T>(
 			.flatMap(d =>
 				d.errors
 					.filter(e =>
-						e.kind === 'unknown_key' && !alwaysUnknown.some(oe =>
-							oe.node.originalNode === e.node.originalNode
-						)
+						e.kind === 'unknown_key'
+						&& !alwaysUnknown.some(oe => oe.node.originalNode === e.node.originalNode)
 					)
 			)
 			.map(e => e.node as RuntimeNode<T>)
@@ -688,9 +672,7 @@ function condenseErrorsAndFilterSiblings<T>(
 					e.kind === 'invalid_key_combination'
 				).map(e => e.node as RuntimeNode<T>),
 			)
-			.filter((v, i, arr) =>
-				arr.findIndex(o => o.originalNode === v.originalNode) === i
-			)
+			.filter((v, i, arr) => arr.findIndex(o => o.originalNode === v.originalNode) === i)
 
 		errors.push({ kind: 'invalid_key_combination', node: unknownKeys })
 	}
@@ -737,9 +719,7 @@ function condenseErrorsAndFilterSiblings<T>(
 			!d.errors.some(e =>
 				e.kind === 'some_missing_keys'
 				|| (e.kind === 'missing_key'
-					&& !alwaysMissing.some(oe =>
-						oe.node.originalNode === e.node.originalNode
-					))
+					&& !alwaysMissing.some(oe => oe.node.originalNode === e.node.originalNode))
 			)
 		)
 	if (onlyCommonMissing.length !== 0) {
@@ -756,20 +736,15 @@ function condenseErrorsAndFilterSiblings<T>(
 					d.errors
 						.filter(e =>
 							e.kind === 'missing_key'
-							&& !alwaysMissing.some(oe =>
-								oe.node.originalNode === e.node.originalNode
-							)
+							&& !alwaysMissing.some(oe => oe.node.originalNode === e.node.originalNode)
 						)
 				)
 				.map(e => e.node as RuntimeNode<T>)
 				.concat(
-					validDefinitions.flatMap(d => d.errors).filter(e =>
-						e.kind === 'some_missing_keys'
-					).map(e => e.node as RuntimeNode<T>),
+					validDefinitions.flatMap(d => d.errors).filter(e => e.kind === 'some_missing_keys')
+						.map(e => e.node as RuntimeNode<T>),
 				)
-				.filter((v, i, arr) =>
-					arr.findIndex(o => o.originalNode === v.originalNode) === i
-				)
+				.filter((v, i, arr) => arr.findIndex(o => o.originalNode === v.originalNode) === i)
 				.map(n => ({
 					kind: 'some_missing_keys' as 'some_missing_keys',
 					node: n,
@@ -784,9 +759,7 @@ function condenseErrorsAndFilterSiblings<T>(
 			'number_out_of_range',
 		] as const
 	) {
-		const noRangeError = validDefinitions.filter(d =>
-			!d.errors.some(e => e.kind === kind)
-		)
+		const noRangeError = validDefinitions.filter(d => !d.errors.some(e => e.kind === kind))
 		if (noRangeError.length !== 0) {
 			validDefinitions = noRangeError
 		} else {
@@ -810,9 +783,7 @@ function condenseErrorsAndFilterSiblings<T>(
 	}
 
 	errors.push(
-		...validDefinitions.flatMap(d =>
-			d.errors.filter(e => e.kind === 'internal')
-		),
+		...validDefinitions.flatMap(d => d.errors.filter(e => e.kind === 'internal')),
 	)
 
 	return {
@@ -847,9 +818,7 @@ function checkShallowly<T>(
 		// TODO handle enum field attributes
 		|| (typeDef.kind === 'enum'
 			&& (simplifiedInferred.kind !== 'literal'
-				|| !typeDef.values.some(v =>
-					v.value === simplifiedInferred.value.value
-				)))
+				|| !typeDef.values.some(v => v.value === simplifiedInferred.value.value)))
 	) {
 		return {
 			childDefinitions: Array(children.length).fill(undefined),
@@ -1043,8 +1012,7 @@ function checkShallowly<T>(
 				if (childDef === undefined) {
 					if (Array.isArray(child)) {
 						errors.push(...child.map(v => ({
-							kind:
-								'expected_key_value_pair' as 'expected_key_value_pair',
+							kind: 'expected_key_value_pair' as 'expected_key_value_pair',
 							node: v,
 						})))
 					} else {
@@ -1280,9 +1248,7 @@ function simplifyIndexed<T>(
 		let lookup: string[] = []
 		if (index.kind === 'static') {
 			if (index.value === '%fallback') {
-				values = child.fields.filter(f => f.kind === 'pair').map(f =>
-					f.type
-				)
+				values = child.fields.filter(f => f.kind === 'pair').map(f => f.type)
 				break
 			}
 			if (index.value.startsWith('minecraft:')) {
@@ -1763,9 +1729,7 @@ export function getDefaultErrorReporter<T>(
 						defaultTranslationKey,
 						error.node.inferredType.kind === 'literal'
 							? error.node.inferredType.value.value
-							: `<${
-								localize(`mcdoc.type.${error.node.inferredType.kind}`)
-							}>`,
+							: `<${localize(`mcdoc.type.${error.node.inferredType.kind}`)}>`,
 					),
 					range,
 					core.ErrorSeverity.Warning,

--- a/packages/mcdoc/src/runtime/checker/index.ts
+++ b/packages/mcdoc/src/runtime/checker/index.ts
@@ -172,9 +172,9 @@ export function isAssignable(
 	isEquivalent?: NodeEquivalenceChecker,
 ): boolean {
 	if (
-		assignValue.kind === 'literal' && typeDef.kind === 'literal' &&
-		assignValue.value.kind === typeDef.value.kind &&
-		!assignValue.attributes && !typeDef.attributes
+		assignValue.kind === 'literal' && typeDef.kind === 'literal'
+		&& assignValue.value.kind === typeDef.value.kind
+		&& !assignValue.attributes && !typeDef.attributes
 	) {
 		return assignValue.value.value === typeDef.value.value
 	}
@@ -582,11 +582,11 @@ function condenseErrorsAndFilterSiblings<T>(
 
 	const alwaysMismatch: TypeMismatchError<T>[] = (validDefinitions[0].errors
 		.filter(e =>
-			e.kind === 'type_mismatch' &&
-			!validDefinitions.some(d =>
+			e.kind === 'type_mismatch'
+			&& !validDefinitions.some(d =>
 				!d.errors.some(oe =>
-					oe.kind === 'type_mismatch' &&
-					e.node.originalNode === oe.node.originalNode
+					oe.kind === 'type_mismatch'
+					&& e.node.originalNode === oe.node.originalNode
 				)
 			)
 		) as TypeMismatchError<T>[])
@@ -594,8 +594,8 @@ function condenseErrorsAndFilterSiblings<T>(
 			const expected = validDefinitions
 				.map(d =>
 					(d.errors.find(oe =>
-						oe.kind === 'type_mismatch' &&
-						oe.node.originalNode === e.node.originalNode
+						oe.kind === 'type_mismatch'
+						&& oe.node.originalNode === e.node.originalNode
 					) as TypeMismatchError<T>).expected
 				)
 				.flatMap(t => t.kind === 'union' ? t.members : [t])
@@ -613,8 +613,8 @@ function condenseErrorsAndFilterSiblings<T>(
 
 	const onlyCommonTypeMismatches = definitions.filter(d =>
 		!d.errors.some(e =>
-			e.kind === 'sometimes_type_mismatch' ||
-			(e.kind === 'type_mismatch' && !alwaysMismatch.some(oe =>
+			e.kind === 'sometimes_type_mismatch'
+			|| (e.kind === 'type_mismatch' && !alwaysMismatch.some(oe =>
 				oe.node.originalNode === e.node.originalNode
 			))
 		)
@@ -650,11 +650,11 @@ function condenseErrorsAndFilterSiblings<T>(
 
 	const alwaysUnknown = validDefinitions[0].errors
 		.filter(e =>
-			e.kind === 'unknown_key' &&
-			!validDefinitions.some(d =>
+			e.kind === 'unknown_key'
+			&& !validDefinitions.some(d =>
 				!d.errors.some(oe =>
-					oe.kind === 'unknown_key' &&
-					e.node.originalNode === oe.node.originalNode
+					oe.kind === 'unknown_key'
+					&& e.node.originalNode === oe.node.originalNode
 				)
 			)
 		) as SimpleError<T>[]
@@ -663,9 +663,9 @@ function condenseErrorsAndFilterSiblings<T>(
 	const onlyCommonUnknownKeys = validDefinitions
 		.filter(d =>
 			!d.errors.some(e =>
-				e.kind === 'invalid_key_combination' ||
-				(e.kind === 'unknown_key' &&
-					!alwaysUnknown.some(oe =>
+				e.kind === 'invalid_key_combination'
+				|| (e.kind === 'unknown_key'
+					&& !alwaysUnknown.some(oe =>
 						oe.node.originalNode === e.node.originalNode
 					))
 			)
@@ -705,10 +705,10 @@ function condenseErrorsAndFilterSiblings<T>(
 			...validDefinitions
 				.flatMap(d => d.errors)
 				.filter((e, i, arr) =>
-					e.kind === 'expected_key_value_pair' &&
-					arr.findIndex(oe =>
-							oe.kind === 'expected_key_value_pair' &&
-							oe.node.originalNode === e.node.originalNode
+					e.kind === 'expected_key_value_pair'
+					&& arr.findIndex(oe =>
+							oe.kind === 'expected_key_value_pair'
+							&& oe.node.originalNode === e.node.originalNode
 						) === i
 				),
 		)
@@ -722,12 +722,12 @@ function condenseErrorsAndFilterSiblings<T>(
 	}
 
 	const alwaysMissing = validDefinitions[0].errors.filter(e =>
-		e.kind === 'missing_key' &&
-		!validDefinitions.some(d =>
+		e.kind === 'missing_key'
+		&& !validDefinitions.some(d =>
 			!d.errors.some(oe =>
-				oe.kind === 'missing_key' &&
-				oe.node.originalNode === e.node.originalNode &&
-				oe.key === e.key
+				oe.kind === 'missing_key'
+				&& oe.node.originalNode === e.node.originalNode
+				&& oe.key === e.key
 			)
 		)
 	) as MissingKeyError<T>[]
@@ -735,9 +735,9 @@ function condenseErrorsAndFilterSiblings<T>(
 	const onlyCommonMissing = validDefinitions
 		.filter(d =>
 			!d.errors.some(e =>
-				e.kind === 'some_missing_keys' ||
-				(e.kind === 'missing_key' &&
-					!alwaysMissing.some(oe =>
+				e.kind === 'some_missing_keys'
+				|| (e.kind === 'missing_key'
+					&& !alwaysMissing.some(oe =>
 						oe.node.originalNode === e.node.originalNode
 					))
 			)
@@ -755,8 +755,8 @@ function condenseErrorsAndFilterSiblings<T>(
 				.flatMap(d =>
 					d.errors
 						.filter(e =>
-							e.kind === 'missing_key' &&
-							!alwaysMissing.some(oe =>
+							e.kind === 'missing_key'
+							&& !alwaysMissing.some(oe =>
 								oe.node.originalNode === e.node.originalNode
 							)
 						)
@@ -837,17 +837,17 @@ function checkShallowly<T>(
 	const runtimeValueType = getValueType(simplifiedInferred)
 
 	if (
-		(typeDef.kind !== 'any' && typeDef.kind !== 'unsafe' &&
-			simplifiedInferred.kind !== 'unsafe' &&
-			runtimeValueType.kind !== typeDefValueType.kind &&
-			!options.isEquivalent(runtimeValueType, typeDefValueType)) ||
-		(typeDef.kind === 'literal' &&
-			(simplifiedInferred.kind !== 'literal' ||
-				typeDef.value.value !== simplifiedInferred.value.value)) ||
+		(typeDef.kind !== 'any' && typeDef.kind !== 'unsafe'
+			&& simplifiedInferred.kind !== 'unsafe'
+			&& runtimeValueType.kind !== typeDefValueType.kind
+			&& !options.isEquivalent(runtimeValueType, typeDefValueType))
+		|| (typeDef.kind === 'literal'
+			&& (simplifiedInferred.kind !== 'literal'
+				|| typeDef.value.value !== simplifiedInferred.value.value))
 		// TODO handle enum field attributes
-		(typeDef.kind === 'enum' &&
-			(simplifiedInferred.kind !== 'literal' ||
-				!typeDef.values.some(v =>
+		|| (typeDef.kind === 'enum'
+			&& (simplifiedInferred.kind !== 'literal'
+				|| !typeDef.values.some(v =>
 					v.value === simplifiedInferred.value.value
 				)))
 	) {
@@ -890,11 +890,11 @@ function checkShallowly<T>(
 		case 'float':
 		case 'double':
 			if (
-				typeDef.valueRange &&
-				simplifiedInferred.kind === 'literal' &&
-				typeof simplifiedInferred.value.value ===
-					'number' &&
-				!NumericRange.isInRange(
+				typeDef.valueRange
+				&& simplifiedInferred.kind === 'literal'
+				&& typeof simplifiedInferred.value.value
+					=== 'number'
+				&& !NumericRange.isInRange(
 					typeDef.valueRange,
 					simplifiedInferred.value.value,
 				)
@@ -908,10 +908,10 @@ function checkShallowly<T>(
 			break
 		case 'string':
 			if (
-				typeDef.lengthRange &&
-				simplifiedInferred.kind === 'literal' &&
-				simplifiedInferred.value.kind === 'string' &&
-				!NumericRange.isInRange(
+				typeDef.lengthRange
+				&& simplifiedInferred.kind === 'literal'
+				&& simplifiedInferred.value.kind === 'string'
+				&& !NumericRange.isInRange(
 					typeDef.lengthRange,
 					simplifiedInferred.value.value.length,
 				)
@@ -939,8 +939,8 @@ function checkShallowly<T>(
 					continue
 				}
 				if (
-					child.key.inferredType.kind === 'literal' &&
-					child.key.inferredType.value.kind === 'string'
+					child.key.inferredType.kind === 'literal'
+					&& child.key.inferredType.value.kind === 'string'
 				) {
 					const existing = literalKvps.get(
 						child.key.inferredType.value.value,
@@ -990,8 +990,8 @@ function checkShallowly<T>(
 					}
 					for (const kvp of literalKvps.entries()) {
 						if (
-							!kvp[1].definition &&
-							isAssignable(
+							!kvp[1].definition
+							&& isAssignable(
 								{
 									kind: 'literal',
 									value: { kind: 'string', value: kvp[0] },
@@ -1011,10 +1011,10 @@ function checkShallowly<T>(
 					childDefinitions[match] = pair.type
 				}
 				if (
-					!foundMatch &&
-					pair.key.kind === 'literal' &&
-					pair.key.value.kind === 'string' &&
-					pair.optional !== true
+					!foundMatch
+					&& pair.key.kind === 'literal'
+					&& pair.key.value.kind === 'string'
+					&& pair.optional !== true
 				) {
 					errors.push({
 						kind: 'missing_key',
@@ -1082,8 +1082,8 @@ function checkShallowly<T>(
 			}
 
 			if (
-				typeDef.lengthRange &&
-				!NumericRange.isInRange(typeDef.lengthRange, children.length)
+				typeDef.lengthRange
+				&& !NumericRange.isInRange(typeDef.lengthRange, children.length)
 			) {
 				errors.push({
 					kind: 'invalid_collection_length',
@@ -1376,8 +1376,8 @@ function simplifyIndexed<T>(
 			}
 			for (const value of possibilities.map(p => p.value?.node)) {
 				if (
-					value?.inferredType.kind === 'literal' &&
-					value.inferredType.value.kind === 'string'
+					value?.inferredType.kind === 'literal'
+					&& value.inferredType.value.kind === 'string'
 				) {
 					const ans = value.inferredType.value.value
 					if (ans.startsWith('minecraft:')) {
@@ -1397,12 +1397,12 @@ function simplifyIndexed<T>(
 
 		const currentValues = lookup.map(v =>
 			child.fields.find(f =>
-				f.kind === 'pair' && f.key.kind === 'literal' &&
-				f.key.value.value === v
-			) ??
-				child.fields.find(f =>
-					f.kind === 'pair' && f.key.kind === 'literal' &&
-					f.key.value.value === '%unknown'
+				f.kind === 'pair' && f.key.kind === 'literal'
+				&& f.key.value.value === v
+			)
+				?? child.fields.find(f =>
+					f.kind === 'pair' && f.key.kind === 'literal'
+					&& f.key.value.value === '%unknown'
 				)
 		)
 		if (currentValues.includes(undefined)) {
@@ -1466,8 +1466,8 @@ function simplifyStruct<T>(
 			(handler, config) => {
 				if (!keep) return
 				if (
-					handler.filterElement?.(config, context.options.context) ===
-						false
+					handler.filterElement?.(config, context.options.context)
+						=== false
 				) {
 					keep = false
 				}
@@ -1652,8 +1652,8 @@ function simplifyTemplate<T>(
 	}
 	const mapping = Object.fromEntries(
 		typeDef.typeParams.map((param, i) => {
-			const arg = context.typeArgs?.[i] ??
-				{ kind: 'union', members: [] }
+			const arg = context.typeArgs?.[i]
+				?? { kind: 'union', members: [] }
 			return [param.path, arg]
 		}),
 	)
@@ -1712,8 +1712,8 @@ export function getErrorRangeDefault<T extends core.AstNode>(
 ): core.Range {
 	const { range } = node.originalNode
 	if (
-		error === 'missing_key' ||
-		error === 'invalid_collection_length'
+		error === 'missing_key'
+		|| error === 'invalid_collection_length'
 	) {
 		return { start: range.start, end: range.start + 1 }
 	}

--- a/packages/mcdoc/src/runtime/completer/index.ts
+++ b/packages/mcdoc/src/runtime/completer/index.ts
@@ -4,10 +4,7 @@ import type { McdocType, StructTypePairField } from '../../type/index.js'
 import { handleAttributes } from '../attribute/index.js'
 import type { SimplifiedMcdocType } from '../checker/index.js'
 
-export type SimpleCompletionField = {
-	key: string
-	field: core.DeepReadonly<StructTypePairField>
-}
+export type SimpleCompletionField = { key: string; field: core.DeepReadonly<StructTypePairField> }
 
 export function getFields(
 	typeDef: core.DeepReadonly<SimplifiedMcdocType>,
@@ -17,16 +14,15 @@ export function getFields(
 		case 'union':
 			return typeDef.members.flatMap(getFields)
 		case 'struct':
-			return typeDef.fields
-				.flatMap(field => {
-					if (typeof field.key === 'string') {
-						return [{ key: field.key, field }]
-					}
-					if (field.key.kind === 'literal') {
-						return [{ key: `${field.key.value.value}`, field }]
-					}
-					return []
-				})
+			return typeDef.fields.flatMap(field => {
+				if (typeof field.key === 'string') {
+					return [{ key: field.key, field }]
+				}
+				if (field.key.kind === 'literal') {
+					return [{ key: `${field.key.value.value}`, field }]
+				}
+				return []
+			})
 		default:
 			return []
 	}

--- a/packages/mcdoc/src/type/index.ts
+++ b/packages/mcdoc/src/type/index.ts
@@ -127,9 +127,7 @@ export interface ReferenceType extends McdocBaseType {
 	path?: string
 }
 
-export interface UnionType<T extends McdocType = McdocType>
-	extends McdocBaseType
-{
+export interface UnionType<T extends McdocType = McdocType> extends McdocBaseType {
 	kind: 'union'
 	members: T[]
 }
@@ -308,9 +306,7 @@ export namespace McdocType {
 		let attributesString = ''
 		if (type.attributes?.length) {
 			for (const attribute of type.attributes) {
-				attributesString += `#[${attribute.name}${
-					attribute.value ? '=<value ...>' : ''
-				}] `
+				attributesString += `#[${attribute.name}${attribute.value ? '=<value ...>' : ''}] `
 			}
 		}
 		let typeString: string
@@ -353,9 +349,7 @@ export namespace McdocType {
 				typeString = `float${rangeToString(type.valueRange)}`
 				break
 			case 'indexed':
-				typeString = `${toString(type.child)}${
-					indicesToString(type.parallelIndices)
-				}`
+				typeString = `${toString(type.child)}${indicesToString(type.parallelIndices)}`
 				break
 			case 'int':
 				typeString = `int${rangeToString(type.valueRange)}`
@@ -368,9 +362,7 @@ export namespace McdocType {
 				}`
 				break
 			case 'list':
-				typeString = `[${toString(type.item)}]${
-					rangeToString(type.lengthRange)
-				}`
+				typeString = `[${toString(type.item)}]${rangeToString(type.lengthRange)}`
 				break
 			case 'literal':
 				typeString = `${type.value}`

--- a/packages/mcdoc/src/type/index.ts
+++ b/packages/mcdoc/src/type/index.ts
@@ -11,11 +11,7 @@ export interface Attribute {
 export type AttributeValue = McdocType | { kind: 'tree'; values: AttributeTree }
 export type AttributeTree = { [key: string | number]: AttributeValue }
 
-export type NumericRange = {
-	kind: RangeKind
-	min?: number
-	max?: number
-}
+export type NumericRange = { kind: RangeKind; min?: number; max?: number }
 export namespace NumericRange {
 	export function isInRange(range: NumericRange, val: number): boolean {
 		const { min = -Infinity, max = Infinity } = range
@@ -62,13 +58,7 @@ export namespace NumericRange {
 }
 
 export const StaticIndexKeywords = Object.freeze(
-	[
-		'fallback',
-		'none',
-		'unknown',
-		'spawnitem',
-		'blockitem',
-	] as const,
+	['fallback', 'none', 'unknown', 'spawnitem', 'blockitem'] as const,
 )
 export type StaticIndexKeyword = (typeof StaticIndexKeywords)[number]
 export interface StaticIndex {
@@ -79,7 +69,9 @@ export interface DynamicIndex {
 	kind: 'dynamic'
 	accessor: (string | { keyword: 'key' | 'parent' })[]
 }
-export type Index = StaticIndex | DynamicIndex
+export type Index =
+	| StaticIndex
+	| DynamicIndex
 
 /**
  * Corresponds to the IndexBodyNode
@@ -156,13 +148,8 @@ export interface MappedType extends McdocBaseType {
 	mapping: { [path: string]: McdocType }
 }
 
-export const EmptyUnion: UnionType<never> = Object.freeze({
-	kind: 'union',
-	members: [],
-})
-export function createEmptyUnion(
-	attributes?: Attribute[],
-): UnionType<never> {
+export const EmptyUnion: UnionType<never> = Object.freeze({ kind: 'union', members: [] })
+export function createEmptyUnion(attributes?: Attribute[]): UnionType<never> {
 	return {
 		...EmptyUnion,
 		// attributes,
@@ -178,10 +165,7 @@ export interface StringType extends McdocBaseType {
 	lengthRange?: NumericRange
 }
 
-export type LiteralValue =
-	| LiteralBooleanValue
-	| LiteralStringValue
-	| LiteralNumericValue
+export type LiteralValue = LiteralBooleanValue | LiteralStringValue | LiteralNumericValue
 export interface LiteralBooleanValue {
 	kind: 'boolean'
 	value: boolean
@@ -203,22 +187,12 @@ export interface NumericType extends McdocBaseType {
 	kind: NumericTypeKind
 	valueRange?: NumericRange
 }
-export const NumericTypeIntKinds = Object.freeze(
-	[
-		'byte',
-		'short',
-		'int',
-		'long',
-	] as const,
-)
+export const NumericTypeIntKinds = Object.freeze(['byte', 'short', 'int', 'long'] as const)
 export type NumericTypeIntKind = (typeof NumericTypeIntKinds)[number]
 export const NumericTypeFloatKinds = Object.freeze(['float', 'double'] as const)
 export type NumericTypeFloatKind = (typeof NumericTypeFloatKinds)[number]
 export const NumericTypeKinds = Object.freeze(
-	[
-		...NumericTypeIntKinds,
-		...NumericTypeFloatKinds,
-	] as const,
+	[...NumericTypeIntKinds, ...NumericTypeFloatKinds] as const,
 )
 export type NumericTypeKind = (typeof NumericTypeKinds)[number]
 
@@ -227,13 +201,7 @@ export interface PrimitiveArrayType extends McdocBaseType {
 	valueRange?: NumericRange
 	lengthRange?: NumericRange
 }
-export const PrimitiveArrayValueKinds = Object.freeze(
-	[
-		'byte',
-		'int',
-		'long',
-	] as const,
-)
+export const PrimitiveArrayValueKinds = Object.freeze(['byte', 'int', 'long'] as const)
 export type PrimitiveArrayValueKind = (typeof PrimitiveArrayValueKinds)[number]
 export const PrimitiveArrayKinds = Object.freeze(
 	PrimitiveArrayValueKinds.map((kind) => `${kind}_array` as const),
@@ -278,9 +246,7 @@ export namespace McdocType {
 			return range ? ` @ ${NumericRange.toString(range)}` : ''
 		}
 
-		const indicesToString = (
-			indices: Arrayable<Index | undefined>,
-		): string => {
+		const indicesToString = (indices: Arrayable<Index | undefined>): string => {
 			const strings: string[] = []
 			for (const index of Arrayable.toArray(indices)) {
 				if (index === undefined) {
@@ -290,9 +256,7 @@ export namespace McdocType {
 						index.kind === 'static'
 							? `[${index.value}]`
 							: `[[${
-								index.accessor
-									.map((v) => (typeof v === 'string' ? v : v.keyword))
-									.join('.')
+								index.accessor.map((v) => (typeof v === 'string' ? v : v.keyword)).join('.')
 							}]]`,
 					)
 				}
@@ -319,24 +283,16 @@ export namespace McdocType {
 				typeString = `byte${rangeToString(type.valueRange)}`
 				break
 			case 'byte_array':
-				typeString = `byte${rangeToString(type.valueRange)}[]${
-					rangeToString(
-						type.lengthRange,
-					)
-				}`
+				typeString = `byte${rangeToString(type.valueRange)}[]${rangeToString(type.lengthRange)}`
 				break
 			case 'concrete':
 				typeString = `${toString(type.child)}${
-					type.typeArgs.length
-						? `<${type.typeArgs.map(toString).join(', ')}>`
-						: ''
+					type.typeArgs.length ? `<${type.typeArgs.map(toString).join(', ')}>` : ''
 				}`
 				break
 			case 'dispatcher':
 				typeString = `${type.registry ?? 'spyglass:unknown'}[${
-					indicesToString(
-						type.parallelIndices,
-					)
+					indicesToString(type.parallelIndices)
 				}]`
 				break
 			case 'double':
@@ -355,11 +311,7 @@ export namespace McdocType {
 				typeString = `int${rangeToString(type.valueRange)}`
 				break
 			case 'int_array':
-				typeString = `int${rangeToString(type.valueRange)}[]${
-					rangeToString(
-						type.lengthRange,
-					)
-				}`
+				typeString = `int${rangeToString(type.valueRange)}[]${rangeToString(type.lengthRange)}`
 				break
 			case 'list':
 				typeString = `[${toString(type.item)}]${rangeToString(type.lengthRange)}`
@@ -371,11 +323,7 @@ export namespace McdocType {
 				typeString = `long${rangeToString(type.valueRange)}`
 				break
 			case 'long_array':
-				typeString = `long${rangeToString(type.valueRange)}[]${
-					rangeToString(
-						type.lengthRange,
-					)
-				}`
+				typeString = `long${rangeToString(type.valueRange)}[]${rangeToString(type.lengthRange)}`
 				break
 			case 'mapped':
 				typeString = toString(type.child)

--- a/packages/mcdoc/src/uri_processors.ts
+++ b/packages/mcdoc/src/uri_processors.ts
@@ -1,8 +1,4 @@
-import type {
-	UriBinder,
-	UriBinderContext,
-	UriSorterRegistration,
-} from '@spyglassmc/core'
+import type { UriBinder, UriBinderContext, UriSorterRegistration } from '@spyglassmc/core'
 import { fileUtil } from '@spyglassmc/core'
 import { segToIdentifier } from './common.js'
 

--- a/packages/mcdoc/src/uri_processors.ts
+++ b/packages/mcdoc/src/uri_processors.ts
@@ -5,10 +5,7 @@ import { segToIdentifier } from './common.js'
 const Extension = '.mcdoc'
 const McdocRootPrefix = 'mcdoc/'
 
-export const uriBinder: UriBinder = (
-	uris: readonly string[],
-	ctx: UriBinderContext,
-) => {
+export const uriBinder: UriBinder = (uris: readonly string[], ctx: UriBinderContext) => {
 	let urisAndRels: [string, string][] = []
 	for (const uri of uris) {
 		if (!uri.endsWith(Extension)) {
@@ -28,23 +25,17 @@ export const uriBinder: UriBinder = (
 	// A special check for the directory named `mcdoc`:
 	// If all files are put under this folder, we will treat that folder as the "root" instead.
 	if (urisAndRels.every(([_, rel]) => rel.startsWith(McdocRootPrefix))) {
-		urisAndRels = urisAndRels.map(([uri, rel]) => [
-			uri,
-			rel.slice(McdocRootPrefix.length),
-		])
+		urisAndRels = urisAndRels.map(([uri, rel]) => [uri, rel.slice(McdocRootPrefix.length)])
 	}
 	// Now the value of `urisAndRels`:
 	// file:///root/mcdoc/foo/mod.mcdoc -> foo
 	// file:///root/mcdoc/foo/bar.mcdoc -> foo/bar
 
 	for (const [uri, rel] of urisAndRels) {
-		ctx.symbols
-			.query(uri, 'mcdoc', segToIdentifier(rel.split('/')))
-			.ifKnown(() => {})
-			.elseEnter({
-				data: { subcategory: 'module' },
-				usage: { type: 'definition' },
-			})
+		ctx.symbols.query(uri, 'mcdoc', segToIdentifier(rel.split('/'))).ifKnown(() => {}).elseEnter({
+			data: { subcategory: 'module' },
+			usage: { type: 'definition' },
+		})
 	}
 }
 

--- a/packages/mcdoc/test/__fixture__.spec.ts
+++ b/packages/mcdoc/test/__fixture__.spec.ts
@@ -8,10 +8,7 @@ const DefaultTestFilePath = '/test.mcdoc'
 
 describe('mcdoc __fixture__', async () => {
 	const fixture = removeComments(
-		await fs.readFile(
-			new URL('../test/__fixture__.mcdoc', import.meta.url),
-			'utf8',
-		),
+		await fs.readFile(new URL('../test/__fixture__.mcdoc', import.meta.url), 'utf8'),
 	)
 
 	const meta = new MetaRegistry()
@@ -20,22 +17,15 @@ describe('mcdoc __fixture__', async () => {
 	for (const [caseName, untrimmedCaseContent] of getSections(fixture, 2)) {
 		const caseContent = untrimmedCaseContent.trim()
 		it(caseName, async () => {
-			const files = [...getSections(caseContent, 3, DefaultTestFilePath)]
-				.map(
-					([filePath, fileContent]) => ({
-						uri: `file://${filePath}`,
-						content: fileContent.trim(),
-					}),
-				)
+			const files = [...getSections(caseContent, 3, DefaultTestFilePath)].map((
+				[filePath, fileContent],
+			) => ({ uri: `file://${filePath}`, content: fileContent.trim() }))
 			const project = new SimpleProject(meta, files)
 			project.parse()
 			await project.bind()
 			snapshotWithUri({
 				specName: `mcdoc __fixture__ ${caseName}`,
-				uri: new URL(
-					`./__fixture__/${caseNameToFileName(caseName)}.spec.js`,
-					import.meta.url,
-				),
+				uri: new URL(`./__fixture__/${caseNameToFileName(caseName)}.spec.js`, import.meta.url),
 				value: project.dumpState(['global', 'nodes']),
 			})
 		})

--- a/packages/mcdoc/test/__fixture__.spec.ts
+++ b/packages/mcdoc/test/__fixture__.spec.ts
@@ -1,8 +1,5 @@
 import { MetaRegistry } from '@spyglassmc/core'
-import {
-	SimpleProject,
-	snapshotWithUri,
-} from '@spyglassmc/core/test-out/utils.js'
+import { SimpleProject, snapshotWithUri } from '@spyglassmc/core/test-out/utils.js'
 import { initialize } from '@spyglassmc/mcdoc'
 import fs from 'fs/promises'
 import { URL } from 'url'

--- a/packages/mcdoc/test/common.spec.ts
+++ b/packages/mcdoc/test/common.spec.ts
@@ -1,7 +1,4 @@
-import {
-	identifierToSeg,
-	segToIdentifier,
-} from '@spyglassmc/mcdoc/lib/common.js'
+import { identifierToSeg, segToIdentifier } from '@spyglassmc/mcdoc/lib/common.js'
 import { strict as assert } from 'assert'
 import { describe, it } from 'mocha'
 

--- a/packages/mcdoc/test/common.spec.ts
+++ b/packages/mcdoc/test/common.spec.ts
@@ -4,22 +4,10 @@ import { describe, it } from 'mocha'
 
 describe('mcdoc common.ts', () => {
 	const suites: { identifier: string; segments: string[] }[] = [
-		{
-			identifier: '::',
-			segments: [],
-		},
-		{
-			identifier: '::foo',
-			segments: ['foo'],
-		},
-		{
-			identifier: '::foo::bar',
-			segments: ['foo', 'bar'],
-		},
-		{
-			identifier: '::foo::bar::qux',
-			segments: ['foo', 'bar', 'qux'],
-		},
+		{ identifier: '::', segments: [] },
+		{ identifier: '::foo', segments: ['foo'] },
+		{ identifier: '::foo::bar', segments: ['foo', 'bar'] },
+		{ identifier: '::foo::bar::qux', segments: ['foo', 'bar', 'qux'] },
 	]
 	describe('identifierToSeg()', () => {
 		for (const { identifier, segments } of suites) {

--- a/packages/mcdoc/test/parser/index.spec.ts
+++ b/packages/mcdoc/test/parser/index.spec.ts
@@ -30,20 +30,9 @@ const Suites: Record<
 				'/// This is a doc comment.\nnext line test;',
 			],
 		},
-		float: {
-			content: ['', '-1.4', '0', '.7e+3'],
-		},
+		float: { content: ['', '-1.4', '0', '.7e+3'] },
 		floatRange: {
-			content: [
-				'',
-				'4.2',
-				'4.2..',
-				'4.2<..',
-				'..9.1',
-				'..<9.1',
-				'4.2..9.1',
-				'4.2<..<9.1',
-			],
+			content: ['', '4.2', '4.2..', '4.2<..', '..9.1', '..<9.1', '4.2..9.1', '4.2<..<9.1'],
 		},
 		identifier: {
 			content: [
@@ -58,26 +47,9 @@ const Suites: Record<
 				'super',
 			],
 		},
-		integer: {
-			content: ['', '-1', '0', '1'],
-		},
-		intRange: {
-			content: [
-				'',
-				'1',
-				'1..1',
-				'1..',
-				'1<..',
-				'..2',
-				'..<2',
-				'1..2',
-				'1<..<2',
-			],
-		},
-		literal: {
-			functionParams: ['foo'],
-			content: ['', 'foo', 'foobar', 'foo something else;'],
-		},
+		integer: { content: ['', '-1', '0', '1'] },
+		intRange: { content: ['', '1', '1..1', '1..', '1<..', '..2', '..<2', '1..2', '1<..<2'] },
+		literal: { functionParams: ['foo'], content: ['', 'foo', 'foobar', 'foo something else;'] },
 		path: {
 			content: [
 				'',
@@ -102,17 +74,7 @@ const Suites: Record<
 				'foo:bar\nsomething else;',
 			],
 		},
-		string: {
-			content: [
-				'',
-				'foo',
-				'"foo',
-				'"foo"',
-				'"fo\no"',
-				'"fo\\no"',
-				'"fo\\Ao"',
-			],
-		},
+		string: { content: ['', 'foo', '"foo', '"foo"', '"fo\no"', '"fo\\no"', '"fo\\Ao"'] },
 	},
 	syntax: {
 		attribute: {
@@ -147,11 +109,9 @@ const Suites: Record<
 			],
 		},
 		docComments: {
-			content: [
-				`/// First line
+			content: [`/// First line
 				/// Second line
-				Not comment`,
-			],
+				Not comment`],
 		},
 		useStatement: {
 			content: [
@@ -166,19 +126,10 @@ const Suites: Record<
 		},
 	},
 	'syntax/type': {
-		anyType: {
-			content: ['', 'other', 'any', '#[id] any'],
-		},
-		booleanType: {
-			content: ['', 'other', 'boolean'],
-		},
+		anyType: { content: ['', 'other', 'any', '#[id] any'] },
+		booleanType: { content: ['', 'other', 'boolean'] },
 		dispatcherType: {
-			content: [
-				'',
-				'entity[cow]',
-				':entity[]',
-				'minecraft:entity[cow,[%parent.id],sheep]',
-			],
+			content: ['', 'entity[cow]', ':entity[]', 'minecraft:entity[cow,[%parent.id],sheep]'],
 		},
 		enum_: {
 			content: [
@@ -202,17 +153,7 @@ const Suites: Record<
 				}`,
 			],
 		},
-		listType: {
-			content: [
-				'',
-				'[',
-				'[]',
-				'[boolean',
-				'[boolean]',
-				'[[boolean]]',
-				'[boolean,]',
-			],
-		},
+		listType: { content: ['', '[', '[]', '[boolean', '[boolean]', '[[boolean]]', '[boolean,]'] },
 		literalType: {
 			content: [
 				'',
@@ -250,12 +191,8 @@ const Suites: Record<
 				'byte @ 0..1 [] @ 0..',
 			],
 		},
-		referenceType: {
-			content: ['', '#[uuid] UuidMostLeast', 'MinMaxBounds<float @ 1..2>'],
-		},
-		stringType: {
-			content: ['', 'other', 'string', 'string @', 'string@42..'],
-		},
+		referenceType: { content: ['', '#[uuid] UuidMostLeast', 'MinMaxBounds<float @ 1..2>'] },
+		stringType: { content: ['', 'other', 'string', 'string @', 'string@42..'] },
 		struct: {
 			content: [
 				'',
@@ -319,30 +256,18 @@ const Suites: Record<
 
 describe('mcdoc parser', async () => {
 	for (const [directory, parserSuites] of Object.entries(Suites)) {
-		for (
-			const [parserName, { functionParams }] of Object.entries(
-				parserSuites,
-			)
-		) {
-			const importedParser = (
-				(await import(
-					'@spyglassmc/mcdoc/lib/parser/index.js'
-				)) as unknown as Record<string, any>
-			)[parserName]
-			const parser = (
-				functionParams ? importedParser(...functionParams) : importedParser
-			) as Parser
+		for (const [parserName, { functionParams }] of Object.entries(parserSuites)) {
+			const importedParser =
+				((await import('@spyglassmc/mcdoc/lib/parser/index.js')) as unknown as Record<
+					string,
+					any
+				>)[parserName]
+			const parser =
+				(functionParams ? importedParser(...functionParams) : importedParser) as Parser
 			const describeTitle = `${parserName}${functionParams ? '()' : ''}`
-			const uri = new URL(
-				`./${directory}/${parserName}.spec.js`,
-				import.meta.url,
-			)
+			const uri = new URL(`./${directory}/${parserName}.spec.js`, import.meta.url)
 			describe(describeTitle, () => {
-				for (
-					const content of Suites[directory as keyof typeof Suites][
-						parserName
-					].content
-				) {
+				for (const content of Suites[directory as keyof typeof Suites][parserName].content) {
 					const itTitle = `Parse "${showWhitespaceGlyph(content)}"`
 					it(itTitle, () => {
 						snapshotWithUri({

--- a/packages/mcdoc/test/runtime/checker.spec.ts
+++ b/packages/mcdoc/test/runtime/checker.spec.ts
@@ -12,853 +12,494 @@ import snapshot from 'snap-shot-it'
 import { TextDocument } from 'vscode-languageserver-textdocument'
 
 describe('mcdoc runtime checker', () => {
-	type JsValue = boolean | number | string | JsValue[] | {
-		[key: string]: JsValue
-	}
+	type JsValue = boolean | number | string | JsValue[] | { [key: string]: JsValue }
 	const suites: {
 		name: string
 		type: McdocType
 		init?: (symbols: core.SymbolUtil) => void
 		values: JsValue[]
-	}[] = [
-		{
-			name: 'struct { test: double }',
-			type: {
-				kind: 'struct',
-				fields: [
-					{ kind: 'pair', key: 'test', type: { kind: 'double' } },
-				],
-			},
-			values: [
-				{ test: 1 },
-				{ test: 'hello' },
-			],
+	}[] = [{
+		name: 'struct { test: double }',
+		type: { kind: 'struct', fields: [{ kind: 'pair', key: 'test', type: { kind: 'double' } }] },
+		values: [{ test: 1 }, { test: 'hello' }],
+	}, {
+		name: 'struct { foo: string, bar: [double] }',
+		type: {
+			kind: 'struct',
+			fields: [{ kind: 'pair', key: 'foo', type: { kind: 'string' } }, {
+				kind: 'pair',
+				key: 'bar',
+				type: { kind: 'list', item: { kind: 'double' } },
+			}],
 		},
-		{
-			name: 'struct { foo: string, bar: [double] }',
-			type: {
+		values: [2, {}, { foo: 'hello' }, { foo: true, bar: [] }],
+	}, {
+		name: '( struct { text: string } | struct { selector: number })',
+		type: {
+			kind: 'union',
+			members: [{
 				kind: 'struct',
-				fields: [
-					{ kind: 'pair', key: 'foo', type: { kind: 'string' } },
-					{
+				fields: [{ kind: 'pair', key: 'text', type: { kind: 'string' } }],
+			}, {
+				kind: 'struct',
+				fields: [{ kind: 'pair', key: 'selector', type: { kind: 'double' } }],
+			}],
+		},
+		values: [{}, { text: 'something' }, { selector: 20 }, { text: 'foo', selector: 40 }, {
+			selector: [1],
+		}],
+	}, {
+		name: '[struct { foo: double, bar?: boolean }]',
+		type: {
+			kind: 'list',
+			item: {
+				kind: 'struct',
+				fields: [{ kind: 'pair', key: 'foo', type: { kind: 'double' } }, {
+					kind: 'pair',
+					key: 'bar',
+					optional: true,
+					type: { kind: 'boolean' },
+				}],
+			},
+		},
+		values: [[], [4], [{}], [{ foo: 5 }], [{ foo: 2 }, { foo: 3, bar: 4 }, 'test']],
+	}, {
+		name: 'struct { pages: ([struct { raw: string, filtered?: string }] | [string]) }',
+		type: {
+			kind: 'struct',
+			fields: [{
+				kind: 'pair',
+				key: 'pages',
+				type: {
+					kind: 'union',
+					members: [{
+						kind: 'list',
+						item: {
+							kind: 'struct',
+							fields: [{ kind: 'pair', key: 'raw', type: { kind: 'string' } }, {
+								kind: 'pair',
+								key: 'filtered',
+								optional: true,
+								type: { kind: 'string' },
+							}],
+						},
+					}, { kind: 'list', item: { kind: 'string' } }],
+				},
+			}],
+		},
+		values: [{ pages: [] }, { pages: ['foo', 'bar'] }, {
+			pages: [{ raw: 'foo' }, { raw: 'bar', filtered: 'baz' }],
+		}, { pages: ['foo', { raw: 'bar' }] }],
+	}, {
+		name: 'struct { ...struct { foo: double, bar: boolean }, foo: string }',
+		type: {
+			kind: 'struct',
+			fields: [{
+				kind: 'spread',
+				type: {
+					kind: 'struct',
+					fields: [{ kind: 'pair', key: 'foo', type: { kind: 'double' } }, {
 						kind: 'pair',
 						key: 'bar',
-						type: { kind: 'list', item: { kind: 'double' } },
-					},
-				],
-			},
-			values: [
-				2,
-				{},
-				{ foo: 'hello' },
-				{ foo: true, bar: [] },
-			],
+						type: { kind: 'boolean' },
+					}],
+				},
+			}, { kind: 'pair', key: 'foo', type: { kind: 'string' } }],
 		},
-		{
-			name: '( struct { text: string } | struct { selector: number })',
-			type: {
-				kind: 'union',
-				members: [
-					{
-						kind: 'struct',
-						fields: [
-							{ kind: 'pair', key: 'text', type: { kind: 'string' } },
-						],
-					},
-					{
-						kind: 'struct',
-						fields: [
-							{
-								kind: 'pair',
-								key: 'selector',
-								type: { kind: 'double' },
-							},
-						],
-					},
-				],
+		values: [{}, { foo: 'hello' }, { foo: 'hello', bar: true }, { foo: 4, bar: false }],
+	}, {
+		name: 'struct { foo: double, bar: string }[foo]',
+		type: {
+			kind: 'indexed',
+			child: {
+				kind: 'struct',
+				fields: [{ kind: 'pair', key: 'foo', type: { kind: 'double' } }, {
+					kind: 'pair',
+					key: 'bar',
+					type: { kind: 'string' },
+				}],
 			},
-			values: [
-				{},
-				{ text: 'something' },
-				{ selector: 20 },
-				{ text: 'foo', selector: 40 },
-				{ selector: [1] },
-			],
+			parallelIndices: [{ kind: 'static', value: 'foo' }],
 		},
-		{
-			name: '[struct { foo: double, bar?: boolean }]',
-			type: {
-				kind: 'list',
-				item: {
-					kind: 'struct',
-					fields: [
-						{ kind: 'pair', key: 'foo', type: { kind: 'double' } },
-						{
+		values: [{ foo: 4, bar: 'wrong' }, 5, 'hello'],
+	}, {
+		name:
+			'struct { id: string, ...struct { test: struct { config: double }, other: struct { baz: boolean } }[[id]] }',
+		type: {
+			kind: 'struct',
+			fields: [{ kind: 'pair', key: 'id', type: { kind: 'string' } }, {
+				kind: 'spread',
+				type: {
+					kind: 'indexed',
+					child: {
+						kind: 'struct',
+						fields: [{
 							kind: 'pair',
-							key: 'bar',
-							optional: true,
-							type: { kind: 'boolean' },
-						},
-					],
-				},
-			},
-			values: [
-				[],
-				[4],
-				[{}],
-				[{ foo: 5 }],
-				[{ foo: 2 }, { foo: 3, bar: 4 }, 'test'],
-			],
-		},
-		{
-			name: 'struct { pages: ([struct { raw: string, filtered?: string }] | [string]) }',
-			type: {
-				kind: 'struct',
-				fields: [
-					{
-						kind: 'pair',
-						key: 'pages',
-						type: {
-							kind: 'union',
-							members: [
-								{
-									kind: 'list',
-									item: {
-										kind: 'struct',
-										fields: [
-											{
-												kind: 'pair',
-												key: 'raw',
-												type: { kind: 'string' },
-											},
-											{
-												kind: 'pair',
-												key: 'filtered',
-												optional: true,
-												type: { kind: 'string' },
-											},
-										],
-									},
-								},
-								{
-									kind: 'list',
-									item: {
-										kind: 'string',
-									},
-								},
-							],
-						},
+							key: 'test',
+							type: {
+								kind: 'struct',
+								fields: [{ kind: 'pair', key: 'config', type: { kind: 'double' } }],
+							},
+						}, {
+							kind: 'pair',
+							key: 'other',
+							type: {
+								kind: 'struct',
+								fields: [{ kind: 'pair', key: 'baz', type: { kind: 'boolean' } }],
+							},
+						}],
 					},
-				],
-			},
-			values: [
-				{ pages: [] },
-				{ pages: ['foo', 'bar'] },
-				{ pages: [{ raw: 'foo' }, { raw: 'bar', filtered: 'baz' }] },
-				{ pages: ['foo', { raw: 'bar' }] },
-			],
-		},
-		{
-			name: 'struct { ...struct { foo: double, bar: boolean }, foo: string }',
-			type: {
-				kind: 'struct',
-				fields: [
-					{
-						kind: 'spread',
-						type: {
-							kind: 'struct',
-							fields: [
-								{ kind: 'pair', key: 'foo', type: { kind: 'double' } },
-								{ kind: 'pair', key: 'bar', type: { kind: 'boolean' } },
-							],
-						},
-					},
-					{ kind: 'pair', key: 'foo', type: { kind: 'string' } },
-				],
-			},
-			values: [
-				{},
-				{ foo: 'hello' },
-				{ foo: 'hello', bar: true },
-				{ foo: 4, bar: false },
-			],
-		},
-		{
-			name: 'struct { foo: double, bar: string }[foo]',
-			type: {
-				kind: 'indexed',
-				child: {
-					kind: 'struct',
-					fields: [
-						{ kind: 'pair', key: 'foo', type: { kind: 'double' } },
-						{ kind: 'pair', key: 'bar', type: { kind: 'string' } },
-					],
+					parallelIndices: [{ kind: 'dynamic', accessor: ['id'] }],
 				},
-				parallelIndices: [
-					{ kind: 'static', value: 'foo' },
-				],
-			},
-			values: [
-				{ foo: 4, bar: 'wrong' },
-				5,
-				'hello',
-			],
+			}],
 		},
-		{
-			name:
-				'struct { id: string, ...struct { test: struct { config: double }, other: struct { baz: boolean } }[[id]] }',
-			type: {
+		values: [
+			{},
+			{ id: 'fallback' },
+			{ id: 'test' },
+			{ id: 'test', config: 'hello' },
+			{ id: 'test', config: 5 },
+			{ id: 'test', baz: true },
+			{ id: 'other' },
+			{ id: 'other', baz: 'world' },
+			{ id: 'other', baz: true },
+		],
+	}, {
+		name: 'double @ 3..6.2',
+		type: { kind: 'double', valueRange: { kind: 0b00, min: 3, max: 6.2 } },
+		values: ['hello', 1, 3, 4, 6.2, 6.3],
+	}, {
+		name: 'double @ 2..<4',
+		type: { kind: 'double', valueRange: { kind: 0b01, min: 2, max: 4 } },
+		values: [2, 3.99, 4],
+	}, {
+		name: '(double @ 2..4 | double @ 8..)',
+		type: {
+			kind: 'union',
+			members: [{ kind: 'double', valueRange: { kind: 0b00, min: 2, max: 4 } }, {
+				kind: 'double',
+				valueRange: { kind: 0b00, min: 8 },
+			}],
+		},
+		values: [3, 5, 9],
+	}, {
+		name: '(struct { foo: int @ 0..5 } | struct { foo: int @ 4..6 })',
+		type: {
+			kind: 'union',
+			members: [{
 				kind: 'struct',
-				fields: [
-					{ kind: 'pair', key: 'id', type: { kind: 'string' } },
-					{
-						kind: 'spread',
-						type: {
-							kind: 'indexed',
+				fields: [{
+					kind: 'pair',
+					key: 'foo',
+					type: { kind: 'int', valueRange: { kind: 0b00, min: 0, max: 5 } },
+				}],
+			}, {
+				kind: 'struct',
+				fields: [{
+					kind: 'pair',
+					key: 'foo',
+					type: { kind: 'int', valueRange: { kind: 0b00, min: 4, max: 6 } },
+				}],
+			}],
+		},
+		values: [{ foo: 4 }, { foo: 9 }],
+	}, {
+		name: '(struct { foo: (int @ 0..5 | int @ 20..25) } | struct { foo: int @ 4..6 })',
+		type: {
+			kind: 'union',
+			members: [{
+				kind: 'struct',
+				fields: [{
+					kind: 'pair',
+					key: 'foo',
+					type: {
+						kind: 'union',
+						members: [{ kind: 'int', valueRange: { kind: 0b00, min: 0, max: 5 } }, {
+							kind: 'int',
+							valueRange: { kind: 0b00, min: 20, max: 25 },
+						}],
+					},
+				}],
+			}, {
+				kind: 'struct',
+				fields: [{
+					kind: 'pair',
+					key: 'foo',
+					type: { kind: 'int', valueRange: { kind: 0b00, min: 4, max: 6 } },
+				}],
+			}],
+		},
+		values: [{ foo: 4 }, { foo: 9 }, { foo: 23 }],
+	}, {
+		name: '[int] @ 0..5',
+		type: { kind: 'list', item: { kind: 'int' }, lengthRange: { kind: 0b00, min: 0, max: 5 } },
+		values: [[], [1, 2, 3], [1, 2, 3, 4, 5, 6]],
+	}, {
+		name: '[double @ 0..1] @ 1..3',
+		type: {
+			kind: 'list',
+			item: { kind: 'double', valueRange: { kind: 0b00, min: 0, max: 1 } },
+			lengthRange: { kind: 0b00, min: 1, max: 3 },
+		},
+		values: [[], [0.3, 0.1], [0.2, 6], [0.3, 0.9, 0.1, 0.1], [2, 0.9, 0.1, 0.1]],
+	}, {
+		name: 'string @ ..8',
+		type: { kind: 'string', lengthRange: { kind: 0b00, max: 8 } },
+		values: [1, 'abc', 'abcdefghij'],
+	}, {
+		name:
+			'struct { id: string, data: struct { test: struct { config: double }, other: struct { baz: boolean } }[[id]] }',
+		type: {
+			kind: 'struct',
+			fields: [{ kind: 'pair', key: 'id', type: { kind: 'string' } }, {
+				kind: 'pair',
+				key: 'data',
+				type: {
+					kind: 'indexed',
+					child: {
+						kind: 'struct',
+						fields: [{
+							kind: 'pair',
+							key: 'test',
+							type: {
+								kind: 'struct',
+								fields: [{ kind: 'pair', key: 'config', type: { kind: 'double' } }],
+							},
+						}, {
+							kind: 'pair',
+							key: 'other',
+							type: {
+								kind: 'struct',
+								fields: [{ kind: 'pair', key: 'baz', type: { kind: 'boolean' } }],
+							},
+						}],
+					},
+					parallelIndices: [{ kind: 'dynamic', accessor: ['id'] }],
+				},
+			}],
+		},
+		values: [
+			{},
+			{ id: 'fallback' },
+			{ id: 'fallback', data: {} },
+			{ id: 'fallback', data: { config: 'hello' } },
+			{ id: 'fallback', data: { baz: true } },
+			{ id: 'test', data: {} },
+			{ id: 'test', data: { config: 'hello' } },
+			{ id: 'test', data: { config: 5 } },
+			{ id: 'test', data: { baz: true } },
+			{ id: 'other', data: {} },
+			{ id: 'other', data: { baz: 'world' } },
+			{ id: 'other', data: { baz: true } },
+		],
+	}, {
+		name: 'type Bounds<T> = struct { min: T, max: T }; Bounds<int @ 1..>',
+		type: {
+			kind: 'concrete',
+			child: { kind: 'reference', path: '::Bounds' },
+			typeArgs: [{ kind: 'int', valueRange: { kind: 0b00, min: 1 } }],
+		},
+		init: (symbols) => {
+			symbols.query(TextDocument.create('', '', 0, ''), 'mcdoc', '::Bounds').enter({
+				data: {
+					subcategory: 'type_alias',
+					data: {
+						typeDef: {
+							kind: 'template',
+							typeParams: [{ path: '::T' }],
 							child: {
 								kind: 'struct',
-								fields: [
-									{
-										kind: 'pair',
-										key: 'test',
-										type: {
-											kind: 'struct',
-											fields: [
-												{
-													kind: 'pair',
-													key: 'config',
-													type: { kind: 'double' },
-												},
-											],
-										},
-									},
-									{
-										kind: 'pair',
-										key: 'other',
-										type: {
-											kind: 'struct',
-											fields: [
-												{
-													kind: 'pair',
-													key: 'baz',
-													type: { kind: 'boolean' },
-												},
-											],
-										},
-									},
-								],
+								fields: [{
+									kind: 'pair',
+									key: 'min',
+									type: { kind: 'reference', path: '::T' },
+								}, { kind: 'pair', key: 'max', type: { kind: 'reference', path: '::T' } }],
 							},
-							parallelIndices: [
-								{ kind: 'dynamic', accessor: ['id'] },
-							],
-						},
+						} satisfies McdocType,
 					},
-				],
-			},
-			values: [
-				{},
-				{ id: 'fallback' },
-				{ id: 'test' },
-				{ id: 'test', config: 'hello' },
-				{ id: 'test', config: 5 },
-				{ id: 'test', baz: true },
-				{ id: 'other' },
-				{ id: 'other', baz: 'world' },
-				{ id: 'other', baz: true },
-			],
-		},
-		{
-			name: 'double @ 3..6.2',
-			type: {
-				kind: 'double',
-				valueRange: { kind: 0b00, min: 3, max: 6.2 },
-			},
-			values: [
-				'hello',
-				1,
-				3,
-				4,
-				6.2,
-				6.3,
-			],
-		},
-		{
-			name: 'double @ 2..<4',
-			type: {
-				kind: 'double',
-				valueRange: { kind: 0b01, min: 2, max: 4 },
-			},
-			values: [
-				2,
-				3.99,
-				4,
-			],
-		},
-		{
-			name: '(double @ 2..4 | double @ 8..)',
-			type: {
-				kind: 'union',
-				members: [
-					{
-						kind: 'double',
-						valueRange: { kind: 0b00, min: 2, max: 4 },
-					},
-					{
-						kind: 'double',
-						valueRange: { kind: 0b00, min: 8 },
-					},
-				],
-			},
-			values: [
-				3,
-				5,
-				9,
-			],
-		},
-		{
-			name: '(struct { foo: int @ 0..5 } | struct { foo: int @ 4..6 })',
-			type: {
-				kind: 'union',
-				members: [
-					{
-						kind: 'struct',
-						fields: [
-							{
-								kind: 'pair',
-								key: 'foo',
-								type: {
-									kind: 'int',
-									valueRange: { kind: 0b00, min: 0, max: 5 },
-								},
-							},
-						],
-					},
-					{
-						kind: 'struct',
-						fields: [
-							{
-								kind: 'pair',
-								key: 'foo',
-								type: {
-									kind: 'int',
-									valueRange: { kind: 0b00, min: 4, max: 6 },
-								},
-							},
-						],
-					},
-				],
-			},
-			values: [
-				{ foo: 4 },
-				{ foo: 9 },
-			],
-		},
-		{
-			name: '(struct { foo: (int @ 0..5 | int @ 20..25) } | struct { foo: int @ 4..6 })',
-			type: {
-				kind: 'union',
-				members: [
-					{
-						kind: 'struct',
-						fields: [
-							{
-								kind: 'pair',
-								key: 'foo',
-								type: {
-									kind: 'union',
-									members: [
-										{
-											kind: 'int',
-											valueRange: { kind: 0b00, min: 0, max: 5 },
-										},
-										{
-											kind: 'int',
-											valueRange: { kind: 0b00, min: 20, max: 25 },
-										},
-									],
-								},
-							},
-						],
-					},
-					{
-						kind: 'struct',
-						fields: [
-							{
-								kind: 'pair',
-								key: 'foo',
-								type: {
-									kind: 'int',
-									valueRange: { kind: 0b00, min: 4, max: 6 },
-								},
-							},
-						],
-					},
-				],
-			},
-			values: [
-				{ foo: 4 },
-				{ foo: 9 },
-				{ foo: 23 },
-			],
-		},
-		{
-			name: '[int] @ 0..5',
-			type: {
-				kind: 'list',
-				item: { kind: 'int' },
-				lengthRange: { kind: 0b00, min: 0, max: 5 },
-			},
-			values: [
-				[],
-				[1, 2, 3],
-				[1, 2, 3, 4, 5, 6],
-			],
-		},
-		{
-			name: '[double @ 0..1] @ 1..3',
-			type: {
-				kind: 'list',
-				item: {
-					kind: 'double',
-					valueRange: { kind: 0b00, min: 0, max: 1 },
 				},
-				lengthRange: { kind: 0b00, min: 1, max: 3 },
-			},
-			values: [
-				[],
-				[0.3, 0.1],
-				[0.2, 6],
-				[0.3, 0.9, 0.1, 0.1],
-				[2, 0.9, 0.1, 0.1],
-			],
+				usage: { type: 'definition' },
+			})
 		},
-		{
-			name: 'string @ ..8',
-			type: {
-				kind: 'string',
-				lengthRange: { kind: 0b00, max: 8 },
-			},
-			values: [
-				1,
-				'abc',
-				'abcdefghij',
-			],
+		values: [{}, { min: 2, max: 5 }, { min: 'hello', max: -1 }],
+	}, {
+		name: 'type Tag<V> = (V | [V]); Tag<string>',
+		type: {
+			kind: 'concrete',
+			child: { kind: 'reference', path: '::Tag' },
+			typeArgs: [{ kind: 'string' }],
 		},
-		{
-			name:
-				'struct { id: string, data: struct { test: struct { config: double }, other: struct { baz: boolean } }[[id]] }',
-			type: {
-				kind: 'struct',
-				fields: [
-					{ kind: 'pair', key: 'id', type: { kind: 'string' } },
-					{
-						kind: 'pair',
-						key: 'data',
-						type: {
-							kind: 'indexed',
+		init: (symbols) => {
+			symbols.query(TextDocument.create('', '', 0, ''), 'mcdoc', '::Tag').enter({
+				data: {
+					subcategory: 'type_alias',
+					data: {
+						typeDef: {
+							kind: 'template',
+							typeParams: [{ path: '::V' }],
+							child: {
+								kind: 'union',
+								members: [{ kind: 'reference', path: '::V' }, {
+									kind: 'list',
+									item: { kind: 'reference', path: '::V' },
+								}],
+							},
+						} satisfies McdocType,
+					},
+				},
+				usage: { type: 'definition' },
+			})
+		},
+		values: [2, 'hello', [], ['test'], [10]],
+	}, {
+		name: 'type Tag<V> = [int, V]; Tag<string>',
+		type: {
+			kind: 'concrete',
+			child: { kind: 'reference', path: '::Tag' },
+			typeArgs: [{ kind: 'string' }],
+		},
+		init: (symbols) => {
+			symbols.query(TextDocument.create('', '', 0, ''), 'mcdoc', '::Tag').enter({
+				data: {
+					subcategory: 'type_alias',
+					data: {
+						typeDef: {
+							kind: 'template',
+							typeParams: [{ path: '::V' }],
+							child: {
+								kind: 'tuple',
+								items: [{ kind: 'int' }, { kind: 'reference', path: '::V' }],
+							},
+						} satisfies McdocType,
+					},
+				},
+				usage: { type: 'definition' },
+			})
+		},
+		values: ['test', [4, 5], [10, 'test'], ['foo', 'test'], [10]],
+	}, {
+		name:
+			'type Inner<B> = struct { bar: B }; type Outer<A> = struct { foo: Inner<[A]> }; Outer<string>',
+		type: {
+			kind: 'concrete',
+			child: { kind: 'reference', path: '::Outer' },
+			typeArgs: [{ kind: 'string' }],
+		},
+		init: (symbols) => {
+			symbols.query(TextDocument.create('', '', 0, ''), 'mcdoc', '::Outer').enter({
+				data: {
+					subcategory: 'type_alias',
+					data: {
+						typeDef: {
+							kind: 'template',
+							typeParams: [{ path: '::A' }],
 							child: {
 								kind: 'struct',
-								fields: [
-									{
-										kind: 'pair',
-										key: 'test',
-										type: {
-											kind: 'struct',
-											fields: [
-												{
-													kind: 'pair',
-													key: 'config',
-													type: { kind: 'double' },
-												},
-											],
-										},
-									},
-									{
-										kind: 'pair',
-										key: 'other',
-										type: {
-											kind: 'struct',
-											fields: [
-												{
-													kind: 'pair',
-													key: 'baz',
-													type: { kind: 'boolean' },
-												},
-											],
-										},
-									},
-								],
-							},
-							parallelIndices: [
-								{ kind: 'dynamic', accessor: ['id'] },
-							],
-						},
-					},
-				],
-			},
-			values: [
-				{},
-				{ id: 'fallback' },
-				{ id: 'fallback', data: {} },
-				{ id: 'fallback', data: { config: 'hello' } },
-				{ id: 'fallback', data: { baz: true } },
-				{ id: 'test', data: {} },
-				{ id: 'test', data: { config: 'hello' } },
-				{ id: 'test', data: { config: 5 } },
-				{ id: 'test', data: { baz: true } },
-				{ id: 'other', data: {} },
-				{ id: 'other', data: { baz: 'world' } },
-				{ id: 'other', data: { baz: true } },
-			],
-		},
-		{
-			name: 'type Bounds<T> = struct { min: T, max: T }; Bounds<int @ 1..>',
-			type: {
-				kind: 'concrete',
-				child: { kind: 'reference', path: '::Bounds' },
-				typeArgs: [{ kind: 'int', valueRange: { kind: 0b00, min: 1 } }],
-			},
-			init: (symbols) => {
-				symbols.query(
-					TextDocument.create('', '', 0, ''),
-					'mcdoc',
-					'::Bounds',
-				).enter({
-					data: {
-						subcategory: 'type_alias',
-						data: {
-							typeDef: {
-								kind: 'template',
-								typeParams: [
-									{ path: '::T' },
-								],
-								child: {
-									kind: 'struct',
-									fields: [
-										{
-											kind: 'pair',
-											key: 'min',
-											type: {
-												kind: 'reference',
-												path: '::T',
-											},
-										},
-										{
-											kind: 'pair',
-											key: 'max',
-											type: {
-												kind: 'reference',
-												path: '::T',
-											},
-										},
-									],
-								},
-							} satisfies McdocType,
-						},
-					},
-					usage: { type: 'definition' },
-				})
-			},
-			values: [
-				{},
-				{ min: 2, max: 5 },
-				{ min: 'hello', max: -1 },
-			],
-		},
-		{
-			name: 'type Tag<V> = (V | [V]); Tag<string>',
-			type: {
-				kind: 'concrete',
-				child: { kind: 'reference', path: '::Tag' },
-				typeArgs: [{ kind: 'string' }],
-			},
-			init: (symbols) => {
-				symbols.query(
-					TextDocument.create('', '', 0, ''),
-					'mcdoc',
-					'::Tag',
-				).enter({
-					data: {
-						subcategory: 'type_alias',
-						data: {
-							typeDef: {
-								kind: 'template',
-								typeParams: [
-									{ path: '::V' },
-								],
-								child: {
-									kind: 'union',
-									members: [
-										{
-											kind: 'reference',
-											path: '::V',
-										},
-										{
+								fields: [{
+									kind: 'pair',
+									key: 'foo',
+									type: {
+										kind: 'concrete',
+										child: { kind: 'reference', path: '::Inner' },
+										typeArgs: [{
 											kind: 'list',
-											item: {
-												kind: 'reference',
-												path: '::V',
-											},
-										},
-									],
-								},
-							} satisfies McdocType,
-						},
-					},
-					usage: { type: 'definition' },
-				})
-			},
-			values: [
-				2,
-				'hello',
-				[],
-				['test'],
-				[10],
-			],
-		},
-		{
-			name: 'type Tag<V> = [int, V]; Tag<string>',
-			type: {
-				kind: 'concrete',
-				child: { kind: 'reference', path: '::Tag' },
-				typeArgs: [{ kind: 'string' }],
-			},
-			init: (symbols) => {
-				symbols.query(
-					TextDocument.create('', '', 0, ''),
-					'mcdoc',
-					'::Tag',
-				).enter({
-					data: {
-						subcategory: 'type_alias',
-						data: {
-							typeDef: {
-								kind: 'template',
-								typeParams: [
-									{ path: '::V' },
-								],
-								child: {
-									kind: 'tuple',
-									items: [
-										{
-											kind: 'int',
-										},
-										{
-											kind: 'reference',
-											path: '::V',
-										},
-									],
-								},
-							} satisfies McdocType,
-						},
-					},
-					usage: { type: 'definition' },
-				})
-			},
-			values: [
-				'test',
-				[4, 5],
-				[10, 'test'],
-				['foo', 'test'],
-				[10],
-			],
-		},
-		{
-			name:
-				'type Inner<B> = struct { bar: B }; type Outer<A> = struct { foo: Inner<[A]> }; Outer<string>',
-			type: {
-				kind: 'concrete',
-				child: { kind: 'reference', path: '::Outer' },
-				typeArgs: [{ kind: 'string' }],
-			},
-			init: (symbols) => {
-				symbols.query(
-					TextDocument.create('', '', 0, ''),
-					'mcdoc',
-					'::Outer',
-				).enter({
-					data: {
-						subcategory: 'type_alias',
-						data: {
-							typeDef: {
-								kind: 'template',
-								typeParams: [
-									{ path: '::A' },
-								],
-								child: {
-									kind: 'struct',
-									fields: [
-										{
-											kind: 'pair',
-											key: 'foo',
-											type: {
-												kind: 'concrete',
-												child: {
-													kind: 'reference',
-													path: '::Inner',
-												},
-												typeArgs: [
-													{
-														kind: 'list',
-														item: {
-															kind: 'reference',
-															path: '::A',
-														},
-													},
-												],
-											},
-										},
-									],
-								},
-							} satisfies McdocType,
-						},
-					},
-					usage: { type: 'definition' },
-				})
-				symbols.query(
-					TextDocument.create('', '', 0, ''),
-					'mcdoc',
-					'::Inner',
-				).enter({
-					data: {
-						subcategory: 'type_alias',
-						data: {
-							typeDef: {
-								kind: 'template',
-								typeParams: [
-									{ path: '::B' },
-								],
-								child: {
-									kind: 'struct',
-									fields: [
-										{
-											kind: 'pair',
-											key: 'bar',
-											type: {
-												kind: 'reference',
-												path: '::B',
-											},
-										},
-									],
-								},
-							} satisfies McdocType,
-						},
-					},
-					usage: { type: 'definition' },
-				})
-			},
-			values: [
-				{ foo: 3 },
-				{ foo: { bar: 'hello' } },
-				{ foo: { bar: ['hello'] } },
-				{ foo: { bar: [2] } },
-			],
-		},
-		{
-			name: 'type Ref = double; struct { foo: Ref }',
-			type: {
-				kind: 'struct',
-				fields: [
-					{
-						kind: 'pair',
-						key: 'foo',
-						type: { kind: 'reference', path: '::Ref' },
-					},
-				],
-			},
-			init: (symbols) => {
-				symbols.query(
-					TextDocument.create('', '', 0, ''),
-					'mcdoc',
-					'::Ref',
-				).enter({
-					data: {
-						subcategory: 'type_alias',
-						data: {
-							typeDef: {
-								kind: 'double',
-							} satisfies McdocType,
-						},
-					},
-					usage: { type: 'definition' },
-				})
-			},
-			values: [
-				{},
-				{ foo: 'hello' },
-				{ foo: 4.1 },
-			],
-		},
-		{
-			name:
-				'dispatch minecraft:item[elytra] to struct { Damage: double }; struct { id: string, tag?: minecraft:item[[id]] }',
-			type: {
-				kind: 'struct',
-				fields: [
-					{ kind: 'pair', key: 'id', type: { kind: 'string' } },
-					{
-						kind: 'pair',
-						key: 'tag',
-						optional: true,
-						type: {
-							kind: 'dispatcher',
-							registry: 'minecraft:item',
-							parallelIndices: [
-								{ kind: 'dynamic', accessor: ['id'] },
-							],
-						},
-					},
-				],
-			},
-			init: (symbols) => {
-				symbols.query(
-					TextDocument.create('', '', 0, ''),
-					'mcdoc/dispatcher',
-					'minecraft:item',
-				).enter({
-					usage: { type: 'reference' },
-				})
-				symbols.query(
-					TextDocument.create('', '', 0, ''),
-					'mcdoc/dispatcher',
-					'minecraft:item',
-					'elytra',
-				).enter({
-					data: {
-						data: {
-							typeDef: {
-								kind: 'struct',
-								fields: [
-									{
-										kind: 'pair',
-										key: 'Damage',
-										type: { kind: 'double' },
+											item: { kind: 'reference', path: '::A' },
+										}],
 									},
-								],
-							} satisfies McdocType,
-						},
+								}],
+							},
+						} satisfies McdocType,
 					},
-					usage: { type: 'definition' },
-				})
-			},
-			values: [
-				{},
-				{ id: 'diamond' },
-				{ id: 'elytra', tag: {} },
-				{ id: 'eltrya', tag: { Damage: true } },
-				{ id: 'eltrya', tag: { Damage: 20 } },
-			],
+				},
+				usage: { type: 'definition' },
+			})
+			symbols.query(TextDocument.create('', '', 0, ''), 'mcdoc', '::Inner').enter({
+				data: {
+					subcategory: 'type_alias',
+					data: {
+						typeDef: {
+							kind: 'template',
+							typeParams: [{ path: '::B' }],
+							child: {
+								kind: 'struct',
+								fields: [{
+									kind: 'pair',
+									key: 'bar',
+									type: { kind: 'reference', path: '::B' },
+								}],
+							},
+						} satisfies McdocType,
+					},
+				},
+				usage: { type: 'definition' },
+			})
 		},
-	]
+		values: [{ foo: 3 }, { foo: { bar: 'hello' } }, { foo: { bar: ['hello'] } }, {
+			foo: { bar: [2] },
+		}],
+	}, {
+		name: 'type Ref = double; struct { foo: Ref }',
+		type: {
+			kind: 'struct',
+			fields: [{ kind: 'pair', key: 'foo', type: { kind: 'reference', path: '::Ref' } }],
+		},
+		init: (symbols) => {
+			symbols.query(TextDocument.create('', '', 0, ''), 'mcdoc', '::Ref').enter({
+				data: {
+					subcategory: 'type_alias',
+					data: { typeDef: { kind: 'double' } satisfies McdocType },
+				},
+				usage: { type: 'definition' },
+			})
+		},
+		values: [{}, { foo: 'hello' }, { foo: 4.1 }],
+	}, {
+		name:
+			'dispatch minecraft:item[elytra] to struct { Damage: double }; struct { id: string, tag?: minecraft:item[[id]] }',
+		type: {
+			kind: 'struct',
+			fields: [{ kind: 'pair', key: 'id', type: { kind: 'string' } }, {
+				kind: 'pair',
+				key: 'tag',
+				optional: true,
+				type: {
+					kind: 'dispatcher',
+					registry: 'minecraft:item',
+					parallelIndices: [{ kind: 'dynamic', accessor: ['id'] }],
+				},
+			}],
+		},
+		init: (symbols) => {
+			symbols.query(TextDocument.create('', '', 0, ''), 'mcdoc/dispatcher', 'minecraft:item')
+				.enter({ usage: { type: 'reference' } })
+			symbols.query(
+				TextDocument.create('', '', 0, ''),
+				'mcdoc/dispatcher',
+				'minecraft:item',
+				'elytra',
+			).enter({
+				data: {
+					data: {
+						typeDef: {
+							kind: 'struct',
+							fields: [{ kind: 'pair', key: 'Damage', type: { kind: 'double' } }],
+						} satisfies McdocType,
+					},
+				},
+				usage: { type: 'definition' },
+			})
+		},
+		values: [{}, { id: 'diamond' }, { id: 'elytra', tag: {} }, {
+			id: 'eltrya',
+			tag: { Damage: true },
+		}, { id: 'eltrya', tag: { Damage: 20 } }],
+	}]
 
 	function inferType(value: JsValue): Exclude<McdocType, UnionType> {
 		if (typeof value === 'boolean') {
 			return { kind: 'boolean' }
 		} else if (typeof value === 'number') {
-			return {
-				kind: 'literal',
-				value: { kind: 'double', value: Number(value) },
-			}
+			return { kind: 'literal', value: { kind: 'double', value: Number(value) } }
 		} else if (typeof value === 'string') {
 			return { kind: 'literal', value: { kind: 'string', value } }
 		} else if (Array.isArray(value)) {
@@ -883,17 +524,11 @@ describe('mcdoc runtime checker', () => {
 						}),
 						getChildren: (value) => {
 							if (Array.isArray(value)) {
-								return value.map((e) => [{
-									originalNode: e,
-									inferredType: inferType(e),
-								}])
+								return value.map((e) => [{ originalNode: e, inferredType: inferType(e) }])
 							} else if (typeof value === 'object') {
 								return Object.entries(value).map(([k, v]) => ({
 									key: { originalNode: k, inferredType: inferType(k) },
-									possibleValues: [{
-										originalNode: v,
-										inferredType: inferType(v),
-									}],
+									possibleValues: [{ originalNode: v, inferredType: inferType(v) }],
 								}))
 							}
 							return []
@@ -904,24 +539,14 @@ describe('mcdoc runtime checker', () => {
 						isEquivalent: (inferred, def) => {
 							switch (inferred.kind) {
 								case 'list':
-									return [
-										'list',
-										'byte_array',
-										'int_array',
-										'long_array',
-										'tuple',
-									].includes(def.kind)
+									return ['list', 'byte_array', 'int_array', 'long_array', 'tuple']
+										.includes(def.kind)
 								case 'struct':
 									return def.kind === 'struct'
 								case 'double':
-									return [
-										'byte',
-										'short',
-										'int',
-										'long',
-										'float',
-										'double',
-									].includes(def.kind)
+									return ['byte', 'short', 'int', 'long', 'float', 'double'].includes(
+										def.kind,
+									)
 								default:
 									return false
 							}

--- a/packages/mcdoc/test/runtime/checker.spec.ts
+++ b/packages/mcdoc/test/runtime/checker.spec.ts
@@ -111,8 +111,7 @@ describe('mcdoc runtime checker', () => {
 			],
 		},
 		{
-			name:
-				'struct { pages: ([struct { raw: string, filtered?: string }] | [string]) }',
+			name: 'struct { pages: ([struct { raw: string, filtered?: string }] | [string]) }',
 			type: {
 				kind: 'struct',
 				fields: [
@@ -160,8 +159,7 @@ describe('mcdoc runtime checker', () => {
 			],
 		},
 		{
-			name:
-				'struct { ...struct { foo: double, bar: boolean }, foo: string }',
+			name: 'struct { ...struct { foo: double, bar: boolean }, foo: string }',
 			type: {
 				kind: 'struct',
 				fields: [
@@ -356,8 +354,7 @@ describe('mcdoc runtime checker', () => {
 			],
 		},
 		{
-			name:
-				'(struct { foo: (int @ 0..5 | int @ 20..25) } | struct { foo: int @ 4..6 })',
+			name: '(struct { foo: (int @ 0..5 | int @ 20..25) } | struct { foo: int @ 4..6 })',
 			type: {
 				kind: 'union',
 				members: [

--- a/packages/mcdoc/test/uri_processors.spec.ts
+++ b/packages/mcdoc/test/uri_processors.spec.ts
@@ -28,12 +28,7 @@ describe('mcdoc uriBinder()', () => {
 				'file:///root/mcdoc/minecraft/bar.mcdoc',
 			],
 		},
-		{
-			uris: [
-				'file:///root/mcdoc/foo.mcdoc',
-				'file:///root/mcdoc/minecraft/bar.mcdoc',
-			],
-		},
+		{ uris: ['file:///root/mcdoc/foo.mcdoc', 'file:///root/mcdoc/minecraft/bar.mcdoc'] },
 		{
 			uris: [
 				'file:///root/mcdoc/mod.mcdoc',
@@ -46,17 +41,11 @@ describe('mcdoc uriBinder()', () => {
 		it(
 			`Bind ${
 				JSON.stringify(
-					uris.map((u) =>
-						u.startsWith('file:///root/')
-							? u.slice('file:///root/'.length)
-							: u
-					),
+					uris.map((u) => u.startsWith('file:///root/') ? u.slice('file:///root/'.length) : u),
 				)
 			}`,
 			() => {
-				const ctx = UriBinderContext.create(
-					mockProjectData({ roots: ['file:///root/'] }),
-				)
+				const ctx = UriBinderContext.create(mockProjectData({ roots: ['file:///root/'] }))
 				uriBinder(uris, ctx)
 				snapshot(SymbolFormatter.stringifySymbolTable(ctx.symbols.global))
 			},

--- a/packages/mcfunction/src/colorizer/index.ts
+++ b/packages/mcfunction/src/colorizer/index.ts
@@ -11,8 +11,5 @@ export function register(meta: core.MetaRegistry) {
 		'mcfunction:command_child/trailing',
 		core.colorizer.error,
 	)
-	meta.registerColorizer<MacroNode>(
-		'mcfunction:macro',
-		macro,
-	)
+	meta.registerColorizer<MacroNode>('mcfunction:macro', macro)
 }

--- a/packages/mcfunction/src/colorizer/index.ts
+++ b/packages/mcfunction/src/colorizer/index.ts
@@ -1,9 +1,5 @@
 import * as core from '@spyglassmc/core'
-import type {
-	LiteralCommandChildNode,
-	MacroNode,
-	TrailingCommandChildNode,
-} from '../node/index.js'
+import type { LiteralCommandChildNode, MacroNode, TrailingCommandChildNode } from '../node/index.js'
 import { macro } from './macro.js'
 
 export function register(meta: core.MetaRegistry) {

--- a/packages/mcfunction/src/colorizer/macro.ts
+++ b/packages/mcfunction/src/colorizer/macro.ts
@@ -4,10 +4,7 @@ import type { MacroNode } from '../node/macro'
 export const macro: core.Colorizer<MacroNode> = (node, ctx) => {
 	const tokens: core.ColorToken[] = []
 	tokens.push(
-		core.ColorToken.create(
-			core.Range.create(node.range.start, node.range.start + 1),
-			'literal',
-		),
+		core.ColorToken.create(core.Range.create(node.range.start, node.range.start + 1), 'literal'),
 	) // Dollar Sign
 	for (const child of node.children) {
 		if (child.type === 'mcfunction:macro/other') {
@@ -15,23 +12,11 @@ export const macro: core.Colorizer<MacroNode> = (node, ctx) => {
 		} else {
 			const { start, end } = child.range
 			// $(
-			tokens.push(
-				core.ColorToken.create(
-					core.Range.create(start, start + 2),
-					'literal',
-				),
-			)
+			tokens.push(core.ColorToken.create(core.Range.create(start, start + 2), 'literal'))
 			// Key
-			tokens.push(
-				core.ColorToken.create(
-					core.Range.create(start + 2, end - 1),
-					'property',
-				),
-			)
+			tokens.push(core.ColorToken.create(core.Range.create(start + 2, end - 1), 'property'))
 			// )
-			tokens.push(
-				core.ColorToken.create(core.Range.create(end - 1, end), 'literal'),
-			)
+			tokens.push(core.ColorToken.create(core.Range.create(end - 1, end), 'literal'))
 		}
 	}
 	return tokens

--- a/packages/mcfunction/src/completer/index.ts
+++ b/packages/mcfunction/src/completer/index.ts
@@ -23,10 +23,7 @@ export function entry(
 		if (core.CommentNode.is(childNode) || MacroNode.is(childNode)) {
 			return []
 		} else {
-			return command(tree, getMockNodes)(
-				childNode ?? CommandNode.mock(ctx.offset),
-				ctx,
-			)
+			return command(tree, getMockNodes)(childNode ?? CommandNode.mock(ctx.offset), ctx)
 		}
 	}
 }
@@ -37,8 +34,8 @@ export function command(
 ): core.Completer<CommandNode> {
 	return (node, ctx) => {
 		const index = core.AstNode.findChildIndex(node, ctx.offset, true)
-		const selectedChildNode: DeepReadonly<core.AstNode> | undefined = node
-			.children[index]?.children[0]
+		const selectedChildNode: DeepReadonly<core.AstNode> | undefined = node.children[index]
+			?.children[0]
 		if (selectedChildNode) {
 			return core.completer.dispatch(selectedChildNode, ctx)
 		}
@@ -46,17 +43,12 @@ export function command(
 		const lastChildNode = core.AstNode.findLastChild(node, ctx.offset)
 		if (!lastChildNode) {
 			return Object.keys(tree.children ?? {}).map((v) =>
-				core.CompletionItem.create(v, ctx.offset, {
-					kind: core.CompletionKind.Keyword,
-				})
+				core.CompletionItem.create(v, ctx.offset, { kind: core.CompletionKind.Keyword })
 			)
 		}
 
 		const treePath = lastChildNode.path
-		const { treeNode: parentTreeNode } = resolveParentTreeNode(
-			redirect(tree, treePath),
-			tree,
-		)
+		const { treeNode: parentTreeNode } = resolveParentTreeNode(redirect(tree, treePath), tree)
 		if (!parentTreeNode?.children) {
 			return []
 		}
@@ -67,13 +59,11 @@ export function command(
 
 		return [
 			...literalTreeNodes.map(([name]) =>
-				core.CompletionItem.create(name, ctx.offset, {
-					kind: core.CompletionKind.Keyword,
-				})
+				core.CompletionItem.create(name, ctx.offset, { kind: core.CompletionKind.Keyword })
 			),
 			...argumentTreeNodes.flatMap(([_name, treeNode]) =>
-				core.Arrayable.toArray(getMockNodes(treeNode, ctx)).flatMap(
-					(n) => core.completer.dispatch(n, ctx),
+				core.Arrayable.toArray(getMockNodes(treeNode, ctx)).flatMap((n) =>
+					core.completer.dispatch(n, ctx)
 				)
 			),
 		]

--- a/packages/mcfunction/src/completer/index.ts
+++ b/packages/mcfunction/src/completer/index.ts
@@ -3,11 +3,7 @@ import * as core from '@spyglassmc/core'
 import type { McfunctionNode } from '../node/index.js'
 import { CommandNode, MacroNode } from '../node/index.js'
 import type { ArgumentTreeNode, RootTreeNode } from '../tree/index.js'
-import {
-	categorizeTreeChildren,
-	redirect,
-	resolveParentTreeNode,
-} from '../tree/index.js'
+import { categorizeTreeChildren, redirect, resolveParentTreeNode } from '../tree/index.js'
 
 export type MockNodesGetter = (
 	treeNode: ArgumentTreeNode,

--- a/packages/mcfunction/src/node/command.ts
+++ b/packages/mcfunction/src/node/command.ts
@@ -13,11 +13,7 @@ export namespace CommandNode {
 	}
 
 	export function mock(range: core.RangeLike): CommandNode {
-		return {
-			type: 'mcfunction:command',
-			range: core.Range.get(range),
-			children: [],
-		}
+		return { type: 'mcfunction:command', range: core.Range.get(range), children: [] }
 	}
 }
 
@@ -49,12 +45,8 @@ export interface LiteralCommandChildNode extends core.LiteralBaseNode {
 	type: 'mcfunction:command_child/literal'
 }
 export namespace LiteralCommandChildNode {
-	export function is(
-		node: core.AstNode | undefined,
-	): node is LiteralCommandChildNode {
-		return (
-			(node as LiteralCommandChildNode | undefined)?.type
-				=== 'mcfunction:command_child/literal'
-		)
+	export function is(node: core.AstNode | undefined): node is LiteralCommandChildNode {
+		return ((node as LiteralCommandChildNode | undefined)?.type
+			=== 'mcfunction:command_child/literal')
 	}
 }

--- a/packages/mcfunction/src/node/command.ts
+++ b/packages/mcfunction/src/node/command.ts
@@ -53,8 +53,8 @@ export namespace LiteralCommandChildNode {
 		node: core.AstNode | undefined,
 	): node is LiteralCommandChildNode {
 		return (
-			(node as LiteralCommandChildNode | undefined)?.type ===
-				'mcfunction:command_child/literal'
+			(node as LiteralCommandChildNode | undefined)?.type
+				=== 'mcfunction:command_child/literal'
 		)
 	}
 }

--- a/packages/mcfunction/src/node/macro.ts
+++ b/packages/mcfunction/src/node/macro.ts
@@ -11,8 +11,8 @@ export namespace MacroNode {
 	export function is<T extends core.DeepReadonly<core.AstNode> | undefined>(
 		obj: T,
 	): obj is core.InheritReadonly<MacroNode, T> {
-		return (obj as MacroNode | undefined)?.type ===
-			'mcfunction:macro'
+		return (obj as MacroNode | undefined)?.type
+			=== 'mcfunction:macro'
 	}
 
 	export function mock(range: core.RangeLike): MacroNode {

--- a/packages/mcfunction/src/node/macro.ts
+++ b/packages/mcfunction/src/node/macro.ts
@@ -1,8 +1,6 @@
 import * as core from '@spyglassmc/core'
 
-export interface MacroNode
-	extends core.SequenceNode<MacroOtherNode | MacroArgumentNode>
-{
+export interface MacroNode extends core.SequenceNode<MacroOtherNode | MacroArgumentNode> {
 	type: 'mcfunction:macro'
 	children: (MacroOtherNode | MacroArgumentNode)[]
 }

--- a/packages/mcfunction/src/node/macro.ts
+++ b/packages/mcfunction/src/node/macro.ts
@@ -9,16 +9,11 @@ export namespace MacroNode {
 	export function is<T extends core.DeepReadonly<core.AstNode> | undefined>(
 		obj: T,
 	): obj is core.InheritReadonly<MacroNode, T> {
-		return (obj as MacroNode | undefined)?.type
-			=== 'mcfunction:macro'
+		return (obj as MacroNode | undefined)?.type === 'mcfunction:macro'
 	}
 
 	export function mock(range: core.RangeLike): MacroNode {
-		return {
-			type: 'mcfunction:macro',
-			range: core.Range.get(range),
-			children: [],
-		}
+		return { type: 'mcfunction:macro', range: core.Range.get(range), children: [] }
 	}
 }
 

--- a/packages/mcfunction/src/parser/argument.ts
+++ b/packages/mcfunction/src/parser/argument.ts
@@ -8,14 +8,9 @@ import type { ArgumentTreeNode } from '../tree/index.js'
  *
  * @returns The parser corresponding to that tree node, or `undefined` if such parser doesn't exist.
  */
-export type ArgumentParserGetter = (
-	treeNode: ArgumentTreeNode,
-) => core.Parser | undefined
+export type ArgumentParserGetter = (treeNode: ArgumentTreeNode) => core.Parser | undefined
 
-export function argumentTreeNodeToString(
-	name: string,
-	treeNode: ArgumentTreeNode,
-): string {
+export function argumentTreeNodeToString(name: string, treeNode: ArgumentTreeNode): string {
 	const parserName = treeNode.parser.slice(treeNode.parser.indexOf(':') + 1)
 	return `<${name}: ${parserName}>`
 }

--- a/packages/mcfunction/src/parser/command.ts
+++ b/packages/mcfunction/src/parser/command.ts
@@ -114,8 +114,8 @@ function dispatch(
 
 		if (result !== core.Failure) {
 			const takenName =
-				argumentParsers[out.index - (literalParser ? 1 : 0)]?.name ??
-					(result as LiteralCommandChildNode).value
+				argumentParsers[out.index - (literalParser ? 1 : 0)]?.name
+					?? (result as LiteralCommandChildNode).value
 			const childPath = [...path, takenName]
 
 			ans.push({
@@ -143,8 +143,8 @@ function dispatch(
 			}
 
 			if (
-				(result as UnknownCommandChildNode).type ===
-					'mcfunction:command_child/unknown'
+				(result as UnknownCommandChildNode).type
+					=== 'mcfunction:command_child/unknown'
 			) {
 				// Encountered an unsupported parser. Stop parsing this command.
 				return false

--- a/packages/mcfunction/src/parser/command.ts
+++ b/packages/mcfunction/src/parser/command.ts
@@ -88,11 +88,12 @@ function dispatch(
 			children,
 		)
 
-		const argumentParsers: { name: string; parser: core.Parser }[] =
-			argumentTreeNodes.map(([name, treeNode]) => ({
-				name,
-				parser: argument(treeNode) ?? unknown(treeNode),
-			}))
+		const argumentParsers: { name: string; parser: core.Parser }[] = argumentTreeNodes.map((
+			[name, treeNode],
+		) => ({
+			name,
+			parser: argument(treeNode) ?? unknown(treeNode),
+		}))
 		const literalParser = literalTreeNodes.length
 			? literal(
 				literalTreeNodes.map(([name, _treeNode]) => name),
@@ -113,9 +114,8 @@ function dispatch(
 		const result = parser(src, ctx)
 
 		if (result !== core.Failure) {
-			const takenName =
-				argumentParsers[out.index - (literalParser ? 1 : 0)]?.name
-					?? (result as LiteralCommandChildNode).value
+			const takenName = argumentParsers[out.index - (literalParser ? 1 : 0)]?.name
+				?? (result as LiteralCommandChildNode).value
 			const childPath = [...path, takenName]
 
 			ans.push({

--- a/packages/mcfunction/src/parser/command.ts
+++ b/packages/mcfunction/src/parser/command.ts
@@ -84,21 +84,13 @@ function dispatch(
 			return false
 		}
 
-		const { literalTreeNodes, argumentTreeNodes } = categorizeTreeChildren(
-			children,
-		)
+		const { literalTreeNodes, argumentTreeNodes } = categorizeTreeChildren(children)
 
 		const argumentParsers: { name: string; parser: core.Parser }[] = argumentTreeNodes.map((
 			[name, treeNode],
-		) => ({
-			name,
-			parser: argument(treeNode) ?? unknown(treeNode),
-		}))
+		) => ({ name, parser: argument(treeNode) ?? unknown(treeNode) }))
 		const literalParser = literalTreeNodes.length
-			? literal(
-				literalTreeNodes.map(([name, _treeNode]) => name),
-				parent.type === 'root',
-			)
+			? literal(literalTreeNodes.map(([name, _treeNode]) => name), parent.type === 'root')
 			: undefined
 
 		const parsers: core.Parser[] = [
@@ -142,10 +134,7 @@ function dispatch(
 				)
 			}
 
-			if (
-				(result as UnknownCommandChildNode).type
-					=== 'mcfunction:command_child/unknown'
-			) {
+			if ((result as UnknownCommandChildNode).type === 'mcfunction:command_child/unknown') {
 				// Encountered an unsupported parser. Stop parsing this command.
 				return false
 			}
@@ -177,26 +166,17 @@ function dispatch(
 	}
 }
 
-function unknown(
-	treeNode: ArgumentTreeNode,
-): core.InfallibleParser<UnknownCommandChildNode> {
+function unknown(treeNode: ArgumentTreeNode): core.InfallibleParser<UnknownCommandChildNode> {
 	return (src, ctx): UnknownCommandChildNode => {
 		const start = src.cursor
 		const value = src.readUntilLineEnd()
 		const range = core.Range.create(start, src)
 		ctx.err.report(
-			localize(
-				'mcfunction.parser.unknown-parser',
-				localeQuote(treeNode.parser),
-			),
+			localize('mcfunction.parser.unknown-parser', localeQuote(treeNode.parser)),
 			range,
 			core.ErrorSeverity.Hint,
 		)
-		return {
-			type: 'mcfunction:command_child/unknown',
-			range,
-			value,
-		}
+		return { type: 'mcfunction:command_child/unknown', range, value }
 	}
 }
 
@@ -207,15 +187,8 @@ const trailing: core.InfallibleParser<TrailingCommandChildNode> = (
 	const start = src.cursor
 	const value = src.readUntilLineEnd()
 	const range = core.Range.create(start, src)
-	ctx.err.report(
-		localize('mcfunction.parser.trailing', localeQuote(value)),
-		range,
-	)
-	return {
-		type: 'mcfunction:command_child/trailing',
-		range,
-		value,
-	}
+	ctx.err.report(localize('mcfunction.parser.trailing', localeQuote(value)), range)
+	return { type: 'mcfunction:command_child/trailing', range, value }
 }
 
 function wrapWithBrackets(syntax: string, executable: boolean): string {

--- a/packages/mcfunction/src/parser/common.ts
+++ b/packages/mcfunction/src/parser/common.ts
@@ -11,10 +11,7 @@ export const sep: core.InfallibleParser<string> = (src, ctx): string => {
 	const ans = src.readSpace()
 	if (ans !== ' ') {
 		ctx.err.report(
-			localize(
-				'expected',
-				localize('mcfunction.parser.sep', localeQuote(' ')),
-			),
+			localize('expected', localize('mcfunction.parser.sep', localeQuote(' '))),
 			core.Range.create(start, src),
 		)
 	}

--- a/packages/mcfunction/src/parser/entry.ts
+++ b/packages/mcfunction/src/parser/entry.ts
@@ -24,10 +24,7 @@ function mcfunction(
 			} else if (src.peek() === '$') {
 				result = macro(supportsMacros)(src, ctx) as MacroNode
 			} else {
-				result = command(
-					commandTree,
-					argument,
-				)(src, ctx)
+				result = command(commandTree, argument)(src, ctx)
 			}
 			ans.children.push(result)
 			src.nextLine()
@@ -39,9 +36,7 @@ function mcfunction(
 	}
 }
 
-const comment = core.comment({
-	singleLinePrefixes: new Set(['#']),
-})
+const comment = core.comment({ singleLinePrefixes: new Set(['#']) })
 
 /**
  * @param supportsBackslashContinuation Whether or not to concatenate lines together on trailing backslashes.
@@ -51,13 +46,8 @@ const comment = core.comment({
 export const entry = (
 	commandTree: RootTreeNode,
 	argument: ArgumentParserGetter,
-	{
-		supportsBackslashContinuation = false,
-		supportsMacros = false,
-	} = {},
+	{ supportsBackslashContinuation = false, supportsMacros = false } = {},
 ) => {
 	const parser = mcfunction(commandTree, argument, { supportsMacros })
-	return supportsBackslashContinuation
-		? core.concatOnTrailingBackslash(parser)
-		: parser
+	return supportsBackslashContinuation ? core.concatOnTrailingBackslash(parser) : parser
 }

--- a/packages/mcfunction/src/parser/literal.ts
+++ b/packages/mcfunction/src/parser/literal.ts
@@ -2,10 +2,7 @@ import * as core from '@spyglassmc/core'
 import { localize } from '@spyglassmc/locales'
 import type { LiteralCommandChildNode } from '../node/index.js'
 
-export function literal(
-	names: string[],
-	isRoot = false,
-): core.Parser<LiteralCommandChildNode> {
+export function literal(names: string[], isRoot = false): core.Parser<LiteralCommandChildNode> {
 	const options: core.LiteralOptions = {
 		pool: names,
 		colorTokenType: isRoot ? 'keyword' : 'literal',

--- a/packages/mcfunction/src/parser/macro.ts
+++ b/packages/mcfunction/src/parser/macro.ts
@@ -7,13 +7,8 @@ import type { MacroNode } from '../node/index.js'
  * @param supportsMacros When false, reports the entire line as an error (due to
  * the Minecraft version not supporting macros).
  */
-export function macro(
-	supportsMacros = true,
-): core.Parser<MacroNode | core.ErrorNode> {
-	return (
-		src: core.Source,
-		ctx: core.ParserContext,
-	): core.Result<MacroNode | core.ErrorNode> => {
+export function macro(supportsMacros = true): core.Parser<MacroNode | core.ErrorNode> {
+	return (src: core.Source, ctx: core.ParserContext): core.Result<MacroNode | core.ErrorNode> => {
 		const ans: MacroNode = {
 			type: 'mcfunction:macro',
 			range: core.Range.create(src.cursor),
@@ -23,14 +18,8 @@ export function macro(
 		if (!supportsMacros) {
 			src.skipLine()
 			ans.range.end = src.cursor
-			ctx.err.report(
-				localize('mcfunction.parser.macro.disallowed'),
-				ans.range,
-			)
-			return {
-				...ans,
-				type: 'error',
-			} as core.ErrorNode
+			ctx.err.report(localize('mcfunction.parser.macro.disallowed'), ans.range)
+			return { ...ans, type: 'error' } as core.ErrorNode
 		}
 
 		// Skip the starting '$'
@@ -80,10 +69,7 @@ export function macro(
 		// A line with no macro arguments is invalid
 		if (!hasMacroArgs) {
 			ctx.err.report(
-				localize(
-					'expected',
-					localize('mcfunction.parser.macro.at-least-one'),
-				),
+				localize('expected', localize('mcfunction.parser.macro.at-least-one')),
 				core.Range.create(start, src.cursor),
 			)
 		}
@@ -96,11 +82,7 @@ export function macro(
 /**
  * Error checking for a macro argument/key.
  */
-function validateMacroArgument(
-	src: core.Source,
-	ctx: core.ParserContext,
-	start: number,
-): string {
+function validateMacroArgument(src: core.Source, ctx: core.ParserContext, start: number): string {
 	src.skip(2)
 	const keyStart = src.cursor
 	src.skipUntilOrEnd(core.LF, core.CR, ')')
@@ -121,10 +103,7 @@ function validateMacroArgument(
 	const matchedInvalid = key.replace(/[a-zA-Z0-9_]*/, '')
 	if (matchedInvalid.length > 0) {
 		ctx.err.report(
-			localize(
-				'mcfunction.parser.macro.illegal-key',
-				matchedInvalid.charAt(0),
-			),
+			localize('mcfunction.parser.macro.illegal-key', matchedInvalid.charAt(0)),
 			core.Range.create(keyStart, src.cursor),
 		)
 	}

--- a/packages/mcfunction/src/tree/type.ts
+++ b/packages/mcfunction/src/tree/type.ts
@@ -31,8 +31,7 @@ export interface RootTreeNode extends BaseTreeNode {
 
 export type TreeNode = ArgumentTreeNode | LiteralTreeNode | RootTreeNode
 
-type RecursivePartial<T> = T extends object
-	? { [K in keyof T]?: RecursivePartial<T[K]> }
+type RecursivePartial<T> = T extends object ? { [K in keyof T]?: RecursivePartial<T[K]> }
 	: T
 
 export type PartialTreeNode = RecursivePartial<TreeNode>

--- a/packages/mcfunction/src/tree/type.ts
+++ b/packages/mcfunction/src/tree/type.ts
@@ -1,9 +1,7 @@
 interface BaseTreeNode {
 	// The following properties are provided in `commands.json` created by the data generator.
 	type: string
-	children?: {
-		[name: string]: TreeNode
-	}
+	children?: { [name: string]: TreeNode }
 	executable?: boolean
 	redirect?: readonly string[]
 
@@ -31,8 +29,7 @@ export interface RootTreeNode extends BaseTreeNode {
 
 export type TreeNode = ArgumentTreeNode | LiteralTreeNode | RootTreeNode
 
-type RecursivePartial<T> = T extends object ? { [K in keyof T]?: RecursivePartial<T[K]> }
-	: T
+type RecursivePartial<T> = T extends object ? { [K in keyof T]?: RecursivePartial<T[K]> } : T
 
 export type PartialTreeNode = RecursivePartial<TreeNode>
 export type PartialRootTreeNode = RecursivePartial<RootTreeNode>

--- a/packages/mcfunction/src/tree/util.ts
+++ b/packages/mcfunction/src/tree/util.ts
@@ -38,9 +38,9 @@ export function resolveParentTreeNode(
 			path: [...parentTreeNode.redirect],
 		}
 	} else if (
-		parentTreeNode &&
-		!parentTreeNode.children &&
-		!parentTreeNode.executable
+		parentTreeNode
+		&& !parentTreeNode.children
+		&& !parentTreeNode.executable
 	) {
 		// The `execute.run` literal tree node doesn't have any property.
 		// We should use children from the root tree node in this case.

--- a/packages/mcfunction/src/tree/util.ts
+++ b/packages/mcfunction/src/tree/util.ts
@@ -1,9 +1,4 @@
-import type {
-	ArgumentTreeNode,
-	LiteralTreeNode,
-	RootTreeNode,
-	TreeNode,
-} from './type.js'
+import type { ArgumentTreeNode, LiteralTreeNode, RootTreeNode, TreeNode } from './type.js'
 
 export function redirect(
 	rootTreeNode: TreeNode,

--- a/packages/mcfunction/src/tree/util.ts
+++ b/packages/mcfunction/src/tree/util.ts
@@ -1,13 +1,7 @@
 import type { ArgumentTreeNode, LiteralTreeNode, RootTreeNode, TreeNode } from './type.js'
 
-export function redirect(
-	rootTreeNode: TreeNode,
-	path: readonly string[],
-): TreeNode | undefined {
-	return path.reduce<TreeNode | undefined>(
-		(p, c) => p?.children?.[c],
-		rootTreeNode,
-	)
+export function redirect(rootTreeNode: TreeNode, path: readonly string[]): TreeNode | undefined {
+	return path.reduce<TreeNode | undefined>((p, c) => p?.children?.[c], rootTreeNode)
 }
 
 /**
@@ -32,11 +26,7 @@ export function resolveParentTreeNode(
 			treeNode: redirect(rootTreeNode, parentTreeNode.redirect),
 			path: [...parentTreeNode.redirect],
 		}
-	} else if (
-		parentTreeNode
-		&& !parentTreeNode.children
-		&& !parentTreeNode.executable
-	) {
+	} else if (parentTreeNode && !parentTreeNode.children && !parentTreeNode.executable) {
 		// The `execute.run` literal tree node doesn't have any property.
 		// We should use children from the root tree node in this case.
 		return { treeNode: rootTreeNode, path: [] }

--- a/packages/mcfunction/test/parser/command.spec.ts
+++ b/packages/mcfunction/test/parser/command.spec.ts
@@ -1,7 +1,4 @@
-import {
-	showWhitespaceGlyph,
-	testParser,
-} from '@spyglassmc/core/test-out/utils.js'
+import { showWhitespaceGlyph, testParser } from '@spyglassmc/core/test-out/utils.js'
 import { fail } from 'assert'
 import { describe, it } from 'mocha'
 import snapshot from 'snap-shot-it'

--- a/packages/mcfunction/test/parser/literal.spec.ts
+++ b/packages/mcfunction/test/parser/literal.spec.ts
@@ -1,7 +1,4 @@
-import {
-	showWhitespaceGlyph,
-	testParser,
-} from '@spyglassmc/core/test-out/utils.js'
+import { showWhitespaceGlyph, testParser } from '@spyglassmc/core/test-out/utils.js'
 import { describe, it } from 'mocha'
 import snapshot from 'snap-shot-it'
 import { literal } from '../../lib/parser/index.js'

--- a/packages/mcfunction/test/parser/macro.spec.ts
+++ b/packages/mcfunction/test/parser/macro.spec.ts
@@ -1,7 +1,4 @@
-import {
-	showWhitespaceGlyph,
-	testParser,
-} from '@spyglassmc/core/test-out/utils.js'
+import { showWhitespaceGlyph, testParser } from '@spyglassmc/core/test-out/utils.js'
 import { describe, it } from 'mocha'
 import snapshot from 'snap-shot-it'
 import { macro } from '../../lib/parser/index.js'

--- a/packages/mcfunction/test/parser/utils.ts
+++ b/packages/mcfunction/test/parser/utils.ts
@@ -8,27 +8,11 @@ export const tree: RootTreeNode = {
 			children: {
 				if: {
 					type: 'literal',
-					children: {
-						true: {
-							type: 'literal',
-							executable: true,
-							redirect: ['execute'],
-						},
-					},
+					children: { true: { type: 'literal', executable: true, redirect: ['execute'] } },
 				},
-				run: {
-					type: 'literal',
-				},
+				run: { type: 'literal' },
 			},
 		},
-		say: {
-			type: 'literal',
-			children: {
-				hi: {
-					type: 'literal',
-					executable: true,
-				},
-			},
-		},
+		say: { type: 'literal', children: { hi: { type: 'literal', executable: true } } },
 	},
 }

--- a/packages/nbt/src/checker/index.ts
+++ b/packages/nbt/src/checker/index.ts
@@ -15,10 +15,7 @@ interface Options {
  */
 export function index(
 	registry: core.FullResourceLocation,
-	id?:
-		| core.FullResourceLocation
-		| readonly core.FullResourceLocation[]
-		| undefined,
+	id?: core.FullResourceLocation | readonly core.FullResourceLocation[] | undefined,
 	options: Options = {},
 ): core.SyncChecker<NbtNode> {
 	switch (registry) {
@@ -29,9 +26,7 @@ export function index(
 			return blockStates([id as string], options)
 		case 'custom:spawnitemtag':
 			const entityId = getEntityFromItem(id as core.FullResourceLocation)
-			return entityId
-				? index('minecraft:entity', entityId, options)
-				: core.checker.noop
+			return entityId ? index('minecraft:entity', entityId, options) : core.checker.noop
 		default:
 			const typeDef: mcdoc.McdocType = {
 				kind: 'dispatcher',
@@ -45,10 +40,7 @@ export function index(
 }
 
 function getIndices(
-	id:
-		| core.FullResourceLocation
-		| readonly core.FullResourceLocation[]
-		| undefined,
+	id: core.FullResourceLocation | readonly core.FullResourceLocation[] | undefined,
 ): mcdoc.ParallelIndices {
 	if (typeof id === 'string') {
 		return [{ kind: 'static', value: id }]
@@ -75,18 +67,14 @@ export function typeDefinition(
 				isEquivalent: (inferred, def) => {
 					switch (inferred.kind) {
 						case 'list':
-							return [
-								'list',
-								'tuple',
-							].includes(def.kind)
+							return ['list', 'tuple'].includes(def.kind)
 						case 'struct':
 							return def.kind === 'struct'
 						case 'byte':
 						case 'short':
 						case 'int':
 						case 'long':
-							return ['byte', 'short', 'int', 'long', 'float', 'double']
-								.includes(def.kind)
+							return ['byte', 'short', 'int', 'long', 'float', 'double'].includes(def.kind)
 						case 'float':
 						case 'double':
 							return ['float', 'double'].includes(def.kind)
@@ -100,25 +88,15 @@ export function typeDefinition(
 						type === 'nbt:list' || type === 'nbt:byte_array'
 						|| type === 'nbt:int_array' || type === 'nbt:long_array'
 					) {
-						return node.children.filter(n => n.value)
-							.map(
-								n => [{
-									originalNode: n.value!,
-									inferredType: inferType(n.value!),
-								}],
-							)
+						return node.children.filter(n => n.value).map(
+							n => [{ originalNode: n.value!, inferredType: inferType(n.value!) }],
+						)
 					}
 					if (type === 'nbt:compound') {
 						return node.children.filter(kvp => kvp.key).map(kvp => ({
-							key: {
-								originalNode: kvp.key!,
-								inferredType: inferType(kvp.key!),
-							},
+							key: { originalNode: kvp.key!, inferredType: inferType(kvp.key!) },
 							possibleValues: kvp.value
-								? [{
-									originalNode: kvp.value,
-									inferredType: inferType(kvp.value),
-								}]
+								? [{ originalNode: kvp.value, inferredType: inferType(kvp.value) }]
 								: [],
 						}))
 					}
@@ -131,10 +109,7 @@ export function typeDefinition(
 				attachTypeInfo: (node, definition) => {
 					node.typeDef = definition
 					// TODO: improve hover info
-					if (
-						core.PairNode.is(node.parent)
-						&& NbtStringNode.is(node.parent.key)
-					) {
+					if (core.PairNode.is(node.parent) && NbtStringNode.is(node.parent.key)) {
 						node.parent.key.hover = `\`\`\`typescript\n${node.parent.key.value}: ${
 							mcdoc.McdocType.toString(definition)
 						}\n\`\`\``
@@ -158,20 +133,11 @@ export function typeDefinition(
 function inferType(node: NbtNode): Exclude<mcdoc.McdocType, mcdoc.UnionType> {
 	switch (node.type) {
 		case 'nbt:byte':
-			return {
-				kind: 'literal',
-				value: { kind: 'byte', value: node.value },
-			}
+			return { kind: 'literal', value: { kind: 'byte', value: node.value } }
 		case 'nbt:double':
-			return {
-				kind: 'literal',
-				value: { kind: 'double', value: node.value },
-			}
+			return { kind: 'literal', value: { kind: 'double', value: node.value } }
 		case 'nbt:float':
-			return {
-				kind: 'literal',
-				value: { kind: 'float', value: node.value },
-			}
+			return { kind: 'literal', value: { kind: 'float', value: node.value } }
 		case 'nbt:long':
 			return {
 				kind: 'literal',
@@ -179,20 +145,11 @@ function inferType(node: NbtNode): Exclude<mcdoc.McdocType, mcdoc.UnionType> {
 				value: { kind: 'long', value: Number(node.value) },
 			}
 		case 'nbt:int':
-			return {
-				kind: 'literal',
-				value: { kind: 'int', value: node.value },
-			}
+			return { kind: 'literal', value: { kind: 'int', value: node.value } }
 		case 'nbt:short':
-			return {
-				kind: 'literal',
-				value: { kind: 'short', value: node.value },
-			}
+			return { kind: 'literal', value: { kind: 'short', value: node.value } }
 		case 'nbt:string':
-			return {
-				kind: 'literal',
-				value: { kind: 'string', value: node.value },
-			}
+			return { kind: 'literal', value: { kind: 'string', value: node.value } }
 		case 'nbt:list':
 			return { kind: 'list', item: { kind: 'any' } }
 		case 'nbt:compound':
@@ -206,10 +163,7 @@ function inferType(node: NbtNode): Exclude<mcdoc.McdocType, mcdoc.UnionType> {
 	}
 }
 
-export function blockStates(
-	blocks: string[],
-	_options: Options = {},
-): core.SyncChecker<NbtNode> {
+export function blockStates(blocks: string[], _options: Options = {}): core.SyncChecker<NbtNode> {
 	return (node, ctx) => {
 		if (!NbtCompoundNode.is(node)) {
 			return
@@ -231,9 +185,7 @@ export function blockStates(
 					core.ErrorSeverity.Warning,
 				)
 				continue
-			} else if (
-				valueNode.type !== 'nbt:string' && valueNode.type !== 'nbt:int'
-			) {
+			} else if (valueNode.type !== 'nbt:string' && valueNode.type !== 'nbt:int') {
 				ctx.err.report(
 					localize('nbt.checker.block-states.unexpected-value-type'),
 					valueNode,
@@ -247,11 +199,7 @@ export function blockStates(
 				const stateValues = states[keyNode.value]!
 				if (!stateValues.includes(valueNode.value.toString())) {
 					ctx.err.report(
-						localize(
-							'expected-got',
-							stateValues,
-							localeQuote(valueNode.value.toString()),
-						),
+						localize('expected-got', stateValues, localeQuote(valueNode.value.toString())),
 						valueNode,
 						core.ErrorSeverity.Warning,
 					)
@@ -282,10 +230,7 @@ interface NbtPathLink {
 // TODO: check nbt index nodes and nbt compound nodes
 export function path(
 	registry: core.FullResourceLocation,
-	id:
-		| core.FullResourceLocation
-		| readonly core.FullResourceLocation[]
-		| undefined,
+	id: core.FullResourceLocation | readonly core.FullResourceLocation[] | undefined,
 ): core.SyncChecker<NbtPathNode> {
 	return (node, ctx) => {
 		// TODO: support dispatcher
@@ -295,17 +240,10 @@ export function path(
 			parallelIndices: getIndices(id),
 		}
 		// Create a linked list representation
-		const leaf = {
-			type: 'leaf',
-			range: core.Range.create(node.range.end),
-		} as const
+		const leaf = { type: 'leaf', range: core.Range.create(node.range.end) } as const
 		let link: NbtPathLink = { path: node, node: leaf }
 		for (let i = node.children.length - 1; i >= 0; i -= 1) {
-			link = {
-				path: node,
-				node: node.children[i],
-				next: link,
-			}
+			link = { path: node, node: node.children[i], next: link }
 		}
 		let prev = link
 		while (prev.next) {
@@ -323,34 +261,22 @@ export function path(
 						case 'byte_array':
 						case 'int_array':
 						case 'long_array':
-							return [
-								'list',
-								'tuple',
-								'byte_array',
-								'int_array',
-								'long_array',
-							].includes(def.kind)
+							return ['list', 'tuple', 'byte_array', 'int_array', 'long_array'].includes(
+								def.kind,
+							)
 						default:
 							return false
 					}
 				},
-				getChildren: (
-					link,
-				): mcdoc.runtime.checker.RuntimeUnion<NbtPathLink>[] => {
-					while (
-						link.next && link.node.type !== 'leaf'
-						&& NbtCompoundNode.is(link.node)
-					) {
+				getChildren: (link): mcdoc.runtime.checker.RuntimeUnion<NbtPathLink>[] => {
+					while (link.next && link.node.type !== 'leaf' && NbtCompoundNode.is(link.node)) {
 						link = link.next
 					}
 					if (!link.next || link.node.type === 'leaf') {
 						return []
 					}
 					if (NbtPathIndexNode.is(link.node)) {
-						return [[{
-							originalNode: link.next,
-							inferredType: inferPath(link.next),
-						}]]
+						return [[{ originalNode: link.next, inferredType: inferPath(link.next) }]]
 					}
 					if (NbtStringNode.is(link.node)) {
 						return [{
@@ -371,17 +297,13 @@ export function path(
 					return []
 				},
 				reportError: (error) => {
-					if (
-						error.kind === 'missing_key'
-						|| error.kind === 'invalid_collection_length'
-					) {
+					if (error.kind === 'missing_key' || error.kind === 'invalid_collection_length') {
 						return
 					}
-					mcdoc.runtime.checker
-						.getDefaultErrorReporter<NbtPathLink>(
-							ctx,
-							({ originalNode: link }) => link.node.range,
-						)(error)
+					mcdoc.runtime.checker.getDefaultErrorReporter<NbtPathLink>(
+						ctx,
+						({ originalNode: link }) => link.node.range,
+					)(error)
 				},
 				attachTypeInfo: (link, definition) => {
 					// TODO: attach type def
@@ -407,9 +329,7 @@ export function path(
 	}
 }
 
-function inferPath(
-	link: NbtPathLink,
-): Exclude<mcdoc.McdocType, mcdoc.UnionType> {
+function inferPath(link: NbtPathLink): Exclude<mcdoc.McdocType, mcdoc.UnionType> {
 	if (link.node.type === 'leaf') {
 		return { kind: 'unsafe' }
 	}

--- a/packages/nbt/src/checker/index.ts
+++ b/packages/nbt/src/checker/index.ts
@@ -2,11 +2,7 @@ import * as core from '@spyglassmc/core'
 import { localeQuote, localize } from '@spyglassmc/locales'
 import * as mcdoc from '@spyglassmc/mcdoc'
 import type { NbtNode, NbtPathChild, NbtPathNode } from '../node/index.js'
-import {
-	NbtCompoundNode,
-	NbtPathIndexNode,
-	NbtStringNode,
-} from '../node/index.js'
+import { NbtCompoundNode, NbtPathIndexNode, NbtStringNode } from '../node/index.js'
 import { getBlocksFromItem, getEntityFromItem } from './mcdocUtil.js'
 
 interface Options {
@@ -139,10 +135,9 @@ export function typeDefinition(
 						core.PairNode.is(node.parent)
 						&& NbtStringNode.is(node.parent.key)
 					) {
-						node.parent.key.hover =
-							`\`\`\`typescript\n${node.parent.key.value}: ${
-								mcdoc.McdocType.toString(definition)
-							}\n\`\`\``
+						node.parent.key.hover = `\`\`\`typescript\n${node.parent.key.value}: ${
+							mcdoc.McdocType.toString(definition)
+						}\n\`\`\``
 					}
 				},
 				stringAttacher: (node, attacher) => {
@@ -392,10 +387,9 @@ export function path(
 					// TODO: attach type def
 					// TODO: improve hover info
 					if (NbtStringNode.is(link.prev?.node)) {
-						link.prev.node.hover =
-							`\`\`\`typescript\n${link.prev.node.value}: ${
-								mcdoc.McdocType.toString(definition)
-							}\n\`\`\``
+						link.prev.node.hover = `\`\`\`typescript\n${link.prev.node.value}: ${
+							mcdoc.McdocType.toString(definition)
+						}\n\`\`\``
 					}
 				},
 				stringAttacher: (node, attacher) => {

--- a/packages/nbt/src/checker/index.ts
+++ b/packages/nbt/src/checker/index.ts
@@ -101,8 +101,8 @@ export function typeDefinition(
 				getChildren: node => {
 					const { type } = node
 					if (
-						type === 'nbt:list' || type === 'nbt:byte_array' ||
-						type === 'nbt:int_array' || type === 'nbt:long_array'
+						type === 'nbt:list' || type === 'nbt:byte_array'
+						|| type === 'nbt:int_array' || type === 'nbt:long_array'
 					) {
 						return node.children.filter(n => n.value)
 							.map(
@@ -136,8 +136,8 @@ export function typeDefinition(
 					node.typeDef = definition
 					// TODO: improve hover info
 					if (
-						core.PairNode.is(node.parent) &&
-						NbtStringNode.is(node.parent.key)
+						core.PairNode.is(node.parent)
+						&& NbtStringNode.is(node.parent.key)
 					) {
 						node.parent.key.hover =
 							`\`\`\`typescript\n${node.parent.key.value}: ${
@@ -226,9 +226,9 @@ export function blockStates(
 			}
 			// Type check.
 			if (
-				valueNode.type === 'nbt:byte' &&
-				(ctx.src.slice(valueNode.range).toLowerCase() === 'false' ||
-					ctx.src.slice(valueNode.range).toLowerCase() === 'true')
+				valueNode.type === 'nbt:byte'
+				&& (ctx.src.slice(valueNode.range).toLowerCase() === 'false'
+					|| ctx.src.slice(valueNode.range).toLowerCase() === 'true')
 			) {
 				ctx.err.report(
 					localize('nbt.checker.block-states.fake-boolean'),
@@ -343,8 +343,8 @@ export function path(
 					link,
 				): mcdoc.runtime.checker.RuntimeUnion<NbtPathLink>[] => {
 					while (
-						link.next && link.node.type !== 'leaf' &&
-						NbtCompoundNode.is(link.node)
+						link.next && link.node.type !== 'leaf'
+						&& NbtCompoundNode.is(link.node)
 					) {
 						link = link.next
 					}
@@ -377,8 +377,8 @@ export function path(
 				},
 				reportError: (error) => {
 					if (
-						error.kind === 'missing_key' ||
-						error.kind === 'invalid_collection_length'
+						error.kind === 'missing_key'
+						|| error.kind === 'invalid_collection_length'
 					) {
 						return
 					}

--- a/packages/nbt/src/checker/mcdocUtil.ts
+++ b/packages/nbt/src/checker/mcdocUtil.ts
@@ -2,44 +2,17 @@ import type * as core from '@spyglassmc/core'
 
 const BlockItems: { [item: string]: core.FullResourceLocation[] } = {
 	// Coral fans.
-	'minecraft:brain_coral_fan': [
-		'minecraft:brain_coral_fan',
-		'minecraft:brain_coral_wall_fan',
-	],
-	'minecraft:bubble_coral_fan': [
-		'minecraft:bubble_coral_fan',
-		'minecraft:bubble_coral_wall_fan',
-	],
-	'minecraft:fire_coral_fan': [
-		'minecraft:fire_coral_fan',
-		'minecraft:fire_coral_wall_fan',
-	],
-	'minecraft:horn_coral_fan': [
-		'minecraft:horn_coral_fan',
-		'minecraft:horn_coral_wall_fan',
-	],
-	'minecraft:tube_coral_fan': [
-		'minecraft:tube_coral_fan',
-		'minecraft:tube_coral_wall_fan',
-	],
+	'minecraft:brain_coral_fan': ['minecraft:brain_coral_fan', 'minecraft:brain_coral_wall_fan'],
+	'minecraft:bubble_coral_fan': ['minecraft:bubble_coral_fan', 'minecraft:bubble_coral_wall_fan'],
+	'minecraft:fire_coral_fan': ['minecraft:fire_coral_fan', 'minecraft:fire_coral_wall_fan'],
+	'minecraft:horn_coral_fan': ['minecraft:horn_coral_fan', 'minecraft:horn_coral_wall_fan'],
+	'minecraft:tube_coral_fan': ['minecraft:tube_coral_fan', 'minecraft:tube_coral_wall_fan'],
 
 	// Heads and skulls.
-	'minecraft:creeper_head': [
-		'minecraft:creeper_head',
-		'minecraft:creeper_wall_head',
-	],
-	'minecraft:dragon_head': [
-		'minecraft:dragon_head',
-		'minecraft:dragon_wall_head',
-	],
-	'minecraft:player_head': [
-		'minecraft:player_head',
-		'minecraft:player_wall_head',
-	],
-	'minecraft:skeleton_skull': [
-		'minecraft:skeleton_skull',
-		'minecraft:skeleton_wall_skull',
-	],
+	'minecraft:creeper_head': ['minecraft:creeper_head', 'minecraft:creeper_wall_head'],
+	'minecraft:dragon_head': ['minecraft:dragon_head', 'minecraft:dragon_wall_head'],
+	'minecraft:player_head': ['minecraft:player_head', 'minecraft:player_wall_head'],
+	'minecraft:skeleton_skull': ['minecraft:skeleton_skull', 'minecraft:skeleton_wall_skull'],
 	'minecraft:wither_skeleton_skull': [
 		'minecraft:wither_skeleton_skull',
 		'minecraft:wither_skeleton_wall_skull',
@@ -69,14 +42,8 @@ const BlockItems: { [item: string]: core.FullResourceLocation[] } = {
 
 	// Torches.
 	'minecraft:torch': ['minecraft:torch', 'minecraft:wall_torch'],
-	'minecraft:soul_torch': [
-		'minecraft:soul_torch',
-		'minecraft:soul_wall_torch',
-	],
-	'minecraft:redstone_torch': [
-		'minecraft:redstone_torch',
-		'minecraft:redstone_wall_torch',
-	],
+	'minecraft:soul_torch': ['minecraft:soul_torch', 'minecraft:soul_wall_torch'],
+	'minecraft:redstone_torch': ['minecraft:redstone_torch', 'minecraft:redstone_wall_torch'],
 
 	'minecraft:beetroot_seeds': ['minecraft:beetroots'],
 	'minecraft:carrot': ['minecraft:carrots'],

--- a/packages/nbt/src/completer/index.ts
+++ b/packages/nbt/src/completer/index.ts
@@ -75,8 +75,12 @@ const primitive: core.Completer<NbtPrimitiveNode> = (node, ctx) => {
 		return []
 	}
 	if (
-		node.children && node.children.length > 0 &&
-		core.Range.contains(core.Range.translate(node, 1, -1), ctx.offset, true)
+		node.children && node.children.length > 0
+		&& core.Range.contains(
+			core.Range.translate(node, 1, -1),
+			ctx.offset,
+			true,
+		)
 	) {
 		const child = node.children[0]
 		return ctx.meta.getCompleter(child.type)(child, ctx)

--- a/packages/nbt/src/completer/index.ts
+++ b/packages/nbt/src/completer/index.ts
@@ -18,9 +18,7 @@ const collection: core.Completer<NbtCollectionNode> = (node, ctx) => {
 	}
 	if (node.typeDef?.kind === 'list') {
 		const completions = getValues(node.typeDef.item, ctx.offset, ctx)
-		if (
-			ctx.offset < node.children[node.children.length - 1]?.range.start ?? 0
-		) {
+		if (ctx.offset < node.children[node.children.length - 1]?.range.start ?? 0) {
 			return completions.map(c => ({ ...c, insertText: c.insertText + ',' }))
 		}
 		return completions
@@ -28,24 +26,17 @@ const collection: core.Completer<NbtCollectionNode> = (node, ctx) => {
 	return []
 }
 
-const compound = core.completer.record<
-	NbtStringNode,
-	NbtNode,
-	NbtCompoundNode
->({
+const compound = core.completer.record<NbtStringNode, NbtNode, NbtCompoundNode>({
 	key: (record, pair, _c, range, iv, ipe, exitingKeys) => {
 		if (!record.typeDef) {
 			return []
 		}
 		const keySet = new Set(exitingKeys.map(n => n.value))
-		return mcdoc.runtime.completer.getFields(record.typeDef)
-			.filter(({ key }) => !keySet.has(key))
+		return mcdoc.runtime.completer.getFields(record.typeDef).filter(({ key }) => !keySet.has(key))
 			.map(({ key, field }) =>
 				core.CompletionItem.create(key, pair?.key ?? range, {
 					kind: core.CompletionKind.Field,
-					detail: mcdoc.McdocType.toString(
-						field.type as core.Mutable<mcdoc.McdocType>,
-					),
+					detail: mcdoc.McdocType.toString(field.type as core.Mutable<mcdoc.McdocType>),
 					deprecated: field.deprecated,
 					sortText: field.optional ? '$b' : '$a', // sort above hardcoded $schema
 					filterText: key,
@@ -59,9 +50,9 @@ const compound = core.completer.record<
 		}
 		if (pair.key && record.typeDef) {
 			const pairKey = pair.key.value
-			const field = mcdoc.runtime.completer.getFields(record.typeDef)
-				.find(({ key }) => key === pairKey)
-				?.field.type
+			const field = mcdoc.runtime.completer.getFields(record.typeDef).find(({ key }) =>
+				key === pairKey
+			)?.field.type
 			if (field) {
 				return getValues(field, range, ctx)
 			}
@@ -76,11 +67,7 @@ const primitive: core.Completer<NbtPrimitiveNode> = (node, ctx) => {
 	}
 	if (
 		node.children && node.children.length > 0
-		&& core.Range.contains(
-			core.Range.translate(node, 1, -1),
-			ctx.offset,
-			true,
-		)
+		&& core.Range.contains(core.Range.translate(node, 1, -1), ctx.offset, true)
 	) {
 		const child = node.children[0]
 		return ctx.meta.getCompleter(child.type)(child, ctx)
@@ -94,15 +81,16 @@ function getValues(
 	range: core.RangeLike,
 	ctx: core.CompleterContext,
 ): core.CompletionItem[] {
-	return mcdoc.runtime.completer.getValues(typeDef, ctx)
-		.map(({ value, detail, kind, completionKind }) =>
-			core.CompletionItem.create(value, range, {
-				kind: completionKind ?? core.CompletionKind.Value,
-				detail,
-				filterText: formatValue(value, kind),
-				insertText: formatValue(value, kind),
-			})
-		)
+	return mcdoc.runtime.completer.getValues(typeDef, ctx).map((
+		{ value, detail, kind, completionKind },
+	) =>
+		core.CompletionItem.create(value, range, {
+			kind: completionKind ?? core.CompletionKind.Value,
+			detail,
+			filterText: formatValue(value, kind),
+			insertText: formatValue(value, kind),
+		})
+	)
 }
 
 function formatValue(value: string, kind?: mcdoc.McdocType['kind']) {

--- a/packages/nbt/src/index.ts
+++ b/packages/nbt/src/index.ts
@@ -13,10 +13,7 @@ export * as parser from './parser/index.js'
 
 /* istanbul ignore next */
 export const initialize: core.SyncProjectInitializer = ({ meta }) => {
-	meta.registerLanguage('nbt', {
-		extensions: ['.snbt'],
-		parser: parser.entry,
-	})
+	meta.registerLanguage('nbt', { extensions: ['.snbt'], parser: parser.entry })
 
 	meta.registerParser<NbtNode>('nbt:entry' as any, parser.entry)
 	meta.registerParser<NbtCompoundNode>('nbt:compound', parser.compound)

--- a/packages/nbt/src/node/index.ts
+++ b/packages/nbt/src/node/index.ts
@@ -13,9 +13,9 @@ export namespace NbtNode {
 	/* istanbul ignore next */
 	export function is(node: core.AstNode | undefined): node is NbtNode {
 		return (
-			NbtPrimitiveNode.is(node) ||
-			NbtCompoundNode.is(node) ||
-			NbtCollectionNode.is(node)
+			NbtPrimitiveNode.is(node)
+			|| NbtCompoundNode.is(node)
+			|| NbtCollectionNode.is(node)
 		)
 	}
 }
@@ -62,10 +62,10 @@ export namespace NbtIntegerAlikeNode {
 		node: core.AstNode | undefined,
 	): node is NbtIntegerAlikeNode {
 		return (
-			NbtByteNode.is(node) ||
-			NbtShortNode.is(node) ||
-			NbtIntNode.is(node) ||
-			NbtLongNode.is(node)
+			NbtByteNode.is(node)
+			|| NbtShortNode.is(node)
+			|| NbtIntNode.is(node)
+			|| NbtLongNode.is(node)
 		)
 	}
 }
@@ -190,9 +190,9 @@ export namespace NbtPrimitiveArrayNode {
 		node: core.AstNode | undefined,
 	): node is NbtPrimitiveArrayNode {
 		return (
-			NbtByteArrayNode.is(node) ||
-			NbtIntArrayNode.is(node) ||
-			NbtLongArrayNode.is(node)
+			NbtByteArrayNode.is(node)
+			|| NbtIntArrayNode.is(node)
+			|| NbtLongArrayNode.is(node)
 		)
 	}
 }

--- a/packages/nbt/src/node/index.ts
+++ b/packages/nbt/src/node/index.ts
@@ -145,9 +145,7 @@ export namespace NbtDoubleNode {
 // #endregion
 // #endregion
 
-export interface NbtCompoundNode
-	extends core.RecordBaseNode<NbtStringNode, NbtNode>, NbtBaseNode
-{
+export interface NbtCompoundNode extends core.RecordBaseNode<NbtStringNode, NbtNode>, NbtBaseNode {
 	readonly type: 'nbt:compound'
 }
 export namespace NbtCompoundNode {
@@ -197,9 +195,7 @@ export namespace NbtPrimitiveArrayNode {
 	}
 }
 
-export interface NbtByteArrayNode
-	extends core.ListNode<NbtByteNode>, NbtBaseNode
-{
+export interface NbtByteArrayNode extends core.ListNode<NbtByteNode>, NbtBaseNode {
 	type: 'nbt:byte_array'
 }
 export namespace NbtByteArrayNode {
@@ -211,9 +207,7 @@ export namespace NbtByteArrayNode {
 	}
 }
 
-export interface NbtIntArrayNode
-	extends core.ListNode<NbtIntNode>, NbtBaseNode
-{
+export interface NbtIntArrayNode extends core.ListNode<NbtIntNode>, NbtBaseNode {
 	type: 'nbt:int_array'
 }
 export namespace NbtIntArrayNode {
@@ -223,9 +217,7 @@ export namespace NbtIntArrayNode {
 	}
 }
 
-export interface NbtLongArrayNode
-	extends core.ListNode<NbtLongNode>, NbtBaseNode
-{
+export interface NbtLongArrayNode extends core.ListNode<NbtLongNode>, NbtBaseNode {
 	type: 'nbt:long_array'
 }
 export namespace NbtLongArrayNode {

--- a/packages/nbt/src/node/index.ts
+++ b/packages/nbt/src/node/index.ts
@@ -5,18 +5,11 @@ interface NbtBaseNode {
 	typeDef?: mcdoc.runtime.checker.SimplifiedMcdocType
 }
 
-export type NbtNode =
-	| NbtPrimitiveNode
-	| NbtCompoundNode
-	| NbtCollectionNode
+export type NbtNode = NbtPrimitiveNode | NbtCompoundNode | NbtCollectionNode
 export namespace NbtNode {
 	/* istanbul ignore next */
 	export function is(node: core.AstNode | undefined): node is NbtNode {
-		return (
-			NbtPrimitiveNode.is(node)
-			|| NbtCompoundNode.is(node)
-			|| NbtCollectionNode.is(node)
-		)
+		return (NbtPrimitiveNode.is(node) || NbtCompoundNode.is(node) || NbtCollectionNode.is(node))
 	}
 }
 
@@ -24,9 +17,7 @@ export namespace NbtNode {
 export type NbtPrimitiveNode = NbtNumberNode | NbtStringNode
 export namespace NbtPrimitiveNode {
 	/* istanbul ignore next */
-	export function is(
-		node: core.AstNode | undefined,
-	): node is NbtPrimitiveNode {
+	export function is(node: core.AstNode | undefined): node is NbtPrimitiveNode {
 		return NbtNumberNode.is(node) || NbtStringNode.is(node)
 	}
 }
@@ -51,22 +42,14 @@ export namespace NbtNumberNode {
 }
 
 // #region NbtIntegerAlikeNode
-export type NbtIntegerAlikeNode =
-	| NbtByteNode
-	| NbtShortNode
-	| NbtIntNode
-	| NbtLongNode
+export type NbtIntegerAlikeNode = NbtByteNode | NbtShortNode | NbtIntNode | NbtLongNode
 export namespace NbtIntegerAlikeNode {
 	/* istanbul ignore next */
-	export function is(
-		node: core.AstNode | undefined,
-	): node is NbtIntegerAlikeNode {
-		return (
-			NbtByteNode.is(node)
+	export function is(node: core.AstNode | undefined): node is NbtIntegerAlikeNode {
+		return (NbtByteNode.is(node)
 			|| NbtShortNode.is(node)
 			|| NbtIntNode.is(node)
-			|| NbtLongNode.is(node)
-		)
+			|| NbtLongNode.is(node))
 	}
 }
 
@@ -115,9 +98,7 @@ export namespace NbtLongNode {
 export type NbtFloatAlikeNode = NbtFloatNode | NbtDoubleNode
 export namespace NbtFloatAlikeNode {
 	/* istanbul ignore next */
-	export function is(
-		node: core.AstNode | undefined,
-	): node is NbtFloatAlikeNode {
+	export function is(node: core.AstNode | undefined): node is NbtFloatAlikeNode {
 		return NbtFloatNode.is(node) || NbtDoubleNode.is(node)
 	}
 }
@@ -159,9 +140,7 @@ export namespace NbtCompoundNode {
 export type NbtCollectionNode = NbtListNode | NbtPrimitiveArrayNode
 export namespace NbtCollectionNode {
 	/* istanbul ignore next */
-	export function is(
-		node: core.AstNode | undefined,
-	): node is NbtCollectionNode {
+	export function is(node: core.AstNode | undefined): node is NbtCollectionNode {
 		return NbtListNode.is(node) || NbtPrimitiveArrayNode.is(node)
 	}
 }
@@ -178,20 +157,11 @@ export namespace NbtListNode {
 }
 
 // #region NbtPrimitiveArrayNode
-export type NbtPrimitiveArrayNode =
-	| NbtByteArrayNode
-	| NbtIntArrayNode
-	| NbtLongArrayNode
+export type NbtPrimitiveArrayNode = NbtByteArrayNode | NbtIntArrayNode | NbtLongArrayNode
 export namespace NbtPrimitiveArrayNode {
 	/* istanbul ignore next */
-	export function is(
-		node: core.AstNode | undefined,
-	): node is NbtPrimitiveArrayNode {
-		return (
-			NbtByteArrayNode.is(node)
-			|| NbtIntArrayNode.is(node)
-			|| NbtLongArrayNode.is(node)
-		)
+	export function is(node: core.AstNode | undefined): node is NbtPrimitiveArrayNode {
+		return (NbtByteArrayNode.is(node) || NbtIntArrayNode.is(node) || NbtLongArrayNode.is(node))
 	}
 }
 
@@ -200,9 +170,7 @@ export interface NbtByteArrayNode extends core.ListNode<NbtByteNode>, NbtBaseNod
 }
 export namespace NbtByteArrayNode {
 	/* istanbul ignore next */
-	export function is(
-		node: core.AstNode | undefined,
-	): node is NbtByteArrayNode {
+	export function is(node: core.AstNode | undefined): node is NbtByteArrayNode {
 		return (node as NbtByteArrayNode | undefined)?.type === 'nbt:byte_array'
 	}
 }
@@ -222,9 +190,7 @@ export interface NbtLongArrayNode extends core.ListNode<NbtLongNode>, NbtBaseNod
 }
 export namespace NbtLongArrayNode {
 	/* istanbul ignore next */
-	export function is(
-		node: core.AstNode | undefined,
-	): node is NbtLongArrayNode {
+	export function is(node: core.AstNode | undefined): node is NbtLongArrayNode {
 		return (node as NbtLongArrayNode | undefined)?.type === 'nbt:long_array'
 	}
 }
@@ -251,9 +217,7 @@ export interface NbtPathIndexNode extends core.AstNode {
 }
 export namespace NbtPathIndexNode {
 	/* istanbul ignore next */
-	export function is(
-		node: core.AstNode | undefined,
-	): node is NbtPathIndexNode {
+	export function is(node: core.AstNode | undefined): node is NbtPathIndexNode {
 		return (node as NbtPathIndexNode | undefined)?.type === 'nbt:path/index'
 	}
 }

--- a/packages/nbt/src/parser/collection.ts
+++ b/packages/nbt/src/parser/collection.ts
@@ -11,13 +11,7 @@ import { entry } from './entry.js'
 import { primitive } from './primitive.js'
 
 export const list: core.Parser<NbtListNode> = (src, ctx) => {
-	const parser = core.list({
-		start: '[',
-		value: entry,
-		sep: ',',
-		trailingSep: false,
-		end: ']',
-	})
+	const parser = core.list({ start: '[', value: entry, sep: ',', trailingSep: false, end: ']' })
 	const ans = parser(src, ctx) as NbtListNode
 	ans.type = 'nbt:list'
 	ans.valueType = ans.children[0]?.value?.type
@@ -27,11 +21,7 @@ export const list: core.Parser<NbtListNode> = (src, ctx) => {
 		for (const { value } of ans.children) {
 			if (value && value.type !== ans.valueType) {
 				ctx.err.report(
-					localize(
-						'expected-got',
-						localizeTag(ans.valueType),
-						localizeTag(value.type),
-					),
+					localize('expected-got', localizeTag(ans.valueType), localizeTag(value.type)),
 					value,
 				)
 			}
@@ -56,11 +46,7 @@ export const byteArray: core.Parser<NbtByteArrayNode> = (src, ctx) => {
 	for (const { value } of ans.children) {
 		if (value && value.type !== 'nbt:byte') {
 			ctx.err.report(
-				localize(
-					'expected-got',
-					localize('nbt.node.byte'),
-					localizeTag(value.type),
-				),
+				localize('expected-got', localize('nbt.node.byte'), localizeTag(value.type)),
 				value,
 			)
 		}
@@ -84,11 +70,7 @@ export const intArray: core.Parser<NbtIntArrayNode> = (src, ctx) => {
 	for (const { value } of ans.children) {
 		if (value && value.type !== 'nbt:int') {
 			ctx.err.report(
-				localize(
-					'expected-got',
-					localize('nbt.node.int'),
-					localizeTag(value.type),
-				),
+				localize('expected-got', localize('nbt.node.int'), localizeTag(value.type)),
 				value,
 			)
 		}
@@ -112,11 +94,7 @@ export const longArray: core.Parser<NbtLongArrayNode> = (src, ctx) => {
 	for (const { value } of ans.children) {
 		if (value && value.type !== 'nbt:long') {
 			ctx.err.report(
-				localize(
-					'expected-got',
-					localize('nbt.node.long'),
-					localizeTag(value.type),
-				),
+				localize('expected-got', localize('nbt.node.long'), localizeTag(value.type)),
 				value,
 			)
 		}

--- a/packages/nbt/src/parser/compound.ts
+++ b/packages/nbt/src/parser/compound.ts
@@ -11,10 +11,7 @@ export const compound: core.InfallibleParser<NbtCompoundNode> = (src, ctx) => {
 				key: core.failOnEmpty(
 					core.setType(
 						'nbt:string',
-						core.string({
-							...core.BrigadierStringOptions,
-							colorTokenType: 'property',
-						}),
+						core.string({ ...core.BrigadierStringOptions, colorTokenType: 'property' }),
 					),
 				),
 				sep: ':',

--- a/packages/nbt/src/parser/entry.ts
+++ b/packages/nbt/src/parser/entry.ts
@@ -8,7 +8,10 @@ export const entry: core.Parser<NbtNode> = (src, ctx) =>
 	core.failOnEmpty(
 		core.select([
 			{ predicate: (src) => src.tryPeek('[B;'), parser: byteArray },
-			{ predicate: (src) => src.tryPeek('[I;'), parser: intArray },
+			{
+				predicate: (src) => src.tryPeek('[I;'),
+				parser: intArray,
+			},
 			{ predicate: (src) => src.tryPeek('[L;'), parser: longArray },
 			{ predicate: (src) => src.tryPeek('['), parser: list },
 			{ predicate: (src) => src.tryPeek('{'), parser: compound },

--- a/packages/nbt/src/parser/path.ts
+++ b/packages/nbt/src/parser/path.ts
@@ -13,11 +13,7 @@ type PartParser = (
 ) => ExpectedPart[]
 
 export const path: core.Parser<NbtPathNode> = (src, ctx) => {
-	const ans: NbtPathNode = {
-		type: 'nbt:path',
-		children: [],
-		range: core.Range.create(src),
-	}
+	const ans: NbtPathNode = { type: 'nbt:path', children: [], range: core.Range.create(src) }
 
 	let expectedParts: ExpectedPart[] = ['filter', 'key']
 	let currentPart = nextPart(src)
@@ -71,10 +67,7 @@ const index: PartParser = (children, src, ctx) => {
 	}
 	src.skipSpace()
 	if (!src.trySkip(']')) {
-		ctx.err.report(
-			localize('expected-got', localeQuote(']'), localeQuote(src.peek())),
-			src,
-		)
+		ctx.err.report(localize('expected-got', localeQuote(']'), localeQuote(src.peek())), src)
 	}
 
 	node.range.end = src.cursor
@@ -92,20 +85,7 @@ const key: PartParser = (children, src, ctx) => {
 			// Single quotes supported since 1.20 Pre-release 2 (roughly pack format 15)
 			// https://bugs.mojang.com/browse/MC-175504
 			quotes: ['"', "'"],
-			unquotable: {
-				blockList: new Set([
-					'\n',
-					'\r',
-					'\t',
-					' ',
-					'"',
-					'[',
-					']',
-					'.',
-					'{',
-					'}',
-				]),
-			},
+			unquotable: { blockList: new Set(['\n', '\r', '\t', ' ', '"', '[', ']', '.', '{', '}']) },
 		}),
 	)(src, ctx)
 	children.push(node)
@@ -133,8 +113,4 @@ function localizePart(part: ExpectedPart): string {
 	return localize(`nbt.node.path.${part}`)
 }
 
-const PartParsers: Record<Part, PartParser> = {
-	filter,
-	index,
-	key,
-}
+const PartParsers: Record<Part, PartParser> = { filter, index, key }

--- a/packages/nbt/src/parser/primitive.ts
+++ b/packages/nbt/src/parser/primitive.ts
@@ -1,11 +1,6 @@
 import * as core from '@spyglassmc/core'
 import { localize } from '@spyglassmc/locales'
-import type {
-	NbtByteNode,
-	NbtNumberNode,
-	NbtPrimitiveNode,
-	NbtStringNode,
-} from '../node/index.js'
+import type { NbtByteNode, NbtNumberNode, NbtPrimitiveNode, NbtStringNode } from '../node/index.js'
 import { localizeTag } from '../util.js'
 
 const enum Group {

--- a/packages/nbt/src/parser/primitive.ts
+++ b/packages/nbt/src/parser/primitive.ts
@@ -12,92 +12,88 @@ const enum Group {
 
 const FloatMaximum = (2 - 2 ** -23) * 2 ** 127
 
-const NumeralPatterns: (
-	| { pattern: RegExp; type: 'nbt:byte'; value: number; group: Group.Boolean }
-	| {
+const NumeralPatterns:
+	({ pattern: RegExp; type: 'nbt:byte'; value: number; group: Group.Boolean } | {
 		pattern: RegExp
 		type: NbtNumberNode['type']
 		hasSuffix: boolean
 		group: Group.FloatAlike
 		min?: number
 		max?: number
-	}
-	| {
+	} | {
 		pattern: RegExp
 		type: NbtNumberNode['type']
 		hasSuffix: boolean
 		group: Group.IntegerAlike
 		min: number
 		max: number
-	}
-	| {
+	} | {
 		pattern: RegExp
 		type: NbtNumberNode['type']
 		hasSuffix: boolean
 		group: Group.LongAlike
 		min: bigint
 		max: bigint
-	}
-)[] = [
-	{
-		pattern: /^[-+]?(?:0|[1-9][0-9]*)b$/i,
-		type: 'nbt:byte',
-		hasSuffix: true,
-		group: Group.IntegerAlike,
-		min: -128,
-		max: 127,
-	},
-	{
-		pattern: /^[-+]?(?:0|[1-9][0-9]*)s$/i,
-		type: 'nbt:short',
-		hasSuffix: true,
-		group: Group.IntegerAlike,
-		min: -32768,
-		max: 32767,
-	},
-	{
-		pattern: /^[-+]?(?:0|[1-9][0-9]*)$/,
-		type: 'nbt:int',
-		hasSuffix: false,
-		group: Group.IntegerAlike,
-		min: -2147483648,
-		max: 2147483647,
-	},
-	{
-		pattern: /^[-+]?(?:0|[1-9][0-9]*)l$/i,
-		type: 'nbt:long',
-		hasSuffix: true,
-		group: Group.LongAlike,
-		min: -9223372036854775808n,
-		max: 9223372036854775807n,
-	},
-	{
-		pattern: /^[-+]?(?:[0-9]+\.?|[0-9]*\.[0-9]+)(?:e[-+]?[0-9]+)?f$/i,
-		type: 'nbt:float',
-		hasSuffix: true,
-		group: Group.FloatAlike,
-		min: -FloatMaximum,
-		max: FloatMaximum,
-	},
-	{
-		pattern: /^[-+]?(?:[0-9]+\.|[0-9]*\.[0-9]+)(?:e[-+]?[0-9]+)?$/i,
-		type: 'nbt:double',
-		hasSuffix: false,
-		group: Group.FloatAlike,
-		min: -Number.MAX_VALUE,
-		max: Number.MAX_VALUE,
-	},
-	{
-		pattern: /^[-+]?(?:[0-9]+\.?|[0-9]*\.[0-9]+)(?:e[-+]?[0-9]+)?d$/i,
-		type: 'nbt:double',
-		hasSuffix: true,
-		group: Group.FloatAlike,
-		min: -Number.MAX_VALUE,
-		max: Number.MAX_VALUE,
-	},
-	{ pattern: /^true$/i, type: 'nbt:byte', value: 1, group: Group.Boolean },
-	{ pattern: /^false$/i, type: 'nbt:byte', value: 0, group: Group.Boolean },
-]
+	})[] = [
+		{
+			pattern: /^[-+]?(?:0|[1-9][0-9]*)b$/i,
+			type: 'nbt:byte',
+			hasSuffix: true,
+			group: Group.IntegerAlike,
+			min: -128,
+			max: 127,
+		},
+		{
+			pattern: /^[-+]?(?:0|[1-9][0-9]*)s$/i,
+			type: 'nbt:short',
+			hasSuffix: true,
+			group: Group.IntegerAlike,
+			min: -32768,
+			max: 32767,
+		},
+		{
+			pattern: /^[-+]?(?:0|[1-9][0-9]*)$/,
+			type: 'nbt:int',
+			hasSuffix: false,
+			group: Group.IntegerAlike,
+			min: -2147483648,
+			max: 2147483647,
+		},
+		{
+			pattern: /^[-+]?(?:0|[1-9][0-9]*)l$/i,
+			type: 'nbt:long',
+			hasSuffix: true,
+			group: Group.LongAlike,
+			min: -9223372036854775808n,
+			max: 9223372036854775807n,
+		},
+		{
+			pattern: /^[-+]?(?:[0-9]+\.?|[0-9]*\.[0-9]+)(?:e[-+]?[0-9]+)?f$/i,
+			type: 'nbt:float',
+			hasSuffix: true,
+			group: Group.FloatAlike,
+			min: -FloatMaximum,
+			max: FloatMaximum,
+		},
+		{
+			pattern: /^[-+]?(?:[0-9]+\.|[0-9]*\.[0-9]+)(?:e[-+]?[0-9]+)?$/i,
+			type: 'nbt:double',
+			hasSuffix: false,
+			group: Group.FloatAlike,
+			min: -Number.MAX_VALUE,
+			max: Number.MAX_VALUE,
+		},
+		{
+			pattern: /^[-+]?(?:[0-9]+\.?|[0-9]*\.[0-9]+)(?:e[-+]?[0-9]+)?d$/i,
+			type: 'nbt:double',
+			hasSuffix: true,
+			group: Group.FloatAlike,
+			min: -Number.MAX_VALUE,
+			max: Number.MAX_VALUE,
+		},
+		{ pattern: /^true$/i, type: 'nbt:byte', value: 1, group: Group.Boolean },
+		{ pattern: /^false$/i, type: 'nbt:byte', value: 0, group: Group.Boolean },
+	]
 
 export const string = core.setType('nbt:string', core.brigadierString)
 
@@ -109,8 +105,11 @@ export const primitive: core.InfallibleParser<NbtPrimitiveNode> = (
 		return string(src, ctx)
 	}
 
-	const { result: unquotedResult, updateSrcAndCtx: updateUnquoted } = core
-		.attempt(string, src, ctx)
+	const { result: unquotedResult, updateSrcAndCtx: updateUnquoted } = core.attempt(
+		string,
+		src,
+		ctx,
+	)
 	for (const e of NumeralPatterns) {
 		if (e.pattern.test(unquotedResult.value)) {
 			if (e.group === Group.Boolean) {
@@ -129,18 +128,16 @@ export const primitive: core.InfallibleParser<NbtPrimitiveNode> = (
 			> = e.group === Group.IntegerAlike
 				// As we already checked the format of the value with `e.pattern` in the if-block, there is no need to check
 				// it again here in the parser, therefore we just pass in a simple /./ regex.
-				? core.integer({
-					pattern: /./,
-					min: e.min,
-					max: e.max,
-					onOutOfRange,
-				})
+				? core.integer({ pattern: /./, min: e.min, max: e.max, onOutOfRange })
 				: e.group === Group.LongAlike
 				? core.long({ pattern: /./, min: e.min, max: e.max, onOutOfRange })
 				: core.float({ pattern: /./, min: e.min, max: e.max, onOutOfRange })
 
-			const { result: numeralResult, updateSrcAndCtx: updateNumeral } = core
-				.attempt(numeralParser, src, ctx)
+			const { result: numeralResult, updateSrcAndCtx: updateNumeral } = core.attempt(
+				numeralParser,
+				src,
+				ctx,
+			)
 			if (isOutOfRange) {
 				ctx.err.report(
 					localize(
@@ -160,10 +157,7 @@ export const primitive: core.InfallibleParser<NbtPrimitiveNode> = (
 				src.skip()
 				numeralResult.range.end++
 			}
-			return {
-				...numeralResult,
-				type: e.type,
-			} as NbtNumberNode
+			return { ...numeralResult, type: e.type } as NbtNumberNode
 		}
 	}
 

--- a/packages/nbt/test/parser/collection.spec.ts
+++ b/packages/nbt/test/parser/collection.spec.ts
@@ -1,13 +1,5 @@
-import {
-	showWhitespaceGlyph,
-	testParser,
-} from '@spyglassmc/core/test-out/utils.js'
-import {
-	byteArray,
-	intArray,
-	list,
-	longArray,
-} from '@spyglassmc/nbt/lib/parser/index.js'
+import { showWhitespaceGlyph, testParser } from '@spyglassmc/core/test-out/utils.js'
+import { byteArray, intArray, list, longArray } from '@spyglassmc/nbt/lib/parser/index.js'
 import { describe, it } from 'mocha'
 import snapshot from 'snap-shot-it'
 

--- a/packages/nbt/test/parser/collection.spec.ts
+++ b/packages/nbt/test/parser/collection.spec.ts
@@ -4,12 +4,9 @@ import { describe, it } from 'mocha'
 import snapshot from 'snap-shot-it'
 
 describe('nbt list()', () => {
-	const suites: { content: string }[] = [
-		{ content: '' },
-		{ content: '[]' },
-		{ content: '["string"]' },
-		{ content: '["string", 1b]' },
-	]
+	const suites: { content: string }[] = [{ content: '' }, { content: '[]' }, {
+		content: '["string"]',
+	}, { content: '["string", 1b]' }]
 	for (const { content } of suites) {
 		it(`Parse "${showWhitespaceGlyph(content)}"`, () => {
 			const parser = list
@@ -19,12 +16,9 @@ describe('nbt list()', () => {
 })
 
 describe('nbt byteArray()', () => {
-	const suites: { content: string }[] = [
-		{ content: '' },
-		{ content: '[B;]' },
-		{ content: '[B; true, 1b]' },
-		{ content: '[B; true, 1b, 2]' },
-	]
+	const suites: { content: string }[] = [{ content: '' }, { content: '[B;]' }, {
+		content: '[B; true, 1b]',
+	}, { content: '[B; true, 1b, 2]' }]
 	for (const { content } of suites) {
 		it(`Parse "${showWhitespaceGlyph(content)}"`, () => {
 			const parser = byteArray
@@ -34,12 +28,9 @@ describe('nbt byteArray()', () => {
 })
 
 describe('nbt intArray()', () => {
-	const suites: { content: string }[] = [
-		{ content: '' },
-		{ content: '[I;]' },
-		{ content: '[I; 0, 1]' },
-		{ content: '[I; 0, 1.]' },
-	]
+	const suites: { content: string }[] = [{ content: '' }, { content: '[I;]' }, {
+		content: '[I; 0, 1]',
+	}, { content: '[I; 0, 1.]' }]
 	for (const { content } of suites) {
 		it(`Parse "${showWhitespaceGlyph(content)}"`, () => {
 			const parser = intArray
@@ -49,12 +40,9 @@ describe('nbt intArray()', () => {
 })
 
 describe('nbt longArray()', () => {
-	const suites: { content: string }[] = [
-		{ content: '' },
-		{ content: '[L;]' },
-		{ content: '[L; 0L, 1L]' },
-		{ content: '[L; 0L, 2, "string"]' },
-	]
+	const suites: { content: string }[] = [{ content: '' }, { content: '[L;]' }, {
+		content: '[L; 0L, 1L]',
+	}, { content: '[L; 0L, 2, "string"]' }]
 	for (const { content } of suites) {
 		it(`Parse "${showWhitespaceGlyph(content)}"`, () => {
 			const parser = longArray

--- a/packages/nbt/test/parser/compound.spec.ts
+++ b/packages/nbt/test/parser/compound.spec.ts
@@ -4,12 +4,9 @@ import { describe, it } from 'mocha'
 import snapshot from 'snap-shot-it'
 
 describe('nbt compound()', () => {
-	const suites: { content: string }[] = [
-		{ content: '' },
-		{ content: '"string"' },
-		{ content: '{}' },
-		{ content: '{ foo: true }' },
-	]
+	const suites: { content: string }[] = [{ content: '' }, { content: '"string"' }, {
+		content: '{}',
+	}, { content: '{ foo: true }' }]
 	for (const { content } of suites) {
 		it(`Parse "${showWhitespaceGlyph(content)}"`, () => {
 			const parser = compound

--- a/packages/nbt/test/parser/compound.spec.ts
+++ b/packages/nbt/test/parser/compound.spec.ts
@@ -1,7 +1,4 @@
-import {
-	showWhitespaceGlyph,
-	testParser,
-} from '@spyglassmc/core/test-out/utils.js'
+import { showWhitespaceGlyph, testParser } from '@spyglassmc/core/test-out/utils.js'
 import { compound } from '@spyglassmc/nbt/lib/parser/index.js'
 import { describe, it } from 'mocha'
 import snapshot from 'snap-shot-it'

--- a/packages/nbt/test/parser/path.spec.ts
+++ b/packages/nbt/test/parser/path.spec.ts
@@ -1,7 +1,4 @@
-import {
-	showWhitespaceGlyph,
-	testParser,
-} from '@spyglassmc/core/test-out/utils.js'
+import { showWhitespaceGlyph, testParser } from '@spyglassmc/core/test-out/utils.js'
 import { path } from '@spyglassmc/nbt/lib/parser/index.js'
 import { describe, it } from 'mocha'
 import snapshot from 'snap-shot-it'

--- a/packages/nbt/test/parser/primitive.spec.ts
+++ b/packages/nbt/test/parser/primitive.spec.ts
@@ -1,7 +1,4 @@
-import {
-	showWhitespaceGlyph,
-	testParser,
-} from '@spyglassmc/core/test-out/utils.js'
+import { showWhitespaceGlyph, testParser } from '@spyglassmc/core/test-out/utils.js'
 import { primitive } from '@spyglassmc/nbt/lib/parser/index.js'
 import { describe, it } from 'mocha'
 import snapshot from 'snap-shot-it'

--- a/packages/playground/src/index.ts
+++ b/packages/playground/src/index.ts
@@ -1,8 +1,5 @@
 /* eslint-disable no-restricted-syntax */
-import type {
-	CompletionContext,
-	CompletionResult,
-} from '@codemirror/autocomplete'
+import type { CompletionContext, CompletionResult } from '@codemirror/autocomplete'
 import { autocompletion } from '@codemirror/autocomplete'
 import { basicSetup, EditorState, EditorView } from '@codemirror/basic-setup'
 import { indentWithTab } from '@codemirror/commands'
@@ -23,8 +20,7 @@ const $editorContainer = document.getElementById(
 const $uri = document.getElementById('uri') as HTMLInputElement
 
 const initialContent = 'execute as @a run say hello world'
-const getLanguage = () =>
-	$language.selectedOptions[0]?.dataset?.language ?? $language.value
+const getLanguage = () => $language.selectedOptions[0]?.dataset?.language ?? $language.value
 const getContent = (state: EditorState) => view.state.sliceDoc(0)
 let version = 0
 

--- a/packages/playground/src/index.ts
+++ b/packages/playground/src/index.ts
@@ -184,8 +184,8 @@ const getColorTokenMark = (t: ColorToken): Decoration => {
 	return Decoration.mark({
 		class: `spyglassmc-color-token-${t.type} ${
 			t.modifiers?.map((m) => `spyglassmc-color-token-modifier-${m}`)
-				.join() ??
-				''
+				.join()
+				?? ''
 		}`,
 	})
 }

--- a/packages/playground/src/index.ts
+++ b/packages/playground/src/index.ts
@@ -14,9 +14,7 @@ import * as je from '@spyglassmc/java-edition'
 import * as mcdoc from '@spyglassmc/mcdoc'
 
 const $language = document.getElementById('language') as HTMLSelectElement
-const $editorContainer = document.getElementById(
-	'editor-container',
-) as HTMLDivElement
+const $editorContainer = document.getElementById('editor-container') as HTMLDivElement
 const $uri = document.getElementById('uri') as HTMLInputElement
 
 const initialContent = 'execute as @a run say hello world'
@@ -34,9 +32,7 @@ const service = new core.Service({
 	]),
 	project: {
 		cacheRoot: 'file:///.cache/',
-		defaultConfig: core.ConfigService.merge(core.VanillaConfig, {
-			env: { dependencies: [] },
-		}),
+		defaultConfig: core.ConfigService.merge(core.VanillaConfig, { env: { dependencies: [] } }),
 		externals: BrowserExternals,
 		initializers: [mcdoc.initialize, je.initialize],
 		projectRoot: 'file:///root/',
@@ -52,17 +48,13 @@ const onChange = EditorView.updateListener.of((update) => {
 		return
 	}
 	const content = getContent(update.state)
-	service.project
-		.onDidChange($uri.value, [{ text: content }], ++version)
-		.catch((e) => console.error('[onChange]', e))
+	service.project.onDidChange($uri.value, [{ text: content }], ++version).catch((e) =>
+		console.error('[onChange]', e)
+	)
 })
 
-async function spyglassCompletions(
-	ctx: CompletionContext,
-): Promise<CompletionResult | null> {
-	const docAndNodes = await service.project.ensureClientManagedChecked(
-		$uri.value,
-	)
+async function spyglassCompletions(ctx: CompletionContext): Promise<CompletionResult | null> {
+	const docAndNodes = await service.project.ensureClientManagedChecked($uri.value)
 	if (!docAndNodes) {
 		return null
 	}
@@ -73,11 +65,7 @@ async function spyglassCompletions(
 	return {
 		from: items[0].range.start,
 		to: items[0].range.end,
-		options: items.map((v) => ({
-			label: v.label,
-			detail: v.detail,
-			info: v.documentation,
-		})),
+		options: items.map((v) => ({ label: v.label, detail: v.detail, info: v.documentation })),
 	}
 }
 
@@ -97,9 +85,7 @@ const diagnosticField = StateField.define<DecorationSet>({
 				add: [
 					getDiagnosticMark(e).range(
 						e.range.start,
-						e.range.end === e.range.start
-							? e.range.start + 1
-							: e.range.end,
+						e.range.end === e.range.start ? e.range.start + 1 : e.range.end,
 					),
 				],
 			})
@@ -111,9 +97,7 @@ const diagnosticField = StateField.define<DecorationSet>({
 
 const getDiagnosticMark = (e: LanguageError): Decoration => {
 	return Decoration.mark({
-		attributes: {
-			'data-diagnostic-message': e.message,
-		},
+		attributes: { 'data-diagnostic-message': e.message },
 		class: `spyglassmc-diagnostic spyglassmc-diagnostic-${e.severity}`,
 	})
 }
@@ -134,21 +118,11 @@ const diagnosticTheme = EditorView.baseTheme({
 		'max-height': '4em',
 		'max-width': '60em',
 	},
-	'.spyglassmc-diagnostic:hover::before': {
-		display: 'block',
-	},
-	'.spyglassmc-diagnostic-0': {
-		textDecoration: 'underline 1.5px darkgray',
-	},
-	'.spyglassmc-diagnostic-1': {
-		textDecoration: 'underline 1.5px lightblue',
-	},
-	'.spyglassmc-diagnostic-2': {
-		textDecoration: 'underline 1.5px orange',
-	},
-	'.spyglassmc-diagnostic-3': {
-		textDecoration: 'underline 1.5px red',
-	},
+	'.spyglassmc-diagnostic:hover::before': { display: 'block' },
+	'.spyglassmc-diagnostic-0': { textDecoration: 'underline 1.5px darkgray' },
+	'.spyglassmc-diagnostic-1': { textDecoration: 'underline 1.5px lightblue' },
+	'.spyglassmc-diagnostic-2': { textDecoration: 'underline 1.5px orange' },
+	'.spyglassmc-diagnostic-3': { textDecoration: 'underline 1.5px red' },
 })
 
 const colorTokenField = StateField.define<DecorationSet>({
@@ -179,9 +153,7 @@ const colorTokenField = StateField.define<DecorationSet>({
 const getColorTokenMark = (t: ColorToken): Decoration => {
 	return Decoration.mark({
 		class: `spyglassmc-color-token-${t.type} ${
-			t.modifiers?.map((m) => `spyglassmc-color-token-modifier-${m}`)
-				.join()
-				?? ''
+			t.modifiers?.map((m) => `spyglassmc-color-token-modifier-${m}`).join() ?? ''
 		}`,
 	})
 }
@@ -240,10 +212,5 @@ $language.onchange = async () => {
 	service.project.onDidClose($uri.value)
 	$uri.value = `file:///root/foo.${$language.value}`
 	version = 0
-	await service.project.onDidOpen(
-		$uri.value,
-		getLanguage(),
-		version,
-		getContent(view.state),
-	)
+	await service.project.onDidOpen($uri.value, getLanguage(), version, getContent(view.state))
 }

--- a/packages/vscode-extension/src/extension.mts
+++ b/packages/vscode-extension/src/extension.mts
@@ -53,8 +53,7 @@ export function activate(context: vsc.ExtensionContext) {
 	]
 
 	const initializationOptions: server.CustomInitializationOptions = {
-		inDevelopmentMode:
-			context.extensionMode === vsc.ExtensionMode.Development,
+		inDevelopmentMode: context.extensionMode === vsc.ExtensionMode.Development,
 	}
 
 	// Options to control the language client
@@ -75,8 +74,8 @@ export function activate(context: vsc.ExtensionContext) {
 	// Start the client. This will also launch the server
 	client.start().then(
 		() => {
-			const customCapabilities: server.CustomServerCapabilities | undefined =
-				client.initializeResult?.capabilities.experimental?.spyglassmc
+			const customCapabilities: server.CustomServerCapabilities | undefined = client
+				.initializeResult?.capabilities.experimental?.spyglassmc
 
 			if (customCapabilities?.dataHackPubify) {
 				context.subscriptions.push(
@@ -91,10 +90,9 @@ export function activate(context: vsc.ExtensionContext) {
 									return
 								}
 
-								const params: server.MyLspDataHackPubifyRequestParams =
-									{
-										initialism,
-									}
+								const params: server.MyLspDataHackPubifyRequestParams = {
+									initialism,
+								}
 								const response: string = await client.sendRequest(
 									'spyglassmc/dataHackPubify',
 									params,

--- a/packages/vscode-extension/src/extension.mts
+++ b/packages/vscode-extension/src/extension.mts
@@ -14,11 +14,7 @@ export function activate(context: vsc.ExtensionContext) {
 	// The server is implemented in node
 	const serverModule = context.asAbsolutePath(path.join('dist', 'server.js'))
 
-	const runOptions = {
-		execArgv: [
-			'--enable-source-maps',
-		],
-	}
+	const runOptions = { execArgv: ['--enable-source-maps'] }
 	const debugOptions = {
 		execArgv: [
 			'--nolazy',
@@ -32,16 +28,8 @@ export function activate(context: vsc.ExtensionContext) {
 	// If the extension is launched in debug mode then the debug server options are used
 	// Otherwise the run options are used
 	const serverOptions: lc.ServerOptions = {
-		run: {
-			module: serverModule,
-			transport: lc.TransportKind.ipc,
-			options: runOptions,
-		},
-		debug: {
-			module: serverModule,
-			transport: lc.TransportKind.ipc,
-			options: debugOptions,
-		},
+		run: { module: serverModule, transport: lc.TransportKind.ipc, options: runOptions },
+		debug: { module: serverModule, transport: lc.TransportKind.ipc, options: debugOptions },
 	}
 
 	const documentSelector: lc.DocumentSelector = [
@@ -72,74 +60,61 @@ export function activate(context: vsc.ExtensionContext) {
 	)
 
 	// Start the client. This will also launch the server
-	client.start().then(
-		() => {
-			const customCapabilities: server.CustomServerCapabilities | undefined = client
-				.initializeResult?.capabilities.experimental?.spyglassmc
+	client.start().then(() => {
+		const customCapabilities: server.CustomServerCapabilities | undefined = client
+			.initializeResult?.capabilities.experimental?.spyglassmc
 
-			if (customCapabilities?.dataHackPubify) {
-				context.subscriptions.push(
-					vsc.commands.registerCommand(
-						'spyglassmc.dataHackPubify',
-						async (): Promise<void> => {
-							try {
-								const initialism = await vsc.window.showInputBox({
-									placeHolder: 'DHP',
-								})
-								if (!initialism) {
-									return
-								}
+		if (customCapabilities?.dataHackPubify) {
+			context.subscriptions.push(
+				vsc.commands.registerCommand('spyglassmc.dataHackPubify', async (): Promise<void> => {
+					try {
+						const initialism = await vsc.window.showInputBox({ placeHolder: 'DHP' })
+						if (!initialism) {
+							return
+						}
 
-								const params: server.MyLspDataHackPubifyRequestParams = {
-									initialism,
-								}
-								const response: string = await client.sendRequest(
-									'spyglassmc/dataHackPubify',
-									params,
-								)
-								await vsc.window.showInformationMessage(response)
-							} catch (e) {
-								console.error('[client#dataHackPubify]', e)
-							}
-						},
-					),
-				)
-			}
+						const params: server.MyLspDataHackPubifyRequestParams = { initialism }
+						const response: string = await client.sendRequest(
+							'spyglassmc/dataHackPubify',
+							params,
+						)
+						await vsc.window.showInformationMessage(response)
+					} catch (e) {
+						console.error('[client#dataHackPubify]', e)
+					}
+				}),
+			)
+		}
 
-			if (customCapabilities?.resetProjectCache) {
-				context.subscriptions.push(
-					vsc.commands.registerCommand(
-						'spyglassmc.resetProjectCache',
-						async (): Promise<void> => {
-							try {
-								await client.sendRequest('spyglassmc/resetProjectCache')
-							} catch (e) {
-								console.error('[client#resetProjectCache]', e)
-							}
-						},
-					),
-				)
-			}
+		if (customCapabilities?.resetProjectCache) {
+			context.subscriptions.push(
+				vsc.commands.registerCommand(
+					'spyglassmc.resetProjectCache',
+					async (): Promise<void> => {
+						try {
+							await client.sendRequest('spyglassmc/resetProjectCache')
+						} catch (e) {
+							console.error('[client#resetProjectCache]', e)
+						}
+					},
+				),
+			)
+		}
 
-			if (customCapabilities?.showCacheRoot) {
-				context.subscriptions.push(
-					vsc.commands.registerCommand(
-						'spyglassmc.showCacheRoot',
-						async (): Promise<void> => {
-							try {
-								await client.sendRequest('spyglassmc/showCacheRoot')
-							} catch (e) {
-								console.error('[client#showCacheRoot]', e)
-							}
-						},
-					),
-				)
-			}
-		},
-		(e) => {
-			console.error('[client#start]', e)
-		},
-	)
+		if (customCapabilities?.showCacheRoot) {
+			context.subscriptions.push(
+				vsc.commands.registerCommand('spyglassmc.showCacheRoot', async (): Promise<void> => {
+					try {
+						await client.sendRequest('spyglassmc/showCacheRoot')
+					} catch (e) {
+						console.error('[client#showCacheRoot]', e)
+					}
+				}),
+			)
+		}
+	}, (e) => {
+		console.error('[client#start]', e)
+	})
 }
 
 export function deactivate(): Thenable<void> | undefined {


### PR DESCRIPTION
Everything up for discussion

- Added `object-shorthand` eslint rule
- Changed `operatorPosition` to `nextLine`
- Changed line width from 80 to 100
- Reformatted project using `preferSingleLine: true` temporarily, to illustrate how it might look like with the new line length (this rule is experimental, makes formatting significantly slower, and crashes when trying to format `java-edition/src/mcfunction/tree/patch.ts`, so it definitley shouldn't be enabled by default, and I like the idea of leaving the option to the author to potentially wrap lines more than neccessary)


This is meant as an illustration of how the formatting could be improved. I think bumping the line width a bit like this is a good compromise, I tried `120` initially, but that seemed a bit too much in some cases.