### PR TITLE
🐛 Re-check client managed files after ready

### DIFF
--- a/packages/core/src/service/Project.ts
+++ b/packages/core/src/service/Project.ts
@@ -377,12 +377,17 @@ export class Project implements ExternalEventEmitter {
 			this.tryClearingCache(uri)
 		}).on('ready', () => {
 			this.#isReady = true
-			// // Recheck client managed files after the READY process, as they may have incomplete results and are user-facing.
-			// const promises: Promise<unknown>[] = []
-			// for (const { doc, node } of this.#clientManagedDocAndNodes.values()) {
-			// 	promises.push(this.check(doc, node))
-			// }
-			// Promise.all(promises).catch(e => this.logger.error('[Project#ready] Error occurred when rechecking client managed files after READY', e))
+			// Recheck client managed files after the READY process, as they may have incomplete results and are user-facing.
+			const promises: Promise<unknown>[] = []
+			for (const { doc, node } of this.#clientManagedDocAndNodes.values()) {
+				promises.push(this.check(doc, node))
+			}
+			Promise.all(promises).catch(e =>
+				this.logger.error(
+					'[Project#ready] Error occurred when rechecking client managed files after READY',
+					e,
+				)
+			)
 		})
 	}
 


### PR DESCRIPTION
This code was commented out in 5c3ce6cbc3492507c4d078aff4f47b3e595a5f4f by @SPGoding, but afaict nothing bad happens when I re-add it.

Files are re-checked, but unfortunately they aren't colorized nor do they get color information. Is there some way we can send that info to the client?

- Fixes #1510 
