### PR TITLE
🔧 Don't clean node_modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 		"build:dev": "wireit",
 		"watch": "npm run build:dev --watch",
 		"clean": "tsc -b packages --clean",
-		"clean:full": "rm -rf node_modules packages/*/lib packages/*/out packages/*/dist packages/*/test-out packages/*/*.tsbuildinfo .wireit packages/*/.wireit",
+		"clean:full": "rm -rf packages/*/lib packages/*/out packages/*/dist packages/*/test-out packages/*/*.tsbuildinfo .wireit packages/*/.wireit",
 		"commit": "gitmoji -c",
 		"docs:install": "cd docs && (bundle || true) && cd ..",
 		"docs:start": "cd docs && (bundle exec jekyll serve --incremental || true) && cd ..",


### PR DESCRIPTION
This change was made in 2636999bd88ac7e033204756147ff74cad50a65d and I only noticed afterwards. I very often want to `clean:full` when switching between branches, mostly to clear out old test-out files. I don't want this to delete my node_modules. I see very few situations where I actually want to do that.