### PR TITLE
🐛 Allow nbt byte to be assignable to boolean

### DIFF
--- a/packages/nbt/src/checker/index.ts
+++ b/packages/nbt/src/checker/index.ts
@@ -65,6 +65,10 @@ export function typeDefinition(
 			{
 				context: ctx,
 				isEquivalent: (inferred, def) => {
+					if (def.kind === 'boolean') {
+						// TODO: this should check whether the value is 0 or 1
+						return inferred.kind === 'byte'
+					}
 					switch (inferred.kind) {
 						case 'list':
 							return ['list', 'tuple'].includes(def.kind)


### PR DESCRIPTION
- Fix #1274 

Future work should allow `isEquivalent` to check the value of a literal