### PR TITLE
🐛 Fix crash when fileModified before dependencyFiles is set

### DIFF
--- a/packages/core/src/service/Project.ts
+++ b/packages/core/src/service/Project.ts
@@ -194,8 +194,8 @@ export class Project implements ExternalEventEmitter {
 	readonly projectRoot: RootUriString
 	symbols: SymbolUtil
 
-	#dependencyRoots!: Set<RootUriString>
-	#dependencyFiles!: Set<string>
+	#dependencyRoots: Set<RootUriString> | undefined
+	#dependencyFiles: Set<string> | undefined
 
 	#roots: readonly RootUriString[] = []
 	/**
@@ -228,7 +228,7 @@ export class Project implements ExternalEventEmitter {
 	}
 
 	private updateRoots(): void {
-		const rawRoots = [...this.#dependencyRoots, this.projectRoot]
+		const rawRoots = [...this.#dependencyRoots ?? [], this.projectRoot]
 		const ans = new Set(rawRoots)
 		// Identify roots indicated by `pack.mcmeta`.
 		for (const file of this.getTrackedFiles()) {
@@ -291,7 +291,7 @@ export class Project implements ExternalEventEmitter {
 	 */
 	getTrackedFiles(): string[] {
 		const extensions: string[] = this.meta.getSupportedFileExtensions()
-		const supportedFiles = [...this.#dependencyFiles, ...this.#watchedFiles].filter((file) =>
+		const supportedFiles = [...this.#dependencyFiles ?? [], ...this.#watchedFiles].filter((file) =>
 			extensions.includes(fileUtil.extname(file) ?? '')
 		)
 		const filteredFiles = this.ignore.filter(supportedFiles)
@@ -966,13 +966,13 @@ export class Project implements ExternalEventEmitter {
 
 	private shouldRemove(uri: string): boolean {
 		return (!this.#clientManagedUris.has(uri)
-			&& !this.#dependencyFiles.has(uri)
+			&& !this.#dependencyFiles?.has(uri)
 			&& !this.#watchedFiles.has(uri))
 	}
 
 	private isOnlyWatched(uri: string): boolean {
 		return (this.#watchedFiles.has(uri)
 			&& !this.#clientManagedUris.has(uri)
-			&& !this.#dependencyFiles.has(uri))
+			&& !this.#dependencyFiles?.has(uri))
 	}
 }

--- a/packages/core/src/service/Project.ts
+++ b/packages/core/src/service/Project.ts
@@ -291,9 +291,8 @@ export class Project implements ExternalEventEmitter {
 	 */
 	getTrackedFiles(): string[] {
 		const extensions: string[] = this.meta.getSupportedFileExtensions()
-		const supportedFiles = [...this.#dependencyFiles ?? [], ...this.#watchedFiles].filter((file) =>
-			extensions.includes(fileUtil.extname(file) ?? '')
-		)
+		const supportedFiles = [...this.#dependencyFiles ?? [], ...this.#watchedFiles]
+			.filter((file) => extensions.includes(fileUtil.extname(file) ?? ''))
 		const filteredFiles = this.ignore.filter(supportedFiles)
 		return filteredFiles
 	}


### PR DESCRIPTION
We got a report on discord where the stacktrace indicated that `isOnlyWatched` was being called from the `on fileModified` handler while `#dependencyFiles` was still undefined. The `fileModified` handler is attached in the contructor, while `#dependencyFiles` is only set during the `ready` phase, so this is not unexpected.

Is it better practice to just initialize these two as empty sets?