### PR TITLE
🐛 Fix enum filtering in completer

### DIFF
--- a/packages/mcdoc/src/runtime/attribute/index.ts
+++ b/packages/mcdoc/src/runtime/attribute/index.ts
@@ -25,7 +25,7 @@ export interface McdocAttribute<C = unknown> {
 		field: StructTypePairField,
 		ctx: McdocCheckerContext<T>,
 	) => StructTypePairField
-	filterElement?: <T>(config: C, ctx: McdocCheckerContext<T>) => boolean
+	filterElement?: (config: C, ctx: core.ContextBase) => boolean
 	stringParser?: <T>(
 		config: C,
 		typeDef: SimplifiedMcdocTypeNoUnion,

--- a/packages/mcdoc/src/runtime/completer/index.ts
+++ b/packages/mcdoc/src/runtime/completer/index.ts
@@ -97,7 +97,18 @@ export function getValues(
 		case 'boolean':
 			return ['false', 'true'].map(v => ({ value: v, kind: 'boolean' }))
 		case 'enum':
-			return typeDef.values.map(v => ({
+			// TODO: de-duplicate this logic from the runtime simplifier
+			const filteredValues = typeDef.values.filter(value => {
+				let keep = true
+				handleAttributes(value.attributes, ctx, (handler, config) => {
+					if (!keep || !handler.filterElement) return
+					if (!handler.filterElement(config, ctx)) {
+						keep = false
+					}
+				})
+				return keep
+			})
+			return filteredValues.map(v => ({
 				value: `${v.value}`,
 				detail: v.identifier,
 				kind: typeDef.enumKind ?? 'string',


### PR DESCRIPTION
This is an ugly fix. Ideally it should run the simplifier, but that would require some more substantial refactors.

- Fixes #1349 