### PR TITLE
✨ Activate extension when creating pack.mcmeta

### DIFF
--- a/packages/json/src/index.ts
+++ b/packages/json/src/index.ts
@@ -16,7 +16,12 @@ export * as parser from './parser/index.js'
 
 export const initialize: core.SyncProjectInitializer = ({ meta }) => {
 	meta.registerLanguage('json', {
-		extensions: ['.json', '.mcmeta'],
+		extensions: ['.json'],
+		triggerCharacters: ['\n', ':', '"'],
+		parser: parser.file,
+	})
+	meta.registerLanguage('mcmeta', {
+		extensions: ['.mcmeta'],
 		triggerCharacters: ['\n', ':', '"'],
 		parser: parser.file,
 	})

--- a/packages/vscode-extension/mcmeta-language-configuration.json
+++ b/packages/vscode-extension/mcmeta-language-configuration.json
@@ -1,0 +1,22 @@
+{
+	"comments": {
+		"lineComment": "//",
+		"blockComment": [ "/*", "*/" ]
+	},
+	"brackets": [
+		["{", "}"],
+		["[", "]"]
+	],
+	"autoClosingPairs": [
+		{ "open": "{", "close": "}", "notIn": ["string"] },
+		{ "open": "[", "close": "]", "notIn": ["string"] },
+		{ "open": "(", "close": ")", "notIn": ["string"] },
+		{ "open": "'", "close": "'", "notIn": ["string"] },
+		{ "open": "\"", "close": "\"", "notIn": ["string", "comment"] },
+		{ "open": "`", "close": "`", "notIn": ["string", "comment"] }
+	],
+	"indentationRules": {
+		"increaseIndentPattern": "({+(?=((\\\\.|[^\"\\\\])*\"(\\\\.|[^\"\\\\])*\")*[^\"}]*)$)|(\\[+(?=((\\\\.|[^\"\\\\])*\"(\\\\.|[^\"\\\\])*\")*[^\"\\]]*)$)",
+		"decreaseIndentPattern": "^\\s*[}\\]],?\\s*$"
+	}
+}

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -134,14 +134,11 @@
         "configuration": "./snbt-language-configuration.json"
       },
       {
-        "id": "json",
+        "id": "mcmeta",
         "extensions": [
           ".mcmeta"
         ],
-        "filenames": [
-          ".spyglassconfig",
-          ".spyglassrc"
-        ]
+        "configuration": "./mcmeta-language-configuration.json"
       }
     ],
     "commands": [

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -135,10 +135,21 @@
       },
       {
         "id": "mcmeta",
+        "aliases": [
+          "MCMETA",
+          "mcmeta"
+        ],
         "extensions": [
           ".mcmeta"
         ],
         "configuration": "./mcmeta-language-configuration.json"
+      }
+    ],
+    "grammars": [
+      {
+        "language": "mcmeta",
+        "scopeName": "source.mcmeta",
+        "path": "./resource/mcmeta.tmLanguage.json"
       }
     ],
     "commands": [

--- a/packages/vscode-extension/resource/mcmeta.tmLanguage.json
+++ b/packages/vscode-extension/resource/mcmeta.tmLanguage.json
@@ -1,0 +1,207 @@
+{
+	"name": "MCMETA",
+	"scopeName": "source.mcmeta",
+	"patterns": [
+		{
+			"include": "#value"
+		}
+	],
+	"repository": {
+		"array": {
+			"begin": "\\[",
+			"beginCaptures": {
+				"0": {
+					"name": "punctuation.definition.array.begin.mcmeta"
+				}
+			},
+			"end": "\\]",
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.definition.array.end.mcmeta"
+				}
+			},
+			"name": "meta.structure.array.mcmeta",
+			"patterns": [
+				{
+					"include": "#value"
+				},
+				{
+					"match": ",",
+					"name": "punctuation.separator.array.mcmeta"
+				},
+				{
+					"match": "[^\\s\\]]",
+					"name": "invalid.illegal.expected-array-separator.mcmeta"
+				}
+			]
+		},
+		"comments": {
+			"patterns": [
+				{
+					"begin": "/\\*\\*(?!/)",
+					"captures": {
+						"0": {
+							"name": "punctuation.definition.comment.mcmeta"
+						}
+					},
+					"end": "\\*/",
+					"name": "comment.block.documentation.mcmeta"
+				},
+				{
+					"begin": "/\\*",
+					"captures": {
+						"0": {
+							"name": "punctuation.definition.comment.mcmeta"
+						}
+					},
+					"end": "\\*/",
+					"name": "comment.block.mcmeta"
+				},
+				{
+					"captures": {
+						"1": {
+							"name": "punctuation.definition.comment.mcmeta"
+						}
+					},
+					"match": "(//).*$\\n?",
+					"name": "comment.line.double-slash.js"
+				}
+			]
+		},
+		"constant": {
+			"match": "\\b(?:true|false|null)\\b",
+			"name": "constant.language.mcmeta"
+		},
+		"number": {
+			"match": "(?x)        # turn on extended mode\n  -?        # an optional minus\n  (?:\n    0       # a zero\n    |       # ...or...\n    [1-9]   # a 1-9 character\n    \\d*     # followed by zero or more digits\n  )\n  (?:\n    (?:\n      \\.    # a period\n      \\d+   # followed by one or more digits\n    )?\n    (?:\n      [eE]  # an e character\n      [+-]? # followed by an option +/-\n      \\d+   # followed by one or more digits\n    )?      # make exponent optional\n  )?        # make decimal portion optional",
+			"name": "constant.numeric.mcmeta"
+		},
+		"object": {
+			"begin": "\\{",
+			"beginCaptures": {
+				"0": {
+					"name": "punctuation.definition.dictionary.begin.mcmeta"
+				}
+			},
+			"end": "\\}",
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.definition.dictionary.end.mcmeta"
+				}
+			},
+			"name": "meta.structure.dictionary.mcmeta",
+			"patterns": [
+				{
+					"comment": "the JSON object key",
+					"include": "#objectkey"
+				},
+				{
+					"include": "#comments"
+				},
+				{
+					"begin": ":",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.separator.dictionary.key-value.mcmeta"
+						}
+					},
+					"end": "(,)|(?=\\})",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.separator.dictionary.pair.mcmeta"
+						}
+					},
+					"name": "meta.structure.dictionary.value.mcmeta",
+					"patterns": [
+						{
+							"comment": "the JSON object value",
+							"include": "#value"
+						},
+						{
+							"match": "[^\\s,]",
+							"name": "invalid.illegal.expected-dictionary-separator.mcmeta"
+						}
+					]
+				},
+				{
+					"match": "[^\\s\\}]",
+					"name": "invalid.illegal.expected-dictionary-separator.mcmeta"
+				}
+			]
+		},
+		"string": {
+			"begin": "\"",
+			"beginCaptures": {
+				"0": {
+					"name": "punctuation.definition.string.begin.mcmeta"
+				}
+			},
+			"end": "\"",
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.definition.string.end.mcmeta"
+				}
+			},
+			"name": "string.quoted.double.mcmeta",
+			"patterns": [
+				{
+					"include": "#stringcontent"
+				}
+			]
+		},
+		"objectkey": {
+			"begin": "\"",
+			"beginCaptures": {
+				"0": {
+					"name": "punctuation.support.type.property-name.begin.mcmeta"
+				}
+			},
+			"end": "\"",
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.support.type.property-name.end.mcmeta"
+				}
+			},
+			"name": "string.mcmeta support.type.property-name.mcmeta",
+			"patterns": [
+				{
+					"include": "#stringcontent"
+				}
+			]
+		},
+		"stringcontent": {
+			"patterns": [
+				{
+					"match": "(?x)                # turn on extended mode\n  \\\\                # a literal backslash\n  (?:               # ...followed by...\n    [\"\\\\/bfnrt]     # one of these characters\n    |               # ...or...\n    u               # a u\n    [0-9a-fA-F]{4}) # and four hex digits",
+					"name": "constant.character.escape.mcmeta"
+				},
+				{
+					"match": "\\\\.",
+					"name": "invalid.illegal.unrecognized-string-escape.mcmeta"
+				}
+			]
+		},
+		"value": {
+			"patterns": [
+				{
+					"include": "#constant"
+				},
+				{
+					"include": "#number"
+				},
+				{
+					"include": "#string"
+				},
+				{
+					"include": "#array"
+				},
+				{
+					"include": "#object"
+				},
+				{
+					"include": "#comments"
+				}
+			]
+		}
+	}
+}

--- a/packages/vscode-extension/src/extension.mts
+++ b/packages/vscode-extension/src/extension.mts
@@ -36,7 +36,7 @@ export function activate(context: vsc.ExtensionContext) {
 		{ language: 'mcfunction' },
 		{ language: 'mcdoc' },
 		{ language: 'snbt' },
-		{ language: 'json', pattern: '**/pack.mcmeta' },
+		{ language: 'mcmeta' },
 		{ language: 'json', pattern: '**/data/*/*/**/*.json' },
 	]
 


### PR DESCRIPTION
A dedicated `mcmeta` language is contributed. This will activate the extension automatically `onLanguage:mcmeta`, and start the language server when a user creates a `pack.mcmeta` in an empty workspace.

The language configuration is copied from https://github.com/microsoft/vscode/blob/main/extensions/json/language-configuration.json

- Fixes #1094 

### Todo
- [x] Contribute a grammer (which is a copy of the json grammer) for mcmeta