### PR TITLE
🐛 Fix `Reset Project Cache` command

### DIFF
--- a/packages/core/src/service/Downloader.ts
+++ b/packages/core/src/service/Downloader.ts
@@ -207,5 +207,8 @@ interface Job<R> {
 	}
 	transformer: (data: Uint8Array) => PromiseLike<R> | R
 	options?: ExternalDownloaderOptions
+	/**
+	 * If set, caches the result in memory. Time in milliseconds.
+	 */
 	ttl?: number
 }

--- a/packages/core/src/service/Downloader.ts
+++ b/packages/core/src/service/Downloader.ts
@@ -13,11 +13,15 @@ export interface DownloaderDownloadOut {
 	checksum?: string
 }
 
+interface MemoryCacheEntry {
+	buffer: Uint8Array
+	time: number
+	cacheUri?: string
+	checksum?: string
+}
+
 export class Downloader {
-	readonly #memoryCache = new Map<
-		string,
-		{ buffer: Uint8Array; time: number }
-	>()
+	readonly #memoryCache = new Map<string, MemoryCacheEntry>()
 
 	constructor(
 		private readonly cacheRoot: RootUriString,
@@ -31,11 +35,14 @@ export class Downloader {
 	): Promise<R | undefined> {
 		const { id, cache, uri, options, transformer, ttl } = job
 		if (ttl && this.#memoryCache.has(uri)) {
-			const { buffer, time } = this.#memoryCache.get(uri)!
+			const memoryCacheEntry = this.#memoryCache.get(uri)!
+			const { buffer, time, cacheUri, checksum } = memoryCacheEntry
 			if (performance.now() <= time + ttl) {
 				this.logger.info(
 					`[Downloader] [${id}] Skipped thanks to valid cache in memory`,
 				)
+				out.cacheUri = cacheUri
+				out.checksum = checksum
 				return await transformer(buffer)
 			} else {
 				this.#memoryCache.delete(uri)
@@ -72,6 +79,8 @@ export class Downloader {
 							if (ttl) {
 								this.#memoryCache.set(uri, {
 									buffer: cachedBuffer,
+									cacheUri: cacheUri,
+									checksum: checksum,
 									time: performance.now(),
 								})
 							}

--- a/packages/core/src/service/Downloader.ts
+++ b/packages/core/src/service/Downloader.ts
@@ -32,7 +32,7 @@ export class Downloader {
 		const { id, cache, uri, options, transformer, ttl } = job
 		if (ttl && this.#memoryCache.has(uri)) {
 			const { buffer, time } = this.#memoryCache.get(uri)!
-			if (time <= performance.now() + ttl) {
+			if (performance.now() <= time + ttl) {
 				this.logger.info(
 					`[Downloader] [${id}] Skipped thanks to valid cache in memory`,
 				)

--- a/packages/java-edition/src/dependency/index.ts
+++ b/packages/java-edition/src/dependency/index.ts
@@ -11,6 +11,7 @@ import type {
 } from './mcmeta.js'
 import { Fluids, getMcmetaSummaryUris } from './mcmeta.js'
 
+// Memory cache TTL in milliseconds
 const DownloaderTtl = 15_000
 
 /* istanbul ignore next */


### PR DESCRIPTION
- Fixes #1258

The issue was caused because the `vanilla-datapack` and `vanilla-mcdoc` dependencies relied on the downloader setting the `out.cacheUri` field. This did not happen when memory cache was found (because only the raw buffer was stored in the memory cache).

The memory cache is only intended to last 15 seconds, but due to a logic error, memory cache entries never expired.