### PR TITLE
🐛 Fix crash when setting language to jsonc

### DIFF
--- a/packages/vscode-extension/src/extension.mts
+++ b/packages/vscode-extension/src/extension.mts
@@ -36,8 +36,8 @@ export function activate(context: vsc.ExtensionContext) {
 		{ language: 'mcfunction' },
 		{ language: 'mcdoc' },
 		{ language: 'snbt' },
-		{ pattern: '**/pack.mcmeta' },
-		{ pattern: '**/data/*/*/**/*.json' },
+		{ language: 'json', pattern: '**/pack.mcmeta' },
+		{ language: 'json', pattern: '**/data/*/*/**/*.json' },
 	]
 
 	const initializationOptions: server.CustomInitializationOptions = {


### PR DESCRIPTION
- Fixes #1307 

This does not add support for setting the language to jsonc, but it makes sure that the language server won't crash.