### PR TITLE
🐛 Deduplicate definitions in the checker tree

### DIFF
--- a/packages/mcdoc/src/runtime/checker/index.ts
+++ b/packages/mcdoc/src/runtime/checker/index.ts
@@ -29,7 +29,7 @@ import { handleAttributes } from '../attribute/index.js'
 import type { NodeEquivalenceChecker, RuntimeNode, RuntimePair, RuntimeUnion } from './context.js'
 import { McdocCheckerContext } from './context.js'
 import type { ErrorCondensingDefinition, McdocRuntimeError } from './error.js'
-import { condenseErrorsAndFilterSiblings } from './error.js'
+import { condenseAndPropagate } from './error.js'
 
 export * from './context.js'
 export * from './error.js'
@@ -169,12 +169,13 @@ export interface CheckerTreeRuntimeNode<T> {
 }
 
 export interface CheckerTreeDefinitionGroupNode<T> {
-	parent: CheckerTreeDefinitionNode<T> | undefined
+	parents: CheckerTreeDefinitionNode<T>[]
 	runtimeNode: CheckerTreeRuntimeNode<T>
 	condensedErrors: McdocRuntimeError<T>[][]
 
 	desc?: string
 	keyDefinition: SimplifiedMcdocTypeNoUnion | undefined
+	originalTypeDef: McdocType
 	validDefinitions: CheckerTreeDefinitionNode<T>[]
 }
 
@@ -206,9 +207,10 @@ export function typeDefinition<T>(
 			? simplifiedRoot.members
 			: [simplifiedRoot]
 		value.definitionsByParent = [{
-			parent: undefined,
+			parents: [],
 			keyDefinition: undefined,
 			runtimeNode: value,
+			originalTypeDef: typeDef,
 			condensedErrors: [],
 			validDefinitions: [],
 		}]
@@ -221,7 +223,7 @@ export function typeDefinition<T>(
 	const nodeQueue: CheckerTreeNode<T>[] = [rootNode]
 
 	while (nodeQueue.length !== 0) {
-		const node = nodeQueue.splice(0, 1)[0]
+		const node = nodeQueue.shift()!
 
 		for (const value of node.possibleValues) {
 			const inferredSimplified = simplify(value.node.inferredType, { ctx, node: value })
@@ -271,7 +273,23 @@ export function typeDefinition<T>(
 							continue
 						}
 						const child = childNodes[i]
+						const existingDefIndex = child.possibleValues.length > 0
+							? child.possibleValues[0].definitionsByParent
+								.findIndex(
+									d =>
+										(d.keyDefinition === undefined || childDef.keyType === undefined
+											? d.keyDefinition === undefined
+											: McdocType.equals(d.keyDefinition, childDef.keyType))
+										&& McdocType.equals(d.originalTypeDef, childDef.type),
+								)
+							: -1
+
 						for (const childValue of child.possibleValues) {
+							if (existingDefIndex >= 0) {
+								childValue.definitionsByParent[existingDefIndex].parents.push(def)
+								def.children.push(childValue.definitionsByParent[existingDefIndex])
+								continue
+							}
 							// TODO We need some sort of map / local cache which keeps track of the original
 							// non-simplified types and see if they have been compared yet. This is needed
 							// for structures that are cyclic, to essentially bail out once we are comparing
@@ -280,9 +298,10 @@ export function typeDefinition<T>(
 							// text component definitions
 							const simplified = simplify(childDef.type, { ctx, node: childValue })
 							const childDefinitionGroup: CheckerTreeDefinitionGroupNode<T> = {
-								parent: def,
+								parents: [def],
 								runtimeNode: childValue,
 								keyDefinition: childDef.keyType,
+								originalTypeDef: childDef.type,
 								validDefinitions: [],
 								condensedErrors: [],
 								desc: childDef.desc,
@@ -302,85 +321,7 @@ export function typeDefinition<T>(
 					}
 				}
 
-				let curNode: CheckerTreeDefinitionGroupNode<T> | undefined = definitionGroup
-				let depth = 0
-				let errorsOnLayer = definitionErrors
-				while (curNode) {
-					const stillValidDefintions: CheckerTreeDefinitionNode<T>[] = []
-					const { definitions, condensedErrors } = condenseErrorsAndFilterSiblings(
-						errorsOnLayer,
-					)
-
-					stillValidDefintions.push(...definitions)
-
-					curNode.condensedErrors.push(condensedErrors)
-
-					if (curNode.validDefinitions.length !== stillValidDefintions.length) {
-						filterChildDefinitions(
-							curNode.validDefinitions.filter(d => !stillValidDefintions.includes(d)),
-							curNode.runtimeNode.children,
-						)
-
-						function filterChildDefinitions(
-							removedDefs: CheckerTreeDefinitionNode<T>[],
-							children: CheckerTreeNode<T>[],
-						) {
-							for (const child of children) {
-								for (const childValue of child.possibleValues) {
-									const removedChildDefs: CheckerTreeDefinitionNode<T>[] = []
-									const stillValidChildDefs: CheckerTreeDefinitionGroupNode<T>[] = []
-
-									for (const definitionGroup of childValue.definitionsByParent) {
-										if (removedDefs.includes(definitionGroup.parent!)) {
-											removedChildDefs.push(...definitionGroup.validDefinitions)
-										} else {
-											stillValidChildDefs.push(definitionGroup)
-										}
-									}
-									childValue.definitionsByParent = stillValidChildDefs
-
-									if (removedChildDefs.length > 0) {
-										filterChildDefinitions(
-											removedChildDefs,
-											childValue.children,
-										)
-									}
-								}
-							}
-						}
-						curNode.validDefinitions = stillValidDefintions
-					}
-
-					const oldNode: CheckerTreeDefinitionGroupNode<T> = curNode
-					curNode = oldNode.parent?.groupNode
-
-					const lastChild = curNode?.validDefinitions.flatMap(d => d.children).findLast(v => {
-						if (v.condensedErrors.length > depth) {
-							return true
-						}
-
-						let children = [v]
-						for (let i = 0; i < depth; i++) {
-							children = children.flatMap(v => v.validDefinitions).flatMap(v => v.children)
-						}
-						return children.length > 0
-					})
-
-					if (lastChild !== oldNode) {
-						// Wait for all siblings to be evaluated first
-						break
-					}
-
-					errorsOnLayer = curNode!.validDefinitions
-						.flatMap(d => ({
-							definition: d,
-							errors: d.children.flatMap(c =>
-								c.condensedErrors.length > depth ? c.condensedErrors[depth] : []
-							),
-						}))
-
-					depth++
-				}
+				condenseAndPropagate(definitionGroup, definitionErrors)
 			}
 			value.children = childNodes
 			nodeQueue.push(...childNodes)


### PR DESCRIPTION
Fixes #1401

This deduplicates definitions when adding them to the checker tree. This is done as early as possible which has a few advantages performance-wise:

## Complexity of deduplicating itself
By definition, deduplication means complexity O(n^2) which isn't great, as each definition needs to be checked against each other definition.

This approach reduces this to be always effectively O(n*m), where m is the number of _unique_ definitions, and n is the number of _total_defintions.

This means each definition is guranteed to be checked only against other uniquely different definitions, since we only collect definitions that differ in the first place, and never write any duplicates

So this is only bad compexity wise if we have a definition that means that a child for some reason gets a ton of valid definitions which are all different from each other, which really shouldn't happen.

## Performance gains
On types that have a lot of duplicate definitions for some nodes (one example is a common base type being spread over all types of a dispatcher, while using the fallback case; in this case all children of the struct which appear in the common base type are duplicated to all dispatched values), this means:
- simplify() is only called once per unique definition.
- The whole checking logic is also only executed once per unique definition

I expect some performance improvements from this for such types, one example would be the entity fallback which is sometimes used in commands.

## The fix in action
In particular, #1401 is fixed:
![image](https://github.com/SpyglassMC/Spyglass/assets/12124394/ef69c656-563e-45af-9e62-6296fa076df3)

There however still seems to be a bug with error condensing here:
![image](https://github.com/SpyglassMC/Spyglass/assets/12124394/a6f2b29e-a8a5-409a-8bc7-d69dba58416e)
I'll take a look at the remaining issue and see how easy it is to fix.