### PR TITLE
🔊 Remove quotes around logged URIs

### DIFF
--- a/packages/core/src/service/CacheService.ts
+++ b/packages/core/src/service/CacheService.ts
@@ -123,7 +123,7 @@ export class CacheService {
 		let filePath: string | undefined
 		try {
 			filePath = await this.getCacheFileUri()
-			this.project.logger.info(`[CacheService#load] symbolCachePath = “${filePath}”`)
+			this.project.logger.info(`[CacheService#load] symbolCachePath = ${filePath}`)
 			const cache =
 				(await fileUtil.readGzippedJson(this.project.externals, filePath)) as CacheFile
 			__profiler.task('Read File')
@@ -236,7 +236,7 @@ export class CacheService {
 
 			return true
 		} catch (e) {
-			this.project.logger.error(`[CacheService#save] path = “${filePath}”`, e)
+			this.project.logger.error(`[CacheService#save] path = ${filePath}`, e)
 		}
 		return false
 	}

--- a/packages/core/src/service/Downloader.ts
+++ b/packages/core/src/service/Downloader.ts
@@ -78,7 +78,7 @@ export class Downloader {
 							)
 							return ans
 						} catch (e) {
-							this.logger.error(`[Downloader] [${id}] Loading cached file “${cacheUri}”`, e)
+							this.logger.error(`[Downloader] [${id}] Loading cached file ${cacheUri}`, e)
 							if (this.externals.error.isKind(e, 'ENOENT')) {
 								// Cache checksum exists, but cached file doesn't.
 								// Remove the invalid cache checksum.
@@ -86,7 +86,7 @@ export class Downloader {
 									await this.externals.fs.unlink(cacheChecksumUri)
 								} catch (e) {
 									this.logger.error(
-										`[Downloader] [${id}] Removing invalid cache checksum “${cacheChecksumUri}”`,
+										`[Downloader] [${id}] Removing invalid cache checksum ${cacheChecksumUri}`,
 										e,
 									)
 								}
@@ -96,14 +96,14 @@ export class Downloader {
 				} catch (e) {
 					if (!this.externals.error.isKind(e, 'ENOENT')) {
 						this.logger.error(
-							`[Downloader] [${id}] Loading cache checksum “${cacheChecksumUri}”`,
+							`[Downloader] [${id}] Loading cache checksum ${cacheChecksumUri}`,
 							e,
 						)
 					}
 				}
 			} catch (e) {
 				this.logger.error(
-					`[Downloader] [${id}] Fetching latest checksum “${checksumJob.uri}”`,
+					`[Downloader] [${id}] Fetching latest checksum ${checksumJob.uri}`,
 					e,
 				)
 			}
@@ -120,7 +120,7 @@ export class Downloader {
 						await fileUtil.writeFile(this.externals, cacheChecksumUri, `${checksum}\n`)
 					} catch (e) {
 						this.logger.error(
-							`[Downloader] [${id}] Saving cache checksum “${cacheChecksumUri}”`,
+							`[Downloader] [${id}] Saving cache checksum ${cacheChecksumUri}`,
 							e,
 						)
 					}
@@ -129,23 +129,23 @@ export class Downloader {
 					const serializer = cache.serializer ?? ((b) => b)
 					await fileUtil.writeFile(this.externals, cacheUri, serializer(buffer))
 				} catch (e) {
-					this.logger.error(`[Downloader] [${id}] Caching file “${cacheUri}”`, e)
+					this.logger.error(`[Downloader] [${id}] Caching file ${cacheUri}`, e)
 				}
 			}
-			this.logger.info(`[Downloader] [${id}] Downloaded from “${uri}”`)
+			this.logger.info(`[Downloader] [${id}] Downloaded from ${uri}`)
 			return await transformer(buffer)
 		} catch (e) {
-			this.logger.error(`[Downloader] [${id}] Downloading “${uri}”`, e)
+			this.logger.error(`[Downloader] [${id}] Downloading ${uri}`, e)
 			if (cache && cacheUri) {
 				try {
 					const cachedBuffer = await fileUtil.readFile(this.externals, cacheUri)
 					const deserializer = cache.deserializer ?? ((b) => b)
 					const ans = await transformer(deserializer(cachedBuffer))
-					this.logger.warn(`[Downloader] [${id}] Fell back to cached file “${cacheUri}”`)
+					this.logger.warn(`[Downloader] [${id}] Fell back to cached file ${cacheUri}`)
 					return ans
 				} catch (e) {
 					this.logger.error(
-						`[Downloader] [${id}] Fallback: loading cached file “${cacheUri}”`,
+						`[Downloader] [${id}] Fallback: loading cached file ${cacheUri}`,
 						e,
 					)
 				}

--- a/packages/core/src/service/FileService.ts
+++ b/packages/core/src/service/FileService.ts
@@ -223,7 +223,7 @@ export class FileUriSupporter implements UriProtocolSupporter {
 					files.set(uri, await externals.fs.getAllFiles(uri))
 				}
 			} catch (e) {
-				logger.error(`[FileUriSupporter#create] Bad dependency “${uri}”`, e)
+				logger.error(`[FileUriSupporter#create] Bad dependency ${uri}`, e)
 			}
 		}
 
@@ -310,11 +310,11 @@ export class ArchiveUriSupporter implements UriProtocolSupporter {
 	 */
 	private static decodeUri(uri: Uri): { archiveName: string; pathInArchive: string } {
 		if (uri.protocol !== ArchiveUriSupporter.Protocol) {
-			throw new Error(`Expected protocol “${ArchiveUriSupporter.Protocol}” in “${uri}”`)
+			throw new Error(`Expected protocol “${ArchiveUriSupporter.Protocol}” in ${uri}`)
 		}
 		const path = uri.pathname
 		if (!path) {
-			throw new Error(`Missing path in archive uri “${uri.toString()}”`)
+			throw new Error(`Missing path in archive uri ${uri}`)
 		}
 		return { archiveName: uri.host, pathInArchive: path.charAt(0) === '/' ? path.slice(1) : path }
 	}
@@ -345,7 +345,7 @@ export class ArchiveUriSupporter implements UriProtocolSupporter {
 					entries.set(archiveName, new Map(files.map((f) => [f.path.replace(/\\/g, '/'), f])))
 				}
 			} catch (e) {
-				logger.error(`[SpyglassUriSupporter#create] Bad dependency “${uri}”`, e)
+				logger.error(`[SpyglassUriSupporter#create] Bad dependency ${uri}`, e)
 			}
 		}
 

--- a/packages/core/src/service/Project.ts
+++ b/packages/core/src/service/Project.ts
@@ -328,14 +328,15 @@ export class Project implements ExternalEventEmitter {
 
 		this.#ctx = {}
 
-		this.logger.info(`[Project] [init] cacheRoot = “${cacheRoot}”`)
+		this.logger.info(`[Project] [init] cacheRoot = ${cacheRoot}`)
+		this.logger.info(`[Project] [init] projectRoots = ${projectRoots.join(' ')}`)
 
 		this.#configService.on('changed', ({ config }) => {
 			this.config = config
 			this.logger.info('[Project] [Config] Changed')
 		}).on(
 			'error',
-			({ error, uri }) => this.logger.error(`[Project] [Config] Failed loading “${uri}”`, error),
+			({ error, uri }) => this.logger.error(`[Project] [Config] Failed loading ${uri}`, error),
 		)
 
 		this.setInitPromise()
@@ -674,7 +675,7 @@ export class Project implements ExternalEventEmitter {
 				const content = bufferToString(await this.fs.readFile(uri))
 				return TextDocument.create(uri, languageId, -1, content)
 			} catch (e) {
-				this.logger.warn(`[Project] [read] Failed creating TextDocument for “${uri}”`, e)
+				this.logger.warn(`[Project] [read] Failed creating TextDocument for ${uri}`, e)
 				return undefined
 			}
 		}
@@ -727,7 +728,7 @@ export class Project implements ExternalEventEmitter {
 				return result.doc
 			}
 			throw new Error(
-				`[Project] [read] Client-managed URI “${uri}” does not have a TextDocument in the cache`,
+				`[Project] [read] Client-managed URI ${uri} does not have a TextDocument in the cache`,
 			)
 		}
 		return getCacheHandlingPromise(uri)
@@ -767,7 +768,7 @@ export class Project implements ExternalEventEmitter {
 			this.#bindingInProgressUris.delete(doc.uri)
 			this.#symbolUpToDateUris.add(doc.uri)
 		} catch (e) {
-			this.logger.error(`[Project] [bind] Failed for “${doc.uri}” #${doc.version}`, e)
+			this.logger.error(`[Project] [bind] Failed for ${doc.uri} # ${doc.version}`, e)
 		}
 	}
 
@@ -786,7 +787,7 @@ export class Project implements ExternalEventEmitter {
 				this.lint(doc, node)
 			})
 		} catch (e) {
-			this.logger.error(`[Project] [check] Failed for “${doc.uri}” #${doc.version}`, e)
+			this.logger.error(`[Project] [check] Failed for ${doc.uri} # ${doc.version}`, e)
 		}
 	}
 
@@ -827,7 +828,7 @@ export class Project implements ExternalEventEmitter {
 				;(node.linterErrors as LanguageError[]).push(...ctx.err.dump())
 			}
 		} catch (e) {
-			this.logger.error(`[Project] [lint] Failed for “${doc.uri}” #${doc.version}`, e)
+			this.logger.error(`[Project] [lint] Failed for ${doc.uri} # ${doc.version}`, e)
 		}
 	}
 
@@ -903,9 +904,7 @@ export class Project implements ExternalEventEmitter {
 		const doc = this.#clientManagedDocAndNodes.get(uri)?.doc
 		if (!doc) {
 			throw new Error(
-				`TextDocument for “${uri}” is ${
-					!doc ? 'not cached' : 'a Promise'
-				}. This should not happen. Did the language client send a didChange notification without sending a didOpen one, or is there a logic error on our side resulting the 'read' function overriding the 'TextDocument' created in the 'didOpen' notification handler?`,
+				`TextDocument for ${uri} is not cached. This should not happen. Did the language client send a didChange notification without sending a didOpen one, or is there a logic error on our side resulting the 'read' function overriding the 'TextDocument' created in the 'didOpen' notification handler?`,
 			)
 		}
 		TextDocument.update(doc, changes, version)

--- a/packages/core/src/service/Service.ts
+++ b/packages/core/src/service/Service.ts
@@ -52,18 +52,18 @@ export class Service {
 
 	colorize(node: FileNode<AstNode>, doc: TextDocument, range?: Range): readonly ColorToken[] {
 		try {
-			this.debug(`Colorizing '${doc.uri}' # ${doc.version}`)
+			this.debug(`Colorizing ${doc.uri} # ${doc.version}`)
 			const colorizer = this.project.meta.getColorizer(node.type)
 			return colorizer(node, ColorizerContext.create(this.project, { doc, range }))
 		} catch (e) {
-			this.logger.error(`[Service] [colorize] Failed for “${doc.uri}” #${doc.version}`, e)
+			this.logger.error(`[Service] [colorize] Failed for ${doc.uri} # ${doc.version}`, e)
 		}
 		return []
 	}
 
 	getColorInfo(node: FileNode<AstNode>, doc: TextDocument): ColorInfo[] {
 		try {
-			this.debug(`Getting color info for '${doc.uri}' # ${doc.version}`)
+			this.debug(`Getting color info for ${doc.uri} # ${doc.version}`)
 			const ans: ColorInfo[] = []
 			traversePreOrder(
 				node,
@@ -77,7 +77,7 @@ export class Service {
 			)
 			return ans
 		} catch (e) {
-			this.logger.error(`[Service] [getColorInfo] Failed for “${doc.uri}” #${doc.version}`, e)
+			this.logger.error(`[Service] [getColorInfo] Failed for ${doc.uri} # ${doc.version}`, e)
 		}
 		return []
 	}
@@ -90,9 +90,7 @@ export class Service {
 	): ColorPresentation[] {
 		try {
 			this.debug(
-				`Getting color presentation for '${doc.uri}' # ${doc.version} @ ${
-					Range.toString(range)
-				}`,
+				`Getting color presentation for ${doc.uri} # ${doc.version} @ ${Range.toString(range)}`,
 			)
 			let node = AstNode.findDeepestChild({ node: file, needle: range.start })
 			while (node) {
@@ -107,7 +105,7 @@ export class Service {
 			}
 		} catch (e) {
 			this.logger.error(
-				`[Service] [getColorPresentation] Failed for “${doc.uri}” #${doc.version}`,
+				`[Service] [getColorPresentation] Failed for ${doc.uri} # ${doc.version}`,
 				e,
 			)
 		}
@@ -116,7 +114,7 @@ export class Service {
 
 	complete(node: FileNode<AstNode>, doc: TextDocument, offset: number, triggerCharacter?: string) {
 		try {
-			this.debug(`Getting completion for '${doc.uri}' # ${doc.version} @ ${offset}`)
+			this.debug(`Getting completion for ${doc.uri} # ${doc.version} @ ${offset}`)
 			const shouldComplete = this.project.meta.shouldComplete(doc.languageId, triggerCharacter)
 			if (shouldComplete) {
 				return completer.file(
@@ -125,7 +123,7 @@ export class Service {
 				)
 			}
 		} catch (e) {
-			this.logger.error(`[Service] [complete] Failed for “${doc.uri}” #${doc.version}`, e)
+			this.logger.error(`[Service] [complete] Failed for ${doc.uri} # ${doc.version}`, e)
 		}
 		return []
 	}
@@ -151,21 +149,21 @@ export class Service {
 
 	format(node: FileNode<AstNode>, doc: TextDocument, tabSize: number, insertSpaces: boolean) {
 		try {
-			this.debug(`Formatting '${doc.uri}' # ${doc.version}`)
+			this.debug(`Formatting ${doc.uri} # ${doc.version}`)
 			const formatter = this.project.meta.getFormatter(node.type)
 			return formatter(
 				node,
 				FormatterContext.create(this.project, { doc, tabSize, insertSpaces }),
 			)
 		} catch (e) {
-			this.logger.error(`[Service] [format] Failed for “${doc.uri}” #${doc.version}`, e)
+			this.logger.error(`[Service] [format] Failed for ${doc.uri} # ${doc.version}`, e)
 			throw e
 		}
 	}
 
 	getHover(file: FileNode<AstNode>, doc: TextDocument, offset: number): Hover | undefined {
 		try {
-			this.debug(`Getting hover for '${doc.uri}' # ${doc.version} @ ${offset}`)
+			this.debug(`Getting hover for ${doc.uri} # ${doc.version} @ ${offset}`)
 			let node = AstNode.findDeepestChild({ node: file, needle: offset })
 			while (node) {
 				const symbol = this.project.symbols.resolveAlias(node.symbol)
@@ -182,7 +180,7 @@ export class Service {
 				node = node.parent
 			}
 		} catch (e) {
-			this.logger.error(`[Service] [getHover] Failed for “${doc.uri}” #${doc.version}`, e)
+			this.logger.error(`[Service] [getHover] Failed for ${doc.uri} # ${doc.version}`, e)
 		}
 		return undefined
 	}
@@ -190,7 +188,7 @@ export class Service {
 	getInlayHints(node: FileNode<AstNode>, doc: TextDocument, range?: Range): InlayHint[] {
 		try {
 			// TODO: `range` argument is not used.
-			this.debug(`Getting inlay hints for '${doc.uri}' # ${doc.version}`)
+			this.debug(`Getting inlay hints for ${doc.uri} # ${doc.version}`)
 			const ans: InlayHint[] = []
 			const ctx = ProcessorContext.create(this.project, { doc })
 			for (const provider of this.project.meta.inlayHintProviders) {
@@ -198,7 +196,7 @@ export class Service {
 			}
 			return ans
 		} catch (e) {
-			this.logger.error(`[Service] [getInlayHints] Failed for “${doc.uri}” #${doc.version}`, e)
+			this.logger.error(`[Service] [getInlayHints] Failed for ${doc.uri} # ${doc.version}`, e)
 		}
 		return []
 	}
@@ -209,7 +207,7 @@ export class Service {
 		offset: number,
 	): SignatureHelp | undefined {
 		try {
-			this.debug(`Getting signature help for '${doc.uri}' # ${doc.version} @ ${offset}`)
+			this.debug(`Getting signature help for ${doc.uri} # ${doc.version} @ ${offset}`)
 			const ctx = SignatureHelpProviderContext.create(this.project, { doc, offset })
 			for (const provider of this.project.meta.signatureHelpProviders) {
 				const result = provider(node, ctx)
@@ -219,7 +217,7 @@ export class Service {
 			}
 		} catch (e) {
 			this.logger.error(
-				`[Service] [getSignatureHelp] Failed for “${doc.uri}” #${doc.version}`,
+				`[Service] [getSignatureHelp] Failed for ${doc.uri} # ${doc.version}`,
 				e,
 			)
 		}
@@ -243,7 +241,7 @@ export class Service {
 			this.debug(
 				`Getting symbol locations of usage '${
 					searchedUsages.join(',')
-				}' for '${doc.uri}' # ${doc.version} @ ${offset} with currentFileOnly=${currentFileOnly}`,
+				}' for ${doc.uri} # ${doc.version} @ ${offset} with currentFileOnly=${currentFileOnly}`,
 			)
 			let node = AstNode.findDeepestChild({ node: file, needle: offset })
 			while (node) {
@@ -272,7 +270,7 @@ export class Service {
 			}
 		} catch (e) {
 			this.logger.error(
-				`[Service] [getSymbolLocations] Failed for “${doc.uri}” #${doc.version}`,
+				`[Service] [getSymbolLocations] Failed for ${doc.uri} # ${doc.version}`,
 				e,
 			)
 		}

--- a/packages/core/test/utils.ts
+++ b/packages/core/test/utils.ts
@@ -278,7 +278,7 @@ export class SimpleProject {
 				node.binderErrors = ctx.err.dump()
 			})
 		} catch (e) {
-			throw new Error(format(`[bind] Failed for “${uri}”:`, e))
+			throw new Error(format(`[bind] Failed for ${uri}:`, e))
 		} finally {
 			this.#bindingInProgressUris.delete(uri)
 		}

--- a/packages/java-edition/src/index.ts
+++ b/packages/java-edition/src/index.ts
@@ -34,7 +34,7 @@ export const initialize: core.ProjectInitializer = async (ctx) => {
 		} catch (e) {
 			if (!externals.error.isKind(e, 'ENOENT')) {
 				// `pack.mcmeta` exists but broken. Log an error.
-				logger.error(`[je.initialize] Failed loading pack.mcmeta “${uri}”`, e)
+				logger.error(`[je.initialize] Failed loading pack.mcmeta ${uri}`, e)
 			}
 		}
 		return undefined
@@ -53,7 +53,7 @@ export const initialize: core.ProjectInitializer = async (ctx) => {
 					const data = await readPackMcmeta(uri)
 					if (data) {
 						logger.info(
-							`[je.initialize] Found a valid pack.mcmeta “${uri}” with pack_format “${data.pack.pack_format}”`,
+							`[je.initialize] Found a valid pack.mcmeta ${uri} with pack_format ${data.pack.pack_format}`,
 						)
 						return data
 					}


### PR DESCRIPTION
Vscode would underline these quotes and that meant you couldn't ctrl+click these uris as expected from the output log.

Also added a `projectRoots` log entry