### PR TITLE
🐛 Fix auto complete suggesting namespace-less entries with isPredicate

### DIFF
--- a/packages/mcdoc/src/runtime/attribute/builtin.ts
+++ b/packages/mcdoc/src/runtime/attribute/builtin.ts
@@ -129,7 +129,7 @@ export function registerBuiltinAttributes(meta: core.MetaRegistry) {
 		stringMocker: (config, typeDef, ctx) => {
 			const options = getResourceLocationOptions(
 				config,
-				ctx.requireCannonical ?? false,
+				ctx.requireCanonical ?? false,
 				ctx,
 				typeDef,
 			)

--- a/packages/mcdoc/src/runtime/attribute/builtin.ts
+++ b/packages/mcdoc/src/runtime/attribute/builtin.ts
@@ -127,7 +127,12 @@ export function registerBuiltinAttributes(meta: core.MetaRegistry) {
 			}
 		},
 		stringMocker: (config, typeDef, ctx) => {
-			const options = getResourceLocationOptions(config, false, ctx, typeDef)
+			const options = getResourceLocationOptions(
+				config,
+				ctx.requireCannonical ?? false,
+				ctx,
+				typeDef,
+			)
 			if (!options) {
 				return undefined
 			}

--- a/packages/mcdoc/src/runtime/attribute/index.ts
+++ b/packages/mcdoc/src/runtime/attribute/index.ts
@@ -5,6 +5,7 @@ import type {
 	SimplifiedMcdocType,
 	SimplifiedMcdocTypeNoUnion,
 } from '../checker/index.js'
+import type { McdocCompleterContext } from '../completer/index.js'
 import type { McdocAttributeValidator } from './validator.js'
 
 export * as validator from './validator.js'
@@ -34,7 +35,7 @@ export interface McdocAttribute<C = unknown> {
 	stringMocker?: (
 		config: C,
 		typeDef: core.DeepReadonly<SimplifiedMcdocTypeNoUnion>,
-		ctx: core.CompleterContext,
+		ctx: McdocCompleterContext,
 	) => core.AstNode | undefined
 }
 

--- a/packages/mcdoc/src/runtime/completer/index.ts
+++ b/packages/mcdoc/src/runtime/completer/index.ts
@@ -6,9 +6,13 @@ import type { SimplifiedEnum, SimplifiedMcdocType } from '../checker/index.js'
 
 export type SimpleCompletionField = { key: string; field: core.DeepReadonly<StructTypePairField> }
 
+export interface McdocCompleterContext extends core.CompleterContext {
+	requireCannonical?: boolean
+}
+
 export function getFields(
 	typeDef: core.DeepReadonly<SimplifiedMcdocType>,
-	ctx: core.CompleterContext,
+	ctx: McdocCompleterContext,
 ): SimpleCompletionField[] {
 	switch (typeDef.kind) {
 		case 'union':
@@ -59,7 +63,7 @@ export type SimpleCompletionValue = {
 // TODO: only accept SimplifiedMcdocType here
 export function getValues(
 	typeDef: core.DeepReadonly<McdocType>,
-	ctx: core.CompleterContext,
+	ctx: McdocCompleterContext,
 ): SimpleCompletionValue[] {
 	if (
 		typeDef.kind === 'string'
@@ -127,7 +131,7 @@ export function getValues(
 
 function getStringCompletions(
 	typeDef: core.DeepReadonly<StringType | SimplifiedEnum | LiteralType>,
-	ctx: core.CompleterContext,
+	ctx: McdocCompleterContext,
 ) {
 	const ans: SimpleCompletionValue[] = []
 	handleAttributes(typeDef.attributes, ctx, (handler, config) => {

--- a/packages/mcdoc/src/runtime/completer/index.ts
+++ b/packages/mcdoc/src/runtime/completer/index.ts
@@ -7,7 +7,7 @@ import type { SimplifiedEnum, SimplifiedMcdocType } from '../checker/index.js'
 export type SimpleCompletionField = { key: string; field: core.DeepReadonly<StructTypePairField> }
 
 export interface McdocCompleterContext extends core.CompleterContext {
-	requireCannonical?: boolean
+	requireCanonical?: boolean
 }
 
 export function getFields(

--- a/packages/nbt/src/checker/index.ts
+++ b/packages/nbt/src/checker/index.ts
@@ -135,6 +135,7 @@ export function typeDefinition(
 				),
 				attachTypeInfo: (node, definition, desc = '') => {
 					node.typeDef = definition
+					node.requireCannonical = options.isPredicate
 					// TODO: improve hover info
 					if (
 						node.parent && core.PairNode?.is(node.parent)

--- a/packages/nbt/src/checker/index.ts
+++ b/packages/nbt/src/checker/index.ts
@@ -135,7 +135,7 @@ export function typeDefinition(
 				),
 				attachTypeInfo: (node, definition, desc = '') => {
 					node.typeDef = definition
-					node.requireCannonical = options.isPredicate
+					node.requireCanonical = options.isPredicate
 					// TODO: improve hover info
 					if (
 						node.parent && core.PairNode?.is(node.parent)

--- a/packages/nbt/src/completer/index.ts
+++ b/packages/nbt/src/completer/index.ts
@@ -21,7 +21,7 @@ const collection: core.Completer<NbtCollectionNode> = (node, ctx) => {
 	if (node.typeDef?.kind === 'list') {
 		const completions = getValues(node.typeDef.item, ctx.offset, {
 			...ctx,
-			requireCannonical: node.requireCannonical,
+			requireCanonical: node.requireCanonical,
 		})
 		if (ctx.offset < node.children[node.children.length - 1]?.range.start ?? 0) {
 			return completions.map(c => ({ ...c, insertText: c.insertText + ',' }))
@@ -38,7 +38,7 @@ const compound = core.completer.record<NbtStringNode, NbtNode, NbtCompoundNode>(
 		}
 		const keySet = new Set(exitingKeys.map(n => n.value))
 		return mcdoc.runtime.completer
-			.getFields(record.typeDef, { ...ctx, requireCannonical: record.requireCannonical })
+			.getFields(record.typeDef, { ...ctx, requireCanonical: record.requireCanonical })
 			.filter(({ key }) => !keySet.has(key))
 			.map(({ key, field }) =>
 				core.CompletionItem.create(key, pair?.key ?? range, {
@@ -64,7 +64,7 @@ const compound = core.completer.record<NbtStringNode, NbtNode, NbtCompoundNode>(
 			if (field) {
 				return getValues(field, range, {
 					...ctx,
-					requireCannonical: record.requireCannonical,
+					requireCanonical: record.requireCanonical,
 				})
 			}
 		}
@@ -85,7 +85,7 @@ const primitive: core.Completer<NbtPrimitiveNode> = (node, ctx) => {
 	}
 	return getValues(node.typeDef, insideRange ? node : ctx.offset, {
 		...ctx,
-		requireCannonical: node.requireCannonical,
+		requireCanonical: node.requireCanonical,
 	})
 }
 
@@ -121,7 +121,7 @@ function getPathKeys(
 	ctx: core.CompleterContext,
 ) {
 	return mcdoc.runtime.completer
-		.getFields(typeDef, { ...ctx, requireCannonical: true })
+		.getFields(typeDef, { ...ctx, requireCanonical: true })
 		.map(({ key, field }) =>
 			core.CompletionItem.create(key, range, {
 				kind: core.CompletionKind.Field,

--- a/packages/nbt/src/completer/index.ts
+++ b/packages/nbt/src/completer/index.ts
@@ -19,7 +19,10 @@ const collection: core.Completer<NbtCollectionNode> = (node, ctx) => {
 		return ctx.meta.getCompleter(item.value.type)(item.value, ctx)
 	}
 	if (node.typeDef?.kind === 'list') {
-		const completions = getValues(node.typeDef.item, ctx.offset, ctx)
+		const completions = getValues(node.typeDef.item, ctx.offset, {
+			...ctx,
+			requireCannonical: node.requireCannonical,
+		})
 		if (ctx.offset < node.children[node.children.length - 1]?.range.start ?? 0) {
 			return completions.map(c => ({ ...c, insertText: c.insertText + ',' }))
 		}
@@ -35,7 +38,7 @@ const compound = core.completer.record<NbtStringNode, NbtNode, NbtCompoundNode>(
 		}
 		const keySet = new Set(exitingKeys.map(n => n.value))
 		return mcdoc.runtime.completer
-			.getFields(record.typeDef, ctx)
+			.getFields(record.typeDef, { ...ctx, requireCannonical: record.requireCannonical })
 			.filter(({ key }) => !keySet.has(key))
 			.map(({ key, field }) =>
 				core.CompletionItem.create(key, pair?.key ?? range, {
@@ -54,11 +57,15 @@ const compound = core.completer.record<NbtStringNode, NbtNode, NbtCompoundNode>(
 		}
 		if (pair.key && record.typeDef) {
 			const pairKey = pair.key.value
-			const field = mcdoc.runtime.completer.getFields(record.typeDef, ctx)
+			const field = mcdoc.runtime.completer
+				.getFields(record.typeDef, ctx)
 				.find(({ key }) => key === pairKey)
 				?.field.type
 			if (field) {
-				return getValues(field, range, ctx)
+				return getValues(field, range, {
+					...ctx,
+					requireCannonical: record.requireCannonical,
+				})
 			}
 		}
 		return []
@@ -76,7 +83,10 @@ const primitive: core.Completer<NbtPrimitiveNode> = (node, ctx) => {
 	if (!node.typeDef) {
 		return []
 	}
-	return getValues(node.typeDef, insideRange ? node : ctx.offset, ctx)
+	return getValues(node.typeDef, insideRange ? node : ctx.offset, {
+		...ctx,
+		requireCannonical: node.requireCannonical,
+	})
 }
 
 const path: core.Completer<NbtPathNode> = (node, ctx) => {
@@ -111,7 +121,7 @@ function getPathKeys(
 	ctx: core.CompleterContext,
 ) {
 	return mcdoc.runtime.completer
-		.getFields(typeDef, ctx)
+		.getFields(typeDef, { ...ctx, requireCannonical: true })
 		.map(({ key, field }) =>
 			core.CompletionItem.create(key, range, {
 				kind: core.CompletionKind.Field,
@@ -127,7 +137,7 @@ function getPathKeys(
 function getValues(
 	typeDef: core.DeepReadonly<mcdoc.McdocType>,
 	range: core.RangeLike,
-	ctx: core.CompleterContext,
+	ctx: mcdoc.runtime.completer.McdocCompleterContext,
 ): core.CompletionItem[] {
 	return mcdoc.runtime.completer.getValues(typeDef, ctx)
 		.map(({ value, detail, kind, completionKind, insertText }) =>

--- a/packages/nbt/src/node/index.ts
+++ b/packages/nbt/src/node/index.ts
@@ -3,7 +3,7 @@ import type * as mcdoc from '@spyglassmc/mcdoc'
 
 interface NbtBaseNode {
 	typeDef?: mcdoc.runtime.checker.SimplifiedMcdocType
-	requireCannonical?: boolean
+	requireCanonical?: boolean
 }
 
 export type NbtNode = NbtPrimitiveNode | NbtCompoundNode | NbtCollectionNode

--- a/packages/nbt/src/node/index.ts
+++ b/packages/nbt/src/node/index.ts
@@ -3,6 +3,7 @@ import type * as mcdoc from '@spyglassmc/mcdoc'
 
 interface NbtBaseNode {
 	typeDef?: mcdoc.runtime.checker.SimplifiedMcdocType
+	requireCannonical?: boolean
 }
 
 export type NbtNode = NbtPrimitiveNode | NbtCompoundNode | NbtCollectionNode


### PR DESCRIPTION
This was mentioned on discord while discussing #1415 

Json never has a predicate that requires specifying the namespace, so JSON remains unchanged

For SNBT, I save whether checking was using the isPredicate ruleset on the NBT node when attaching the mcdoc typeinfo.

For NBT paths, this is always true, similar to how NBT paths are always checked with the isPredicate ruleset.

There is a new mcdoc completer context now which extends the core completer context with an optional requireCannoical parameter.