### PR TITLE
✨ Show doc comments on mcdoc hover

### DIFF
--- a/packages/json/src/checker/index.ts
+++ b/packages/json/src/checker/index.ts
@@ -66,17 +66,17 @@ export function index(
 					ctx,
 					mcdoc.runtime.checker.getErrorRangeDefault<JsonNode>,
 				),
-				attachTypeInfo: (node, definition) => {
+				attachTypeInfo: (node, definition, desc = '') => {
 					node.typeDef = definition
 					// TODO: improve hover info
 					if (
-						node.parent && JsonPairNode?.is(node.parent) &&
+						node.parent && JsonPairNode.is(node.parent) &&
 						node.parent.key
 					) {
 						node.parent.key.hover =
 							`\`\`\`typescript\n${node.parent.key.value}: ${
 								mcdoc.McdocType.toString(definition)
-							}\n\`\`\``
+							}\n\`\`\`\n${desc}`
 					}
 				},
 				stringAttacher: (node, attacher) => {

--- a/packages/mcdoc/src/binder/index.ts
+++ b/packages/mcdoc/src/binder/index.ts
@@ -1115,12 +1115,14 @@ function convertStructPairField(
 	node: StructPairFieldNode,
 	ctx: McdocBinderContext,
 ): StructTypePairField {
-	const { attributes, key, type, isOptional } = StructPairFieldNode.destruct(
-		node,
-	)
+	const { attributes, docComments, key, type, isOptional } =
+		StructPairFieldNode.destruct(
+			node,
+		)
 	return {
 		kind: 'pair',
 		attributes: convertAttributes(attributes, ctx),
+		desc: DocCommentsNode.asText(docComments),
 		key: convertStructKey(key, ctx),
 		type: convertType(type, ctx),
 		optional: isOptional,

--- a/packages/mcdoc/src/node/index.ts
+++ b/packages/mcdoc/src/node/index.ts
@@ -920,12 +920,14 @@ export interface StructPairFieldNode extends AstNode {
 export namespace StructPairFieldNode {
 	export function destruct(node: StructPairFieldNode): {
 		attributes: AttributeNode[]
+		docComments?: DocCommentsNode
 		key: StructKeyNode
 		type: TypeNode
 		isOptional?: boolean
 	} {
 		return {
 			attributes: node.children.filter(AttributeNode.is),
+			docComments: node.children.find(DocCommentsNode.is),
 			key: node.children.find(StructKeyNode.is)!,
 			type: node.children.find(TypeNode.is)!,
 			isOptional: node.isOptional,

--- a/packages/mcdoc/src/type/index.ts
+++ b/packages/mcdoc/src/type/index.ts
@@ -106,6 +106,7 @@ export interface StructTypePairField extends McdocBaseType {
 	type: McdocType
 	optional?: boolean
 	deprecated?: boolean
+	desc?: string
 }
 export interface StructTypeSpreadField extends McdocBaseType {
 	kind: 'spread'

--- a/packages/nbt/src/checker/index.ts
+++ b/packages/nbt/src/checker/index.ts
@@ -132,7 +132,7 @@ export function typeDefinition(
 					ctx,
 					mcdoc.runtime.checker.getErrorRangeDefault<NbtNode>,
 				),
-				attachTypeInfo: (node, definition) => {
+				attachTypeInfo: (node, definition, desc = '') => {
 					node.typeDef = definition
 					// TODO: improve hover info
 					if (
@@ -142,7 +142,7 @@ export function typeDefinition(
 						node.parent.key.hover =
 							`\`\`\`typescript\n${node.parent.key.value}: ${
 								mcdoc.McdocType.toString(definition)
-							}\n\`\`\``
+							}\n\`\`\`\n${desc}`
 					}
 				},
 				stringAttacher: (node, attacher) => {
@@ -388,14 +388,14 @@ export function path(
 							({ originalNode: link }) => link.node.range,
 						)(error)
 				},
-				attachTypeInfo: (link, definition) => {
+				attachTypeInfo: (link, definition, desc = '') => {
 					// TODO: attach type def
 					// TODO: improve hover info
 					if (NbtStringNode.is(link.prev?.node)) {
 						link.prev.node.hover =
 							`\`\`\`typescript\n${link.prev.node.value}: ${
 								mcdoc.McdocType.toString(definition)
-							}\n\`\`\``
+							}\n\`\`\`\n${desc}`
 					}
 				},
 				stringAttacher: (node, attacher) => {


### PR DESCRIPTION
- Fixes #1264 

**Important:**
When switching to this PR, run `Reset Project Cache` to allow the doc comments to be included in the symbol table

![image](https://github.com/SpyglassMC/Spyglass/assets/13565346/bbe87739-f727-4e06-869b-9af9618fe845)
