### PR TITLE
✨ Handle mcdoc `tags="required"` resource locations

### DIFF
--- a/packages/core/src/node/ResourceLocationNode.ts
+++ b/packages/core/src/node/ResourceLocationNode.ts
@@ -21,13 +21,21 @@ export type ResourceLocationOptions =
 		category: ResourceLocationCategory
 		pool?: undefined
 		allowTag?: false
+		requireTag?: false
 		allowUnknown?: false
 	} | {
 		category: TaggableResourceLocationCategory
 		pool?: undefined
 		allowTag?: boolean
+		requireTag?: boolean
 		allowUnknown?: false
-	} | { category?: undefined; pool: string[]; allowTag?: false; allowUnknown?: boolean })
+	} | {
+		category?: undefined
+		pool: string[]
+		allowTag?: false
+		requireTag?: false
+		allowUnknown?: boolean
+	})
 
 export interface ResourceLocationBaseNode extends AstNode, Partial<ResourceLocation> {
 	readonly options: ResourceLocationOptions

--- a/packages/core/src/parser/resourceLocation.ts
+++ b/packages/core/src/parser/resourceLocation.ts
@@ -119,6 +119,10 @@ export function resourceLocation(
 				ctx.err.report(localize('parser.resource-location.tag-disallowed'), ans)
 			}
 
+			if (!ans.isTag && options.requireTag) {
+				ctx.err.report(localize('parser.resource-location.tag-required'), ans)
+			}
+
 			if (!ans.namespace && options.requireCanonical) {
 				ctx.err.report(localize('parser.resource-location.namespace-expected'), ans)
 			}

--- a/packages/core/src/processor/completer/builtin.ts
+++ b/packages/core/src/processor/completer/builtin.ts
@@ -211,7 +211,9 @@ export const resourceLocation: Completer<ResourceLocationNode> = (node, ctx) => 
 	const pool = node.options.pool
 		? optimizePool(node.options.pool)
 		: [
-			...getPool(node.options.category),
+			...(!node.options.requireTag
+				? getPool(node.options.category)
+				: []),
 			...(node.options.allowTag
 				? getPool(`tag/${node.options.category}`).map((v) =>
 					`${ResourceLocation.TagPrefix}${v}`

--- a/packages/locales/src/locales/en.json
+++ b/packages/locales/src/locales/en.json
@@ -199,6 +199,7 @@
   "parser.resource-location.illegal": "Illegal character(s): %0%",
   "parser.resource-location.namespace-expected": "Namespaces cannot be omitted here",
   "parser.resource-location.tag-disallowed": "Tags are not allowed here",
+  "parser.resource-location.tag-required": "Only tags are allowed here",
   "parser.string.illegal-brigadier": "Encountered non-[0-9A-Za-z_.+-] characters in %0%",
   "parser.string.illegal-escape": "Unexpected escape character %0%",
   "parser.string.illegal-quote": "Only %0% can be used to quote strings here",

--- a/packages/mcdoc/src/runtime/attribute/builtin.ts
+++ b/packages/mcdoc/src/runtime/attribute/builtin.ts
@@ -45,7 +45,6 @@ function getResourceLocationOptions(
 	if (tags === 'implicit') {
 		registry = `tag/${registry}`
 	}
-	// TODO: disallow non-tags when tags=required
 	if (tags === 'allowed' || tags === 'required') {
 		if (core.TaggableResourceLocationCategory.is(registry)) {
 			return {

--- a/packages/mcdoc/src/runtime/attribute/builtin.ts
+++ b/packages/mcdoc/src/runtime/attribute/builtin.ts
@@ -52,6 +52,7 @@ function getResourceLocationOptions(
 				category: registry,
 				requireCanonical,
 				allowTag: true,
+				requireTag: tags === 'required',
 			}
 		}
 	} else if (core.ResourceLocationCategory.is(registry)) {


### PR DESCRIPTION
Handles mcdoc with id attribute with `tags="required"` properly.

Example from dimension types: 
```
infiniburn: #[id(registry="block",tags="required")] string 
```