### PR TITLE
🐛 Implement storage dispatcher

### DIFF
--- a/packages/java-edition/src/mcfunction/checker/index.ts
+++ b/packages/java-edition/src/mcfunction/checker/index.ts
@@ -181,7 +181,10 @@ function nbtChecker(dispatchedBy?: core.AstNode): core.SyncChecker<NbtNode> {
 				break
 			case 'minecraft:storage':
 				if (nbt.NbtCompoundNode.is(compound)) {
-					nbt.checker.index('minecraft:storage')(compound, ctx)
+					const storage = core.ResourceLocationNode.is(dispatchedBy)
+						? core.ResourceLocationNode.toString(dispatchedBy)
+						: undefined
+					nbt.checker.index('minecraft:storage', storage)(compound, ctx)
 				}
 				break
 		}


### PR DESCRIPTION
This was a pretty simple error. I just forgot to pass the storage resource location to the nbt checker.