### PR TITLE
🐛 Add patch for schedule clear command

### DIFF
--- a/packages/java-edition/src/mcfunction/tree/patch.ts
+++ b/packages/java-edition/src/mcfunction/tree/patch.ts
@@ -544,6 +544,18 @@ export function getPatch(release: ReleaseVersion): PartialRootTreeNode {
 			'save-on': {
 				permission: 4,
 			},
+			schedule: {
+				children: {
+					clear: {
+						children: {
+							function: {
+								parser: 'minecraft:function',
+								properties: undefined,
+							},
+						},
+					},
+				},
+			},
 			scoreboard: {
 				children: {
 					objectives: {


### PR DESCRIPTION
The game uses a greedy string to parse this argument, with a custom suggest method that lists all the currently scheduled functions. We need to patch this to just show all functions.
