### PR TITLE
🚑️ Fix mcfunction binder

### DIFF
--- a/packages/java-edition/src/binder/index.ts
+++ b/packages/java-edition/src/binder/index.ts
@@ -1,8 +1,7 @@
 import type {
+	CheckerContext,
 	FileCategory,
-	MetaRegistry,
 	RootUriString,
-	SyncBinder,
 	TaggableResourceLocationCategory,
 	UriBinder,
 	UriBinderContext,
@@ -219,39 +218,35 @@ function matchVersion(
 	return true
 }
 
-const fileBinder: SyncBinder<JsonFileNode | McfunctionNode> = (node, ctx) => {
-	const parts = dissectUri(ctx.doc.uri, ctx)
-	if (parts?.ok === false) {
-		const release = ctx.project['loadedVersion'] as ReleaseVersion | undefined
-		if (!release) {
-			return
-		}
-		if (parts.expected) {
-			ctx.err.report(
-				localize(
-					'java-edition.binder.wrong-folder',
-					localeQuote(parts.path),
-					release,
-					localeQuote(parts.expected),
-				),
-				Range.Beginning,
-				ErrorSeverity.Hint,
-			)
-		} else {
-			ctx.err.report(
-				localize(
-					'java-edition.binder.wrong-version',
-					localeQuote(parts.path),
-					release,
-				),
-				Range.Beginning,
-				ErrorSeverity.Hint,
-			)
-		}
+export function reportDissectError(
+	realPath: string,
+	expectedPath: string | undefined,
+	ctx: CheckerContext,
+) {
+	const release = ctx.project['loadedVersion'] as ReleaseVersion | undefined
+	if (!release) {
+		return
 	}
-}
-
-export function registerBinders(meta: MetaRegistry) {
-	meta.registerBinder<JsonFileNode>('json:file', fileBinder)
-	meta.registerBinder<McfunctionNode>('mcfunction:entry', fileBinder)
+	if (expectedPath) {
+		ctx.err.report(
+			localize(
+				'java-edition.binder.wrong-folder',
+				localeQuote(realPath),
+				release,
+				localeQuote(expectedPath),
+			),
+			Range.Beginning,
+			ErrorSeverity.Hint,
+		)
+	} else {
+		ctx.err.report(
+			localize(
+				'java-edition.binder.wrong-version',
+				localeQuote(realPath),
+				release,
+			),
+			Range.Beginning,
+			ErrorSeverity.Hint,
+		)
+	}
 }

--- a/packages/java-edition/src/index.ts
+++ b/packages/java-edition/src/index.ts
@@ -2,7 +2,7 @@ import * as core from '@spyglassmc/core'
 import * as json from '@spyglassmc/json'
 import * as mcdoc from '@spyglassmc/mcdoc'
 import * as nbt from '@spyglassmc/nbt'
-import { registerBinders, uriBinder } from './binder/index.js'
+import { uriBinder } from './binder/index.js'
 import type { McmetaSummary } from './dependency/index.js'
 import {
 	getMcmetaSummary,
@@ -42,7 +42,6 @@ export const initialize: core.ProjectInitializer = async (ctx) => {
 	}
 
 	meta.registerUriBinder(uriBinder)
-	registerBinders(meta)
 
 	const versions = await getVersions(ctx.externals, ctx.downloader)
 	if (!versions) {

--- a/packages/java-edition/src/json/checker/index.ts
+++ b/packages/java-edition/src/json/checker/index.ts
@@ -1,7 +1,7 @@
 import type * as core from '@spyglassmc/core'
 import * as json from '@spyglassmc/json'
 import type * as mcdoc from '@spyglassmc/mcdoc'
-import { dissectUri } from '../../binder/index.js'
+import { dissectUri, reportDissectError } from '../../binder/index.js'
 
 function createTagDefinition(registry: string): mcdoc.McdocType {
 	const id: mcdoc.AttributeValue = {
@@ -36,6 +36,8 @@ export const file: core.Checker<json.JsonFileNode> = (node, ctx) => {
 			parallelIndices: [{ kind: 'static', value: parts.category }],
 		}
 		return json.checker.index(type, { discardDuplicateKeyErrors: true })(child, ctx)
+	} else if (parts?.ok === false) {
+		reportDissectError(parts.path, parts.expected, ctx)
 	}
 }
 

--- a/packages/java-edition/src/mcfunction/checker/index.ts
+++ b/packages/java-edition/src/mcfunction/checker/index.ts
@@ -1,9 +1,10 @@
 import * as core from '@spyglassmc/core'
 import * as json from '@spyglassmc/json'
-import { arrayToMessage, localize } from '@spyglassmc/locales'
+import { localize } from '@spyglassmc/locales'
 import type * as mcdoc from '@spyglassmc/mcdoc'
 import * as mcf from '@spyglassmc/mcfunction'
 import * as nbt from '@spyglassmc/nbt'
+import { dissectUri, reportDissectError } from '../../binder/index.js'
 import { getTagValues } from '../../common/index.js'
 import { ReleaseVersion } from '../../dependency/common.js'
 import type { EntitySelectorInvertableArgumentValueNode } from '../node/index.js'
@@ -20,6 +21,14 @@ import {
 	NbtResourceNode,
 	ParticleNode,
 } from '../node/index.js'
+
+const entry: core.Checker<mcf.McfunctionNode> = (node, ctx) => {
+	const parts = dissectUri(ctx.doc.uri, ctx)
+	if (parts?.ok === false) {
+		reportDissectError(parts.path, parts.expected, ctx)
+	}
+	core.checker.dispatchSync(node, ctx)
+}
 
 export const command: core.Checker<mcf.CommandNode> = (node, ctx) => {
 	if (node.slash && node.parent && mcf.McfunctionNode.is(node.parent)) {
@@ -330,6 +339,7 @@ function getTypesFromEntity(
 }
 
 export function register(meta: core.MetaRegistry) {
+	meta.registerChecker<mcf.McfunctionNode>('mcfunction:entry', entry)
 	meta.registerChecker<mcf.CommandNode>('mcfunction:command', command)
 	meta.registerChecker<BlockNode>('mcfunction:block', block)
 	meta.registerChecker<EntityNode>('mcfunction:entity', entity)


### PR DESCRIPTION
This was caused by #1386, which added a `mcfunction:entry` binder, but this prevented the child binders from running. Changed so this logic happens in the checker, and the mcfunction entry checker now dispatches its children.