### PR TITLE
⚡ Optimize `isAssignable` for literal types

### DIFF
--- a/packages/mcdoc/src/runtime/attribute/index.ts
+++ b/packages/mcdoc/src/runtime/attribute/index.ts
@@ -57,15 +57,11 @@ export function handleAttributes(
 	for (const { name, value } of attributes ?? []) {
 		const handler = getAttribute(ctx.meta, name)
 		if (!handler) {
-			ctx.logger.warn(`[mcdoc] Unhandled attribute ${name}`)
 			continue
 		}
 
 		const config = handler.validator(value, ctx)
 		if (config === core.Failure) {
-			ctx.logger.warn(
-				`[mcdoc] Invalid attribute ${name}: ${JSON.stringify(value)}`,
-			)
 			continue
 		}
 		fn(handler.attribute, config)

--- a/packages/mcdoc/src/runtime/checker/index.ts
+++ b/packages/mcdoc/src/runtime/checker/index.ts
@@ -165,6 +165,12 @@ export function isAssignable(
 	ctx: core.CheckerContext,
 	isEquivalent?: NodeEquivalenceChecker,
 ): boolean {
+	if (
+		assignValue.kind === 'literal' && typeDef.kind === 'literal' &&
+		assignValue.value.kind === typeDef.value.kind
+	) {
+		return assignValue.value.value === typeDef.value.value
+	}
 	let ans = true
 	const options: McdocCheckerOptions<McdocType> = {
 		context: ctx,

--- a/packages/mcdoc/src/runtime/checker/index.ts
+++ b/packages/mcdoc/src/runtime/checker/index.ts
@@ -167,7 +167,8 @@ export function isAssignable(
 ): boolean {
 	if (
 		assignValue.kind === 'literal' && typeDef.kind === 'literal' &&
-		assignValue.value.kind === typeDef.value.kind
+		assignValue.value.kind === typeDef.value.kind &&
+		!assignValue.attributes && !typeDef.attributes
 	) {
 		return assignValue.value.value === typeDef.value.value
 	}


### PR DESCRIPTION
The vast majority (if not all) calls to `isAssignable` compare two literal types. This PR introduces a fast path for those cases, assuming that two literal types of the same kind are always equal to each other when their values match.

A few benchmarks:
* 9.39ms -> 2.36ms
* 170.11ms -> 117.26ms
* 320.82ms -> 274.17ms

That last one in particular was
```
data merge entity @s {Air:1b,state:"rolling",Passengers:[{Air:0}]}
```

Additionally this PR removes some of the attribute warnings, bringing the total time of that last example all the way down to 8.08ms!