### PR TITLE
✨ Add color information to JSON and NBT

### DIFF
--- a/__snapshots__/packages/core/test-out/processor/ColorInfoProvider.spec.js
+++ b/__snapshots__/packages/core/test-out/processor/ColorInfoProvider.spec.js
@@ -1,4 +1,11 @@
-exports['Color fromCompositeInt() Should return correctly 1'] = [
+exports['Color fromCompositeARGB() Should return correctly 1'] = [
+  1,
+  0.6666666666666666,
+  0.3333333333333333,
+  0.9333333333333333
+]
+
+exports['Color fromCompositeRGB() Should return correctly 1'] = [
   1,
   0.6666666666666666,
   0.3333333333333333,

--- a/__snapshots__/packages/mcdoc/test-out/parser/syntax/attribute.spec.js
+++ b/__snapshots__/packages/mcdoc/test-out/parser/syntax/attribute.spec.js
@@ -413,7 +413,7 @@ exports['mcdoc attribute Parse "#[bitfield=enum (int) {↓⮀⮀⮀⮀⮀Foo = 1
   "errors": []
 }
 
-exports['mcdoc attribute Parse "#[color=composite_int]" 1'] = {
+exports['mcdoc attribute Parse "#[color=composite_rgb]" 1'] = {
   "node": {
     "type": "mcdoc:attribute",
     "children": [
@@ -437,7 +437,7 @@ exports['mcdoc attribute Parse "#[color=composite_int]" 1'] = {
                   "start": 8,
                   "end": 21
                 },
-                "value": "composite_int"
+                "value": "composite_rgb"
               }
             ],
             "range": {

--- a/packages/core/src/node/StringNode.ts
+++ b/packages/core/src/node/StringNode.ts
@@ -70,6 +70,12 @@ export interface StringBaseNode extends AstNode {
 	value: string
 	readonly valueMap: IndexMap
 }
+export namespace StringBaseNode {
+	export function is(obj: object | undefined): obj is StringBaseNode {
+		return Array.isArray((obj as StringBaseNode | undefined)?.valueMap)
+			&& typeof (obj as StringBaseNode | undefined)?.options === 'object'
+	}
+}
 
 export interface StringNode extends StringBaseNode {
 	readonly type: 'string'

--- a/packages/core/src/processor/ColorInfoProvider.ts
+++ b/packages/core/src/processor/ColorInfoProvider.ts
@@ -30,6 +30,14 @@ export namespace Color {
 	])
 	export const ColorNames = [...NamedColors.keys()]
 
+	export function fromNamed(value: string): Color | undefined {
+		const composite = NamedColors.get(value)
+		if (composite === undefined) {
+			return undefined
+		}
+		return fromCompositeRGB(composite)
+	}
+
 	/**
 	 * @param r A decimal within [0.0, 1.0].
 	 * @param g A decimal within [0.0, 1.0].
@@ -66,6 +74,17 @@ export namespace Color {
 	 */
 	export function fromIntRGB(r: number, g: number, b: number): Color {
 		return fromIntRGBA(r, g, b, 255)
+	}
+
+	/**
+	 * @param value A string in the format `#rrggbb`
+	 */
+	export function fromHexRGB(value: string): Color {
+		var bigint = parseInt(value.slice(1), 16)
+		var r = (bigint >> 16) & 255
+		var g = (bigint >> 8) & 255
+		var b = bigint & 255
+		return fromIntRGB(r, g, b)
 	}
 
 	/**
@@ -175,10 +194,10 @@ export namespace ColorPresentation {
 				}`
 			case ColorFormat.CompositeARGB:
 				return `${
-					Math.round(
-						((color[3] * 255) << 24) + ((color[0] * 255) << 16) + ((color[1] * 255) << 8)
-							+ color[2] * 255,
-					)
+					(BigInt(Math.round(color[3] * 255)) << 24n)
+					+ (BigInt(Math.round(color[0] * 255)) << 16n)
+					+ (BigInt(Math.round(color[1] * 255)) << 8n)
+					+ BigInt(Math.round(color[2] * 255))
 				}`
 		}
 	}

--- a/packages/core/src/processor/ColorInfoProvider.ts
+++ b/packages/core/src/processor/ColorInfoProvider.ts
@@ -71,16 +71,30 @@ export namespace Color {
 	/**
 	 * @param value `R << 16 + G << 8 + B`. Negative values result in white.
 	 */
-	export function fromCompositeInt(value: number): Color {
+	export function fromCompositeRGB(value: number): Color {
 		if (value < 0) {
 			return fromDecRGB(1.0, 1.0, 1.0)
 		}
 		const b = value % 256
-		value >>= 8
+		value >>>= 8
 		const g = value % 256
-		value >>= 8
+		value >>>= 8
 		const r = value % 256
 		return fromIntRGB(r, g, b)
+	}
+
+	/**
+	 * @param value `A << 24 + R << 16 + G << 8 + B`.
+	 */
+	export function fromCompositeARGB(value: number): Color {
+		const b = value % 256
+		value >>>= 8
+		const g = value % 256
+		value >>>= 8
+		const r = value % 256
+		value >>>= 8
+		const a = value % 256
+		return fromIntRGBA(r, g, b, a)
 	}
 }
 
@@ -112,7 +126,11 @@ export enum ColorFormat {
 	/**
 	 * `16620441`
 	 */
-	CompositeInt,
+	CompositeRGB,
+	/**
+	 * `4294945365`
+	 */
+	CompositeARGB,
 }
 
 export type FormattableColor = { value: Color; format: ColorFormat[]; range?: Range }
@@ -151,9 +169,16 @@ export namespace ColorPresentation {
 					Math.round(((color[0] * 255) << 16) + ((color[1] * 255) << 8) + color[2] * 255)
 						.toString(16).padStart(6, '0')
 				}`
-			case ColorFormat.CompositeInt:
+			case ColorFormat.CompositeRGB:
 				return `${
 					Math.round(((color[0] * 255) << 16) + ((color[1] * 255) << 8) + color[2] * 255)
+				}`
+			case ColorFormat.CompositeARGB:
+				return `${
+					Math.round(
+						((color[3] * 255) << 24) + ((color[0] * 255) << 16) + ((color[1] * 255) << 8)
+							+ color[2] * 255,
+					)
 				}`
 		}
 	}

--- a/packages/core/test/processor/ColorInfoProvider.spec.ts
+++ b/packages/core/test/processor/ColorInfoProvider.spec.ts
@@ -24,12 +24,17 @@ describe('Color', () => {
 			snapshot(Color.fromIntRGB(255, 191, 127))
 		})
 	})
-	describe('fromCompositeInt()', () => {
+	describe('fromCompositeRGB()', () => {
 		it('Should return correctly', () => {
-			snapshot(Color.fromCompositeInt(0xffaa55))
+			snapshot(Color.fromCompositeRGB(0xffaa55))
 		})
 		it('Should return white for negative number', () => {
-			assert.deepStrictEqual(Color.fromCompositeInt(-1), [1.0, 1.0, 1.0, 1.0])
+			assert.deepStrictEqual(Color.fromCompositeRGB(-1), [1.0, 1.0, 1.0, 1.0])
+		})
+	})
+	describe('fromCompositeARGB()', () => {
+		it('Should return correctly', () => {
+			snapshot(Color.fromCompositeARGB(0xeeffaa55))
 		})
 	})
 })

--- a/packages/java-edition/src/mcfunction/parser/argument.ts
+++ b/packages/java-edition/src/mcfunction/parser/argument.ts
@@ -150,7 +150,7 @@ export const argument: mcf.ArgumentParserGetter = (rawTreeNode): core.Parser | u
 					(res) => ({
 						...res,
 						color: core.Color.NamedColors.has(res.value)
-							? core.Color.fromCompositeInt(core.Color.NamedColors.get(res.value)!)
+							? core.Color.fromCompositeRGB(core.Color.NamedColors.get(res.value)!)
 							: undefined,
 					}),
 				),

--- a/packages/mcdoc/src/runtime/checker/error.ts
+++ b/packages/mcdoc/src/runtime/checker/error.ts
@@ -557,10 +557,10 @@ export function getDefaultErrorReporter<T>(
 				localizedText = localize(`mcdoc.runtime.checker.${defaultTranslationKey}`)
 				break
 			case 'internal':
-				break
+				return
 			default:
 				localizedText = localize(defaultTranslationKey)
 		}
-		ctx.err.report(localizedText!, getErrorRange(error.node, error.kind), severity)
+		ctx.err.report(localizedText, getErrorRange(error.node, error.kind), severity)
 	}
 }

--- a/packages/mcdoc/test/parser/index.spec.ts
+++ b/packages/mcdoc/test/parser/index.spec.ts
@@ -84,7 +84,7 @@ const Suites: Record<
 				'#[]',
 				'#[uuid]',
 				'#[since=1.17]',
-				'#[color=composite_int]',
+				'#[color=composite_rgb]',
 				'#[vector(dimension=3,integer=true)]',
 				'#[advancement_criterion=(type=definition,id=test)]',
 				'#[bitfield(enum (int) {})]',


### PR DESCRIPTION
- Closes #1269 

TODO:
- [ ] Fix autocomplete and weirdness with text component colors
- [ ] Implement `dec_rgba` (used in particles)

![image](https://github.com/SpyglassMC/Spyglass/assets/17352009/8007bf9f-3a01-49ae-b8e0-c7fa21e2a862)
