### PR TITLE
🐛 Fix data append and prepend using list definition instead of list item for type checking

### DIFF
--- a/packages/java-edition/src/mcfunction/checker/index.ts
+++ b/packages/java-edition/src/mcfunction/checker/index.ts
@@ -258,8 +258,6 @@ function getListLikeChild(typeDef: mcdoc.McdocType): mcdoc.McdocType | undefined
 			return { kind: 'int' }
 		case 'long_array':
 			return { kind: 'long' }
-		case 'tuple':
-			return { kind: 'union', members: typeDef.items }
 		case 'union':
 			const members = typeDef.members
 				.map(m => getListLikeChild(m))

--- a/packages/java-edition/src/mcfunction/checker/index.ts
+++ b/packages/java-edition/src/mcfunction/checker/index.ts
@@ -202,12 +202,12 @@ function nbtChecker(
 		const tag = node.children[0]
 		if (indexedBy) {
 			if (NbtPathNode.is(indexedBy)) {
-				let typeDef: mcdoc.McdocType | undefined = indexedBy.children[0].endTypeDef
-				if (typeDef && node.properties.isListIndex) {
-					typeDef = getListLikeChild(typeDef)
-				}
+				const indexedByTypedef = indexedBy.children[0].endTypeDef
+				const typeDef = indexedByTypedef && node.properties.isListIndex
+					? getListLikeChild(indexedByTypedef)
+					: indexedByTypedef
 				if (typeDef) {
-					nbt.checker.typeDefinition(typeDef)(tag, ctx)
+					nbt.checker.typeDefinition(typeDef, node.properties)(tag, ctx)
 				}
 			}
 			return
@@ -248,7 +248,9 @@ function nbtChecker(
 	}
 }
 
-function getListLikeChild(typeDef: mcdoc.McdocType): mcdoc.McdocType | undefined {
+function getListLikeChild(
+	typeDef: mcdoc.runtime.checker.SimplifiedMcdocType,
+): mcdoc.McdocType | undefined {
 	switch (typeDef.kind) {
 		case 'list':
 			return typeDef.item

--- a/packages/java-edition/src/mcfunction/checker/index.ts
+++ b/packages/java-edition/src/mcfunction/checker/index.ts
@@ -201,8 +201,14 @@ function nbtChecker(
 		}
 		const tag = node.children[0]
 		if (indexedBy) {
-			if (NbtPathNode.is(indexedBy) && indexedBy.children[0].endTypeDef) {
-				nbt.checker.typeDefinition(indexedBy.children[0].endTypeDef)(tag, ctx)
+			if (NbtPathNode.is(indexedBy)) {
+				let typeDef: mcdoc.McdocType | undefined = indexedBy.children[0].endTypeDef
+				if (typeDef && node.properties.isListIndex) {
+					typeDef = getListLikeChild(typeDef)
+				}
+				if (typeDef) {
+					nbt.checker.typeDefinition(typeDef)(tag, ctx)
+				}
 			}
 			return
 		}
@@ -239,6 +245,33 @@ function nbtChecker(
 				}
 				break
 		}
+	}
+}
+
+function getListLikeChild(typeDef: mcdoc.McdocType): mcdoc.McdocType | undefined {
+	switch (typeDef.kind) {
+		case 'list':
+			return typeDef.item
+		case 'byte_array':
+			return { kind: 'byte' }
+		case 'int_array':
+			return { kind: 'int' }
+		case 'long_array':
+			return { kind: 'long' }
+		case 'union':
+			const members = typeDef.members
+				.map(m => getListLikeChild(m))
+				.filter((m): m is mcdoc.McdocType => m !== undefined)
+
+			if (members.length === 0) {
+				return undefined
+			}
+			if (members.length === 1) {
+				return members[0]
+			}
+			return { kind: 'union', members }
+		default:
+			return undefined
 	}
 }
 

--- a/packages/java-edition/src/mcfunction/checker/index.ts
+++ b/packages/java-edition/src/mcfunction/checker/index.ts
@@ -258,6 +258,8 @@ function getListLikeChild(typeDef: mcdoc.McdocType): mcdoc.McdocType | undefined
 			return { kind: 'int' }
 		case 'long_array':
 			return { kind: 'long' }
+		case 'tuple':
+			return { kind: 'union', members: typeDef.items }
 		case 'union':
 			const members = typeDef.members
 				.map(m => getListLikeChild(m))

--- a/packages/java-edition/src/mcfunction/tree/argument.ts
+++ b/packages/java-edition/src/mcfunction/tree/argument.ts
@@ -147,6 +147,11 @@ export interface NbtParserProperties extends Record<string, unknown> {
 	 * merge NBT argument, keys can be missing.
 	 */
 	isMerge?: boolean
+	/**
+	 * `true` if the NBT checker should check this type using the list item of
+	 * {@link indexedBy}
+	 */
+	isListIndex?: boolean
 }
 export interface MinecraftNbtCompoundTagArgumentTreeNode extends mcf.ArgumentTreeNode {
 	parser: 'minecraft:nbt_compound_tag'

--- a/packages/java-edition/src/mcfunction/tree/patch.ts
+++ b/packages/java-edition/src/mcfunction/tree/patch.ts
@@ -129,7 +129,9 @@ export function getPatch(release: ReleaseVersion): PartialRootTreeNode {
 						nbtAccessType: SymbolAccessType.Write,
 						vaultAccessType: SymbolAccessType.Write,
 						children: (type) => ({
-							append: getDataModifySource(type),
+							append: getDataModifySource(type, {
+								isListIndex: true,
+							}),
 							insert: {
 								children: {
 									index: getDataModifySource(type),
@@ -138,7 +140,9 @@ export function getPatch(release: ReleaseVersion): PartialRootTreeNode {
 							merge: getDataModifySource(type, {
 								isMerge: true,
 							}),
-							prepend: getDataModifySource(type),
+							prepend: getDataModifySource(type, {
+								isListIndex: true,
+							}),
 							set: getDataModifySource(type),
 						}),
 					}),
@@ -902,8 +906,10 @@ const getDataModifySource = (
 	type: 'block' | 'entity' | 'storage',
 	{
 		isMerge = false,
+		isListIndex = false,
 	}: {
 		isMerge?: boolean | undefined
+		isListIndex?: boolean | undefined
 	} = {},
 ): PartialTreeNode =>
 	Object.freeze({
@@ -918,6 +924,7 @@ const getDataModifySource = (
 							dispatchedBy: type === 'block' ? 'targetPos' : 'target',
 							indexedBy: 'targetPath',
 							isMerge,
+							isListIndex,
 						} satisfies NbtParserProperties,
 					},
 				},


### PR DESCRIPTION
Fixes #1403

With this, the list item definition is used instead for append and prepend.

We probably want to verify that the item returned by the path is actually a list. The type checking for the Nbt node is completely disabled when no list-like is found at the index.

Similarly, there is currently no error when trying to use data modify merge on anything else than a compound.