### PR TITLE
🐛 Fix symbol clear not checking contributor when removing locations

### DIFF
--- a/packages/core/src/symbol/SymbolUtil.ts
+++ b/packages/core/src/symbol/SymbolUtil.ts
@@ -254,7 +254,10 @@ export class SymbolUtil implements ExternalEventEmitter {
 				}
 				this.removeLocationsFromSymbol(
 					symbol,
-					uri ? (data) => data.location.uri === uri && predicate(data) : predicate,
+					(data) =>
+						(!uri || data.location.uri === uri)
+						&& data.location.contributor === contributor
+						&& predicate(data),
 				)
 			}
 			this.trim(table)


### PR DESCRIPTION
- Fixes #1327 

The `SymbolUtil#clear` function takes a `contributor`, but the bug was that it only used this contributor for getting the right symbol cache. When actually removing the symbol locations it removes all of the locations. This breaks when there is a symbol reference (contributed by `binder`) in the same file that defines it (contributed by `uri_binder`).