### PR TITLE
🐛 Fix nbt paths ending with an enum type

### DIFF
--- a/packages/mcdoc/src/runtime/checker/index.ts
+++ b/packages/mcdoc/src/runtime/checker/index.ts
@@ -465,11 +465,15 @@ function checkShallowly<T>(
 	}
 
 	if (
-		(typeDef.kind === 'literal'
+		(typeDef.kind !== 'any' && typeDef.kind !== 'unsafe'
+			&& simplifiedInferred.kind !== 'unsafe'
+			&& typeDef.kind === 'literal'
 			&& (simplifiedInferred.kind !== 'literal'
 				|| typeDef.value.value !== simplifiedInferred.value.value))
 		// TODO handle enum field attributes
-		|| (typeDef.kind === 'enum'
+		|| (typeDef.kind !== 'any' && typeDef.kind !== 'unsafe'
+			&& simplifiedInferred.kind !== 'unsafe'
+			&& typeDef.kind === 'enum'
 			&& (simplifiedInferred.kind !== 'literal'
 				|| !typeDef.values.some(v => v.value === simplifiedInferred.value.value)))
 	) {

--- a/packages/mcdoc/src/runtime/checker/index.ts
+++ b/packages/mcdoc/src/runtime/checker/index.ts
@@ -435,17 +435,21 @@ function checkShallowly<T>(
 	typeDef: SimplifiedMcdocTypeNoUnion,
 	ctx: McdocCheckerContext<T>,
 ): ShallowCheckResult<T> {
-	const typeDefValueType = getValueType(typeDef)
-	const runtimeValueType = getValueType(simplifiedInferred)
-
 	const childDefinitions = Array<ShallowCheckResultChildDefinition | undefined>(children.length)
 		.fill(undefined)
 
 	if (
-		(typeDef.kind !== 'any' && typeDef.kind !== 'unsafe'
-			&& simplifiedInferred.kind !== 'unsafe'
-			&& runtimeValueType.kind !== typeDefValueType.kind
-			&& !ctx.isEquivalent(runtimeValueType, typeDefValueType))
+		typeDef.kind === 'any' || typeDef.kind === 'unsafe' || simplifiedInferred.kind === 'unsafe'
+	) {
+		return { childDefinitions, errors: [] }
+	}
+
+	const typeDefValueType = getValueType(typeDef)
+	const runtimeValueType = getValueType(simplifiedInferred)
+
+	if (
+		runtimeValueType.kind !== typeDefValueType.kind
+		&& !ctx.isEquivalent(runtimeValueType, typeDefValueType)
 	) {
 		return {
 			childDefinitions,
@@ -465,15 +469,11 @@ function checkShallowly<T>(
 	}
 
 	if (
-		(typeDef.kind !== 'any' && typeDef.kind !== 'unsafe'
-			&& simplifiedInferred.kind !== 'unsafe'
-			&& typeDef.kind === 'literal'
+		(typeDef.kind === 'literal'
 			&& (simplifiedInferred.kind !== 'literal'
 				|| typeDef.value.value !== simplifiedInferred.value.value))
 		// TODO handle enum field attributes
-		|| (typeDef.kind !== 'any' && typeDef.kind !== 'unsafe'
-			&& simplifiedInferred.kind !== 'unsafe'
-			&& typeDef.kind === 'enum'
+		|| (typeDef.kind === 'enum'
 			&& (simplifiedInferred.kind !== 'literal'
 				|| !typeDef.values.some(v => v.value === simplifiedInferred.value.value)))
 	) {
@@ -484,9 +484,6 @@ function checkShallowly<T>(
 	}
 
 	switch (typeDef.kind) {
-		case 'any':
-		case 'unsafe':
-			break
 		case 'byte':
 		case 'short':
 		case 'int':


### PR DESCRIPTION
- Fixes #1437 

Because NBT paths uses `unsafe` as their leaf type, this would cause a type mismatch when the nbt paths ended with an enum (or literal)