### PR TITLE
🐛 Register builtin empty loot table symbol

### DIFF
--- a/__snapshots__/packages/java-edition/test-out/dependency/mcmeta.spec.js
+++ b/__snapshots__/packages/java-edition/test-out/dependency/mcmeta.spec.js
@@ -488,4 +488,9 @@ CATEGORY worldgen/tree_decorator_type
 + SYMBOL minecraft:trunk_vine {worldgen/tree_decorator_type} [Public]
 + + declaration:
 + + + {"uri":"mcmeta://summary/registries.json"}
+------------
+CATEGORY loot_table
++ SYMBOL minecraft:empty {loot_table} [Public]
++ + declaration:
++ + + {"uri":"mcmeta://summary/registries.json"}
 `

--- a/packages/java-edition/src/dependency/mcmeta.ts
+++ b/packages/java-edition/src/dependency/mcmeta.ts
@@ -177,10 +177,16 @@ export function symbolRegistrar(summary: McmetaSummary): core.SymbolRegistrar {
 		}
 	}
 
+	function addBuiltinSymbols(symbols: core.SymbolUtil) {
+		symbols.query(McmetaSummaryUri, 'loot_table', 'minecraft:empty')
+			.enter({ usage: { type: 'declaration' } })
+	}
+
 	return (symbols) => {
 		addRegistriesSymbols(summary.registries, symbols)
 		addStatesSymbols('block', summary.blocks, symbols)
 		addStatesSymbols('fluid', summary.fluids, symbols)
+		addBuiltinSymbols(symbols)
 	}
 }
 


### PR DESCRIPTION
The `minecraft:empty` loot table is not present in the vanilla data pack, it needs to be manually registered to the symbol table (assuming that it has existed at least since 1.15)