### PR TITLE
🐛 Fix completer issue when cursor is not inside string node

### DIFF
--- a/packages/json/src/completer/index.ts
+++ b/packages/json/src/completer/index.ts
@@ -62,14 +62,14 @@ const object = core.completer.record<JsonStringNode, JsonNode, JsonObjectNode>({
 })
 
 const primitive: core.Completer<JsonPrimitiveNode> = (node, ctx) => {
-	if (node.type === 'json:string' && node.children?.length) {
+	const insideRange = core.Range.contains(node, ctx.offset, true)
+	if (node.type === 'json:string' && node.children?.length && insideRange) {
 		return core.completer.string(node, ctx)
 	}
 	if (!node.typeDef) {
 		return []
 	}
-	const range = core.Range.contains(node, ctx.offset, true) ? node : ctx.offset
-	return getValues(node.typeDef, range, ctx)
+	return getValues(node.typeDef, insideRange ? node : ctx.offset, ctx)
 }
 
 function getValues(

--- a/packages/nbt/src/completer/index.ts
+++ b/packages/nbt/src/completer/index.ts
@@ -62,14 +62,14 @@ const compound = core.completer.record<NbtStringNode, NbtNode, NbtCompoundNode>(
 })
 
 const primitive: core.Completer<NbtPrimitiveNode> = (node, ctx) => {
-	if (node.type === 'nbt:string' && node.children?.length) {
+	const insideRange = core.Range.contains(node, ctx.offset, true)
+	if (node.type === 'nbt:string' && node.children?.length && insideRange) {
 		return core.completer.string(node, ctx)
 	}
 	if (!node.typeDef) {
 		return []
 	}
-	const range = core.Range.contains(node, ctx.offset, true) ? node : ctx.offset
-	return getValues(node.typeDef, range, ctx)
+	return getValues(node.typeDef, insideRange ? node : ctx.offset, ctx)
 }
 
 function getValues(


### PR DESCRIPTION
When the completer cursor is not inside the string node, don't try to get the completions from it, instead fall back to the `getValues` call, which corrects the range to the current cursor.


This didn't seem to be needed for nbt, but I added it anyways to keep the code consistent. It seems like the real issue is caused by the JSON parser, adding an empty `json:string` node for pairs. This should be corrected in the future. But even with that fix, it doesn't hurt to have this check.