### PR TITLE
✨ Scan the project root for pack.mcmeta files to determine version

### DIFF
--- a/packages/core/src/common/externals/NodeJsExternals.ts
+++ b/packages/core/src/common/externals/NodeJsExternals.ts
@@ -82,9 +82,9 @@ export const NodeJsExternals: Externals = {
 		chmod(location, mode) {
 			return fsp.chmod(toFsPathLike(location), mode)
 		},
-		async getAllFiles(location) {
+		async getAllFiles(location, depth) {
 			const path = toPath(location).replaceAll('\\', '/') + '**/*'
-			const files = await globby(path, { absolute: true, dot: true })
+			const files = await globby(path, { absolute: true, dot: true, deep: depth })
 			return files.map(uriFromPath)
 		},
 		async mkdir(location, options) {

--- a/packages/core/src/common/externals/index.ts
+++ b/packages/core/src/common/externals/index.ts
@@ -57,7 +57,7 @@ export interface ExternalFileSystem {
 	/**
 	 * @returns an array of file URIs under the given `location`.
 	 */
-	getAllFiles(location: FsLocation): Promise<string[]>
+	getAllFiles(location: FsLocation, depth?: number): Promise<string[]>
 	/**
 	 * @param options `mode` - File mode bit mask (e.g. `0o775`).
 	 */

--- a/packages/java-edition/src/dependency/mcmeta.ts
+++ b/packages/java-edition/src/dependency/mcmeta.ts
@@ -4,10 +4,11 @@ import type { PackMcmeta, ReleaseVersion, VersionInfo } from './common.js'
 /**
  * @param inputVersion {@link core.Config.env.gameVersion}
  */
-export function resolveConfiguredVersion(
+export async function resolveConfiguredVersion(
 	inputVersion: string,
-	{ packMcmeta, versions }: { packMcmeta: PackMcmeta | undefined; versions: McmetaVersions },
-): VersionInfo {
+	versions: McmetaVersions,
+	getPackMcmeta: () => Promise<PackMcmeta | undefined>,
+): Promise<VersionInfo> {
 	function findReleaseTarget(version: McmetaVersion): string {
 		if (version.release_target) {
 			return version.release_target
@@ -43,6 +44,7 @@ export function resolveConfiguredVersion(
 	versions = versions.sort((a, b) => b.data_version - a.data_version)
 	const latestRelease = versions.find((v) => v.type === 'release')
 	if (inputVersion === 'auto') {
+		const packMcmeta = await getPackMcmeta()
 		if (packMcmeta && latestRelease) {
 			// If the pack format is larger than the latest release, use the latest snapshot
 			if (packMcmeta.pack.pack_format > latestRelease.data_pack_version) {

--- a/packages/java-edition/src/index.ts
+++ b/packages/java-edition/src/index.ts
@@ -39,7 +39,7 @@ export const initialize: core.ProjectInitializer = async (ctx) => {
 		return undefined
 	}
 
-	async function getPackMcmeta(): Promise<PackMcmeta | undefined> {
+	async function findPackMcmeta(): Promise<PackMcmeta | undefined> {
 		const searched = new Set<string>()
 		for (let depth = 0; depth <= 2; depth += 1) {
 			const files = await externals.fs.getAllFiles(projectRoot, depth + 1)
@@ -71,7 +71,7 @@ export const initialize: core.ProjectInitializer = async (ctx) => {
 		return
 	}
 
-	const version = await resolveConfiguredVersion(config.env.gameVersion, versions, getPackMcmeta)
+	const version = await resolveConfiguredVersion(config.env.gameVersion, versions, findPackMcmeta)
 	const release = version.release
 
 	meta.registerDependencyProvider(

--- a/packages/java-edition/src/index.ts
+++ b/packages/java-edition/src/index.ts
@@ -40,9 +40,14 @@ export const initialize: core.ProjectInitializer = async (ctx) => {
 	}
 
 	async function getPackMcmeta(): Promise<PackMcmeta | undefined> {
+		const searched = new Set<string>()
 		for (let depth = 0; depth <= 2; depth += 1) {
 			const files = await externals.fs.getAllFiles(projectRoot, depth + 1)
 			for (const uri of files.filter(uri => uri.endsWith('/pack.mcmeta'))) {
+				if (searched.has(uri)) {
+					continue
+				}
+				searched.add(uri)
 				const data = await readPackMcmeta(uri)
 				if (data) {
 					logger.info(

--- a/packages/java-edition/test/dependency/mcmeta.spec.ts
+++ b/packages/java-edition/test/dependency/mcmeta.spec.ts
@@ -52,10 +52,11 @@ describe('mcmeta', () => {
 		]
 		for (const { version, packMcmeta } of suites) {
 			it(`Should resolve "${version}"`, async () => {
-				const actual = resolveConfiguredVersion(version, {
-					packMcmeta,
-					versions: Fixtures.Versions,
-				})
+				const actual = await resolveConfiguredVersion(
+					version,
+					Fixtures.Versions,
+					async () => packMcmeta,
+				)
 				snapshot(actual)
 			})
 		}


### PR DESCRIPTION
Before this PR, only a `pack.mcmeta` at the root of the project was detected to determine the loaded version. Now it searches up to a max depth of 2 folders, returning the first pack_format it can find.