### PR TITLE
🐛 Allow downloader to use cache when offline

### DIFF
--- a/packages/core/src/common/externals/NodeJsExternals.ts
+++ b/packages/core/src/common/externals/NodeJsExternals.ts
@@ -37,6 +37,8 @@ class NodeJsExternalDownloader implements ExternalDownloader {
 				} else {
 					resolve(promisifyAsyncIterable(res, (chunks) => Buffer.concat(chunks)))
 				}
+			}).on('error', (e) => {
+				reject(e)
 			})
 		})
 	}

--- a/packages/core/src/service/Downloader.ts
+++ b/packages/core/src/service/Downloader.ts
@@ -60,7 +60,7 @@ export class Downloader {
 					const cacheChecksum = bufferToString(
 						await fileUtil.readFile(this.externals, cacheChecksumUri),
 					).slice(0, -1) // Remove ending newline
-					if (checksum === undefined || checksum === cacheChecksum) {
+					if (checksum === cacheChecksum) {
 						try {
 							const cachedBuffer = await fileUtil.readFile(this.externals, cacheUri)
 							if (ttl) {

--- a/packages/core/src/service/Downloader.ts
+++ b/packages/core/src/service/Downloader.ts
@@ -60,7 +60,7 @@ export class Downloader {
 					const cacheChecksum = bufferToString(
 						await fileUtil.readFile(this.externals, cacheChecksumUri),
 					).slice(0, -1) // Remove ending newline
-					if (checksum === cacheChecksum) {
+					if (checksum === undefined || checksum === cacheChecksum) {
 						try {
 							const cachedBuffer = await fileUtil.readFile(this.externals, cacheUri)
 							if (ttl) {


### PR DESCRIPTION
Two changes:
* Added an error hander on the nodejs downloader. Before this, the language server would crash when not connected to the network.
* ~~Allowed using the cache when fetching the checksum failed. This would allow using the cache both when offline and when the user is being rate limited by GitHub.~~