### PR TITLE
🐛 Fix cached files in archives not detected as removed

### DIFF
--- a/packages/core/src/common/externals/BrowserExternals.ts
+++ b/packages/core/src/common/externals/BrowserExternals.ts
@@ -189,6 +189,9 @@ export const BrowserExternals: Externals = {
 	},
 	downloader: new BrowserExternalDownloader(),
 	error: {
+		createKind(kind, message) {
+			return new Error(`${kind}: ${message}`)
+		},
 		isKind(e, kind) {
 			return e instanceof Error && e.message.startsWith(kind)
 		},

--- a/packages/core/src/common/externals/NodeJsExternals.ts
+++ b/packages/core/src/common/externals/NodeJsExternals.ts
@@ -68,6 +68,11 @@ export const NodeJsExternals: Externals = {
 	},
 	downloader: new NodeJsExternalDownloader(),
 	error: {
+		createKind(kind, message) {
+			const error = new Error(message)
+			;(error as NodeJS.ErrnoException).code = kind
+			return error
+		},
 		isKind(e, kind) {
 			return e instanceof Error && (e as NodeJS.ErrnoException).code === kind
 		},

--- a/packages/core/src/common/externals/index.ts
+++ b/packages/core/src/common/externals/index.ts
@@ -19,7 +19,16 @@ export interface Externals {
 		getSha1: (data: string | Uint8Array) => Promise<string>
 	}
 	downloader: ExternalDownloader
-	error: { isKind: (e: unknown, kind: ExternalErrorKind) => boolean }
+	error: {
+		/**
+		 * @returns an error of the specified kind
+		 */
+		createKind: (kind: ExternalErrorKind, message: string) => unknown
+		/**
+		 * Checks whether the given error is of a certain kind
+		 */
+		isKind: (e: unknown, kind: ExternalErrorKind) => boolean
+	}
 	event: { EventEmitter: new() => ExternalEventEmitter }
 	fs: ExternalFileSystem
 }

--- a/packages/core/src/service/CacheService.ts
+++ b/packages/core/src/service/CacheService.ts
@@ -3,7 +3,6 @@ import { Uri } from '../common/index.js'
 import type { PosRangeLanguageError } from '../source/index.js'
 import type { UnlinkedSymbolTable } from '../symbol/index.js'
 import { SymbolTable } from '../symbol/index.js'
-import { RemovedFileError } from './FileService.js'
 import type { RootUriString } from './fileUtil.js'
 import { fileUtil } from './fileUtil.js'
 import type { Project } from './Project.js'
@@ -187,8 +186,7 @@ export class CacheService {
 				}
 			} catch (e) {
 				if (
-					e instanceof RemovedFileError
-					|| this.project.externals.error.isKind(e, 'ENOENT')
+					this.project.externals.error.isKind(e, 'ENOENT')
 					|| this.project.externals.error.isKind(e, 'EISDIR')
 				) {
 					ans.removedFiles.push(uri)

--- a/packages/core/src/service/CacheService.ts
+++ b/packages/core/src/service/CacheService.ts
@@ -3,6 +3,7 @@ import { Uri } from '../common/index.js'
 import type { PosRangeLanguageError } from '../source/index.js'
 import type { UnlinkedSymbolTable } from '../symbol/index.js'
 import { SymbolTable } from '../symbol/index.js'
+import { RemovedFileError } from './FileService.js'
 import type { RootUriString } from './fileUtil.js'
 import { fileUtil } from './fileUtil.js'
 import type { Project } from './Project.js'
@@ -186,7 +187,8 @@ export class CacheService {
 				}
 			} catch (e) {
 				if (
-					this.project.externals.error.isKind(e, 'ENOENT')
+					e instanceof RemovedFileError
+					|| this.project.externals.error.isKind(e, 'ENOENT')
 					|| this.project.externals.error.isKind(e, 'EISDIR')
 				) {
 					ans.removedFiles.push(uri)

--- a/packages/core/src/service/FileService.ts
+++ b/packages/core/src/service/FileService.ts
@@ -231,14 +231,6 @@ export class FileUriSupporter implements UriProtocolSupporter {
 	}
 }
 
-// namespace ArchiveUri {
-
-// export function is(uri: Uri): boolean {
-// 	return uri.protocol === Protocol && uri.hostname === Hostname
-// }
-
-// }
-
 export class ArchiveUriSupporter implements UriProtocolSupporter {
 	public static readonly Protocol = 'archive:'
 	private static readonly SupportedArchiveExtnames = ['.tar', '.tar.bz2', '.tar.gz', '.zip']
@@ -279,10 +271,14 @@ export class ArchiveUriSupporter implements UriProtocolSupporter {
 		}
 		const entry = entries.get(pathInArchive)
 		if (!entry) {
-			throw new Error(`Path “${pathInArchive}” does not exist in archive “${archiveName}”`)
+			throw new RemovedFileError(
+				`Path “${pathInArchive}” does not exist in archive “${archiveName}”`,
+			)
 		}
 		if (entry.type !== 'file') {
-			throw new Error(`Path “${pathInArchive}” in archive “${archiveName}” is not a file`)
+			throw new RemovedFileError(
+				`Path “${pathInArchive}” in archive “${archiveName}” is not a file`,
+			)
 		}
 		return entry.data
 	}
@@ -354,6 +350,8 @@ export class ArchiveUriSupporter implements UriProtocolSupporter {
 		return new ArchiveUriSupporter(externals, entries)
 	}
 }
+
+export class RemovedFileError extends Error {}
 
 async function hashFile(externals: Externals, uri: string): Promise<string> {
 	return externals.crypto.getSha1(await externals.fs.readFile(uri))

--- a/packages/core/src/service/FileService.ts
+++ b/packages/core/src/service/FileService.ts
@@ -271,12 +271,14 @@ export class ArchiveUriSupporter implements UriProtocolSupporter {
 		}
 		const entry = entries.get(pathInArchive)
 		if (!entry) {
-			throw new RemovedFileError(
+			throw this.externals.error.createKind(
+				'ENOENT',
 				`Path “${pathInArchive}” does not exist in archive “${archiveName}”`,
 			)
 		}
 		if (entry.type !== 'file') {
-			throw new RemovedFileError(
+			throw this.externals.error.createKind(
+				'EISDIR',
 				`Path “${pathInArchive}” in archive “${archiveName}” is not a file`,
 			)
 		}
@@ -350,8 +352,6 @@ export class ArchiveUriSupporter implements UriProtocolSupporter {
 		return new ArchiveUriSupporter(externals, entries)
 	}
 }
-
-export class RemovedFileError extends Error {}
 
 async function hashFile(externals: Externals, uri: string): Promise<string> {
 	return externals.crypto.getSha1(await externals.fs.readFile(uri))


### PR DESCRIPTION
Cached files in an archive were getting detected as "changed" rather than "removed". The issue was that the cache service relied on detecting `ENOENT` and `EISDIR` codes in the thrown error, but this only happened for actual files on the file system, not for files in an archive.

Importantly, this does **not** solve #1213, I haven't been able to reproduce that error (which is slighly different).