### PR TITLE
🔧 Make build fail if a `.only` test is pushed

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -43,7 +43,7 @@ jobs:
 
       - run: npm run build
 
-      - run: npm test
+      - run: npm test -- --forbid-only
 
       - run: tar -cvf build-artifact.tar packages/*/lib/ packages/*/out/ packages/*/dist/
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
 
       - run: npm run build
 
-      - run: npm test
+      - run: npm test -- --forbid-only
 
       #- run: npm run lint
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ Please refrain from using `mocha --watch`, as it might interface with and break 
 
 You can debug tests with breakpoints by running the `Run Unit Tests` configuration and setting your breakpoints accordingly. If you want to run a specific subset of tests, add `.only` after the test block (e.g. `describe.only()`, `it.only()`).
 
+Note that the build will fail in CICD if `.only` tests are pushed to prevent mistakenly merging `.only` to `main` (it should only be used for local testing!).
+
 ### Code style
 
 Tabs for indents, spaces for alignment. Except do not align things because the available tooling is unfortunately terrible.

--- a/packages/core/test/source/Source.spec.ts
+++ b/packages/core/test/source/Source.spec.ts
@@ -4,7 +4,7 @@ import type { IndexMap } from '../../lib/index.js'
 import { Range, Source } from '../../lib/index.js'
 import { markOffsetInString, showWhitespaceGlyph } from '../utils.js'
 
-describe('Source', () => {
+describe.only('Source', () => {
 	describe('getCharRange()', () => {
 		/*
 		 * Index Tens - 000000000011111111112

--- a/packages/core/test/source/Source.spec.ts
+++ b/packages/core/test/source/Source.spec.ts
@@ -4,7 +4,7 @@ import type { IndexMap } from '../../lib/index.js'
 import { Range, Source } from '../../lib/index.js'
 import { markOffsetInString, showWhitespaceGlyph } from '../utils.js'
 
-describe.only('Source', () => {
+describe('Source', () => {
 	describe('getCharRange()', () => {
 		/*
 		 * Index Tens - 000000000011111111112


### PR DESCRIPTION
we can pass in `--forbid-only` to mocha to automatically ensure we aren't pushing `.only` to Github

---

![image](https://github.com/SpyglassMC/Spyglass/assets/13565346/783bc9f5-5688-471d-a75a-375ea0f1232b)
