### PR TITLE
🐛 Add dust_pillar particle type

### DIFF
--- a/packages/java-edition/src/mcfunction/node/argument.ts
+++ b/packages/java-edition/src/mcfunction/node/argument.ts
@@ -510,6 +510,7 @@ export namespace ParticleNode {
 	const OptionTypes = new Set(
 		[
 			...SpecialTypes,
+			'dust_pillar',
 			'entity_effect',
 		],
 	)


### PR DESCRIPTION
This particle type was added in 24w13a (1.20.5 snapshot), and since it has a required `block_state` option, we need to manually specify it.