### PR TITLE
🐛 Fix poor merge behavior of `Config` + overrides

### DIFF
--- a/__snapshots__/packages/core/test-out/service/Config.spec.js
+++ b/__snapshots__/packages/core/test-out/service/Config.spec.js
@@ -80,7 +80,67 @@ exports['ConfigService merge() Should merge nested overrides correctly 1'] = {
 exports['ConfigService merge() Should merge nested overrides correctly 2'] = {
   "env": {
     "dataSource": "GitHub",
+    "dependencies": [
+      "@vanilla-mcdoc"
+    ],
+    "feature": {}
+  },
+  "format": {},
+  "lint": {},
+  "snippet": {}
+}
+
+exports['ConfigService merge() Should merge nested overrides correctly 3'] = {
+  "env": {
+    "dataSource": "GitHub",
+    "dependencies": [
+      "@vanilla-mcdoc"
+    ],
+    "feature": {
+      "b": true
+    }
+  },
+  "format": {},
+  "lint": {},
+  "snippet": {}
+}
+
+exports['ConfigService merge() Should merge nested overrides correctly 4'] = {
+  "env": {
+    "dataSource": "GitHub",
+    "dependencies": [
+      "@vanilla-mcdoc"
+    ],
+    "feature": {
+      "b": true,
+      "c": 9
+    }
+  },
+  "format": {},
+  "lint": {},
+  "snippet": {}
+}
+
+exports['ConfigService merge() Should merge nested overrides correctly 5'] = {
+  "env": {
+    "dataSource": "GitHub",
     "dependencies": [],
+    "feature": {
+      "a": true,
+      "b": false
+    }
+  },
+  "format": {},
+  "lint": {},
+  "snippet": {}
+}
+
+exports['ConfigService merge() Should merge top-level overrides correctly 1'] = {
+  "env": {
+    "dataSource": "GitHub",
+    "dependencies": [
+      "@vanilla-mcdoc"
+    ],
     "feature": {
       "a": true,
       "b": false

--- a/__snapshots__/packages/core/test-out/service/Config.spec.js
+++ b/__snapshots__/packages/core/test-out/service/Config.spec.js
@@ -21,10 +21,7 @@ exports['ConfigService merge() Should merge empty overrides correctly 2'] = {
       "a": true,
       "b": false
     }
-  },
-  "format": {},
-  "lint": {},
-  "snippet": {}
+  }
 }
 
 exports['ConfigService merge() Should merge empty overrides correctly 3'] = {
@@ -37,10 +34,7 @@ exports['ConfigService merge() Should merge empty overrides correctly 3'] = {
       "a": true,
       "b": false
     }
-  },
-  "format": {},
-  "lint": {},
-  "snippet": {}
+  }
 }
 
 exports['ConfigService merge() Should merge multiple overrides correctly 1'] = {
@@ -55,10 +49,7 @@ exports['ConfigService merge() Should merge multiple overrides correctly 1'] = {
     },
     "foo": "qux",
     "erm": 3
-  },
-  "format": {},
-  "lint": {},
-  "snippet": {}
+  }
 }
 
 exports['ConfigService merge() Should merge nested overrides correctly 1'] = {
@@ -71,10 +62,7 @@ exports['ConfigService merge() Should merge nested overrides correctly 1'] = {
       "a": true,
       "b": false
     }
-  },
-  "format": {},
-  "lint": {},
-  "snippet": {}
+  }
 }
 
 exports['ConfigService merge() Should merge nested overrides correctly 2'] = {
@@ -83,11 +71,11 @@ exports['ConfigService merge() Should merge nested overrides correctly 2'] = {
     "dependencies": [
       "@vanilla-mcdoc"
     ],
-    "feature": {}
-  },
-  "format": {},
-  "lint": {},
-  "snippet": {}
+    "feature": {
+      "a": true,
+      "b": false
+    }
+  }
 }
 
 exports['ConfigService merge() Should merge nested overrides correctly 3'] = {
@@ -97,12 +85,10 @@ exports['ConfigService merge() Should merge nested overrides correctly 3'] = {
       "@vanilla-mcdoc"
     ],
     "feature": {
+      "a": true,
       "b": true
     }
-  },
-  "format": {},
-  "lint": {},
-  "snippet": {}
+  }
 }
 
 exports['ConfigService merge() Should merge nested overrides correctly 4'] = {
@@ -112,13 +98,11 @@ exports['ConfigService merge() Should merge nested overrides correctly 4'] = {
       "@vanilla-mcdoc"
     ],
     "feature": {
+      "a": true,
       "b": true,
       "c": 9
     }
-  },
-  "format": {},
-  "lint": {},
-  "snippet": {}
+  }
 }
 
 exports['ConfigService merge() Should merge nested overrides correctly 5'] = {
@@ -129,10 +113,7 @@ exports['ConfigService merge() Should merge nested overrides correctly 5'] = {
       "a": true,
       "b": false
     }
-  },
-  "format": {},
-  "lint": {},
-  "snippet": {}
+  }
 }
 
 exports['ConfigService merge() Should merge top-level overrides correctly 1'] = {
@@ -146,7 +127,5 @@ exports['ConfigService merge() Should merge top-level overrides correctly 1'] = 
       "b": false
     }
   },
-  "format": {},
-  "lint": {},
-  "snippet": {}
+  "test": true
 }

--- a/__snapshots__/packages/core/test-out/service/Config.spec.js
+++ b/__snapshots__/packages/core/test-out/service/Config.spec.js
@@ -1,0 +1,92 @@
+exports['ConfigService merge() Should merge empty overrides correctly 1'] = {
+  "env": {
+    "dataSource": "GitHub",
+    "dependencies": [
+      "@vanilla-mcdoc"
+    ],
+    "feature": {
+      "a": true,
+      "b": false
+    }
+  }
+}
+
+exports['ConfigService merge() Should merge empty overrides correctly 2'] = {
+  "env": {
+    "dataSource": "GitHub",
+    "dependencies": [
+      "@vanilla-mcdoc"
+    ],
+    "feature": {
+      "a": true,
+      "b": false
+    }
+  },
+  "format": {},
+  "lint": {},
+  "snippet": {}
+}
+
+exports['ConfigService merge() Should merge empty overrides correctly 3'] = {
+  "env": {
+    "dataSource": "GitHub",
+    "dependencies": [
+      "@vanilla-mcdoc"
+    ],
+    "feature": {
+      "a": true,
+      "b": false
+    }
+  },
+  "format": {},
+  "lint": {},
+  "snippet": {}
+}
+
+exports['ConfigService merge() Should merge multiple overrides correctly 1'] = {
+  "env": {
+    "dataSource": "TEST",
+    "dependencies": [
+      "@vanilla-mcdoc"
+    ],
+    "feature": {
+      "a": true,
+      "b": false
+    },
+    "foo": "qux",
+    "erm": 3
+  },
+  "format": {},
+  "lint": {},
+  "snippet": {}
+}
+
+exports['ConfigService merge() Should merge nested overrides correctly 1'] = {
+  "env": {
+    "dataSource": "TEST",
+    "dependencies": [
+      "@vanilla-mcdoc"
+    ],
+    "feature": {
+      "a": true,
+      "b": false
+    }
+  },
+  "format": {},
+  "lint": {},
+  "snippet": {}
+}
+
+exports['ConfigService merge() Should merge nested overrides correctly 2'] = {
+  "env": {
+    "dataSource": "GitHub",
+    "dependencies": [],
+    "feature": {
+      "a": true,
+      "b": false
+    }
+  },
+  "format": {},
+  "lint": {},
+  "snippet": {}
+}

--- a/packages/core/src/service/Config.ts
+++ b/packages/core/src/service/Config.ts
@@ -1,6 +1,6 @@
 import rfdc from 'rfdc'
 import type { ExternalEventEmitter } from '../common/index.js'
-import { Arrayable, bufferToString, TypePredicates } from '../common/index.js'
+import { Arrayable, bufferToString, merge, TypePredicates } from '../common/index.js'
 import { ErrorSeverity } from '../source/index.js'
 import { FileCategories, RegistryCategories } from '../symbol/index.js'
 import type { Project } from './Project.js'
@@ -493,13 +493,6 @@ export class ConfigService implements ExternalEventEmitter {
 	}
 
 	public static merge(base: Config, ...overrides: any[]): Config {
-		// FIXME
-		const ans = rfdc()(base)
-		for (const override of overrides) {
-			for (const key of ['env', 'format', 'lint', 'snippet'] as const) {
-				ans[key] = { ...ans[key], ...override[key] } as any
-			}
-		}
-		return ans
+		return overrides.reduce(merge, rfdc()(base))
 	}
 }

--- a/packages/core/test/service/Config.spec.ts
+++ b/packages/core/test/service/Config.spec.ts
@@ -31,8 +31,15 @@ describe('ConfigService', () => {
 			snapshot(ConfigService.merge(base, {}, {}))
 		})
 
+		it('Should merge top-level overrides correctly', async () => {
+			snapshot(ConfigService.merge(base, { test: true }))
+		})
+
 		it('Should merge nested overrides correctly', async () => {
 			snapshot(ConfigService.merge(base, { env: { dataSource: 'TEST' } }))
+			snapshot(ConfigService.merge(base, { env: { feature: {} } }))
+			snapshot(ConfigService.merge(base, { env: { feature: { b: true } } }))
+			snapshot(ConfigService.merge(base, { env: { feature: { b: true, c: 9 } } }))
 			snapshot(ConfigService.merge(base, { env: { dependencies: [] } }))
 		})
 

--- a/packages/core/test/service/Config.spec.ts
+++ b/packages/core/test/service/Config.spec.ts
@@ -1,0 +1,49 @@
+import assert from 'assert'
+import { describe, it } from 'mocha'
+import snapshot from 'snap-shot-it'
+import type { Config } from '../../lib/index.js'
+import { ConfigService } from '../../lib/index.js'
+
+describe('ConfigService', () => {
+	describe('merge()', () => {
+		const base = {
+			env: {
+				dataSource: 'GitHub',
+				dependencies: [
+					'@vanilla-mcdoc',
+				],
+				feature: {
+					a: true,
+					b: false,
+				},
+			},
+		} as unknown as Config
+
+		it('Should create a clone of the base object', async () => {
+			const merged = ConfigService.merge(base)
+			merged.env.dataSource = 'new string'
+			assert.notEqual(base.env.dataSource, merged.env.dataSource)
+		})
+
+		it('Should merge empty overrides correctly', async () => {
+			snapshot(ConfigService.merge(base))
+			snapshot(ConfigService.merge(base, {}))
+			snapshot(ConfigService.merge(base, {}, {}))
+		})
+
+		it('Should merge nested overrides correctly', async () => {
+			snapshot(ConfigService.merge(base, { env: { dataSource: 'TEST' } }))
+			snapshot(ConfigService.merge(base, { env: { dependencies: [] } }))
+		})
+
+		it('Should merge multiple overrides correctly', async () => {
+			snapshot(
+				ConfigService.merge(
+					base,
+					{ env: { dataSource: 'TEST', foo: 'bar' } },
+					{ env: { foo: 'qux', erm: 3 } },
+				),
+			)
+		})
+	})
+})


### PR DESCRIPTION
while working on https://github.com/SpyglassMC/Spyglass/issues/1517, i realized that if you specified an empty object for `feature: {}`, it would effectively delete all other `env.feature` config properties.

example:

```ts
const base = {
	env: {
		feature: {
			a: true,
			b: true,
		}
	}
}

const override = {
	env: {
		feature: {},
	}
}

const ans = ConfigService.merge(base, override)

// ans => `{ env: { feature: {} } }`
```

this is undesired behavior for a config system -- users should not need to specify every adjacent property to override a nested config setting

---

turns out there was an old `FIXME` to do this anyway. we have a `core.merge` method that behaves the way we want so I just hooked into it in this PR