### PR TITLE
🐛 Use minecraft:block dispatcher instead of minecraft:block_entity

### DIFF
--- a/packages/java-edition/src/mcfunction/checker/index.ts
+++ b/packages/java-edition/src/mcfunction/checker/index.ts
@@ -65,7 +65,7 @@ const block: core.SyncChecker<BlockNode> = (node, ctx) => {
 		return
 	}
 
-	nbt.checker.index('minecraft:block_entity', core.ResourceLocationNode.toString(node.id, 'full'))(
+	nbt.checker.index('minecraft:block', core.ResourceLocationNode.toString(node.id, 'full'))(
 		node.nbt,
 		ctx,
 	)
@@ -174,9 +174,9 @@ function nbtChecker(dispatchedBy?: core.AstNode): core.SyncChecker<NbtNode> {
 					})(compound, ctx)
 				}
 				break
-			case 'minecraft:block_entity':
+			case 'minecraft:block':
 				if (nbt.NbtCompoundNode.is(compound)) {
-					nbt.checker.index('minecraft:block_entity')(compound, ctx)
+					nbt.checker.index('minecraft:block')(compound, ctx)
 				}
 				break
 			case 'minecraft:storage':

--- a/packages/java-edition/src/mcfunction/tree/argument.ts
+++ b/packages/java-edition/src/mcfunction/tree/argument.ts
@@ -115,7 +115,7 @@ export interface NbtParserProperties extends Record<string, unknown> {
 	 * argument named by `indexedBy`.
 	 */
 	dispatcher:
-		| 'minecraft:block_entity'
+		| 'minecraft:block'
 		| 'minecraft:entity'
 		| 'minecraft:storage'
 		| 'minecraft:macro_function'

--- a/packages/java-edition/src/mcfunction/tree/patch.ts
+++ b/packages/java-edition/src/mcfunction/tree/patch.ts
@@ -825,7 +825,7 @@ function getDataPatch(
 						children: {
 							[nbtKey]: {
 								properties: {
-									dispatcher: 'minecraft:block_entity',
+									dispatcher: 'minecraft:block',
 									dispatchedBy: `${vaultKey}Pos`,
 									accessType: nbtAccessType,
 									isPredicate,
@@ -889,9 +889,7 @@ const getDataModifySource = (
 				children: {
 					value: {
 						properties: {
-							dispatcher: type === 'block'
-								? 'minecraft:block_entity'
-								: `minecraft:${type}`,
+							dispatcher: `minecraft:${type}`,
 							dispatchedBy: type === 'block' ? 'targetPos' : 'target',
 							indexedBy: 'targetPath',
 						} satisfies NbtParserProperties,

--- a/packages/nbt/src/checker/index.ts
+++ b/packages/nbt/src/checker/index.ts
@@ -43,7 +43,7 @@ function getIndices(
 	id: core.FullResourceLocation | readonly core.FullResourceLocation[] | undefined,
 ): mcdoc.ParallelIndices {
 	if (typeof id === 'string') {
-		return [{ kind: 'static', value: id }]
+		return [{ kind: 'static', value: core.ResourceLocation.shorten(id) }]
 	} else if (id === undefined || id.length === 0) {
 		return [{ kind: 'static', value: '%fallback' }]
 	} else {

--- a/packages/nbt/src/checker/index.ts
+++ b/packages/nbt/src/checker/index.ts
@@ -43,7 +43,7 @@ function getIndices(
 	id: core.FullResourceLocation | readonly core.FullResourceLocation[] | undefined,
 ): mcdoc.ParallelIndices {
 	if (typeof id === 'string') {
-		return [{ kind: 'static', value: core.ResourceLocation.shorten(id) }]
+		return [{ kind: 'static', value: id }]
 	} else if (id === undefined || id.length === 0) {
 		return [{ kind: 'static', value: '%fallback' }]
 	} else {


### PR DESCRIPTION
I realized this only now. We should use `minecraft:block` when we are dispatching block IDs. The `minecraft:block_entity` dispatcher is mostly used internally to map from a block to a block entity.

This fixes a command like `setblock ~ ~ ~ chest{Items:[]}` where previously on hover it would show all possible Items fields (fallback case).