### PR TITLE
🐛 Enable `usePolling` on Windows to fix file-lock

### DIFF
--- a/docs/user/config.adoc
+++ b/docs/user/config.adoc
@@ -42,7 +42,8 @@ There's no support for multiple config files or inheriting/overriding config fil
 		"language": "Default",
 		"permissionLevel": 2,
 		"plugins": [],
-		"mcmetaSummaryOverrides": {}
+		"mcmetaSummaryOverrides": {},
+		useFilePolling: false
 	},
 	"format": {
 		"blockStateBracketSpacing": { "inside": 0 },

--- a/packages/core/src/common/externals/NodeJsExternals.ts
+++ b/packages/core/src/common/externals/NodeJsExternals.ts
@@ -117,9 +117,9 @@ export const NodeJsExternals: Externals = {
 		unlink(location) {
 			return fsp.unlink(toFsPathLike(location))
 		},
-		watch(locations) {
+		watch(locations, { usePolling = false } = {}) {
 			return new ChokidarWatcherWrapper(
-				chokidar.watch(locations.map(toPath), { usePolling: process.platform === 'win32' }),
+				chokidar.watch(locations.map(toPath), { usePolling }),
 			)
 		},
 		writeFile(location, data, options) {

--- a/packages/core/src/common/externals/NodeJsExternals.ts
+++ b/packages/core/src/common/externals/NodeJsExternals.ts
@@ -118,7 +118,9 @@ export const NodeJsExternals: Externals = {
 			return fsp.unlink(toFsPathLike(location))
 		},
 		watch(locations) {
-			return new ChokidarWatcherWrapper(chokidar.watch(locations.map(toPath)))
+			return new ChokidarWatcherWrapper(
+				chokidar.watch(locations.map(toPath), { usePolling: process.platform === 'win32' }),
+			)
 		},
 		writeFile(location, data, options) {
 			return fsp.writeFile(toFsPathLike(location), data, options)

--- a/packages/core/src/common/externals/index.ts
+++ b/packages/core/src/common/externals/index.ts
@@ -71,7 +71,7 @@ export interface ExternalFileSystem {
 	showFile(path: FsLocation): Promise<void>
 	stat(location: FsLocation): Promise<{ isDirectory(): boolean; isFile(): boolean }>
 	unlink(location: FsLocation): Promise<void>
-	watch(locations: FsLocation[]): FsWatcher
+	watch(locations: FsLocation[], options: { usePolling?: boolean }): FsWatcher
 	/**
 	 * @param options `mode` - File mode bit mask (e.g. `0o775`).
 	 */

--- a/packages/core/src/service/Config.ts
+++ b/packages/core/src/service/Config.ts
@@ -115,6 +115,16 @@ export interface EnvConfig {
 	>
 	permissionLevel: 1 | 2 | 3 | 4
 	plugins: string[]
+	/**
+	 * Makes the file-watcher use polling to watch for file changes.
+	 * Comes at a performance cost for very large datapacks.
+	 *
+	 * On Windows, enabling this can fix file-lock issues when Spyglass is running.
+	 * See: https://github.com/SpyglassMC/Spyglass/issues/1414
+	 *
+	 * **You should only consider enabling this for Windows machines.**
+	 */
+	useFilePolling: boolean
 }
 
 export type LinterSeverity = 'hint' | 'information' | 'warning' | 'error'
@@ -352,6 +362,7 @@ export const VanillaConfig: Config = {
 		permissionLevel: 2,
 		plugins: [],
 		mcmetaSummaryOverrides: {},
+		useFilePolling: false,
 	},
 	format: {
 		blockStateBracketSpacing: { inside: 0 },

--- a/packages/core/src/service/Project.ts
+++ b/packages/core/src/service/Project.ts
@@ -511,7 +511,9 @@ export class Project implements ExternalEventEmitter {
 				}
 				this.#watchedFiles.clear()
 				this.#watcherReady = false
-				this.#watcher = this.externals.fs.watch(this.projectRoots).once('ready', () => {
+				this.#watcher = this.externals.fs.watch(this.projectRoots, {
+					usePolling: this.config.env.useFilePolling,
+				}).once('ready', () => {
 					this.#watcherReady = true
 					resolve()
 				}).on('add', (uri) => {


### PR DESCRIPTION
# Summary

- closes #1414 

There hasn't been a noticeable performance drop in my (fairly large) project so I think this solution is more than good enough 🤷 

(if anyone wants to do some performance checks on this in voice chat with me I'd be more than happy to. not entirely sure what to check other than speed at which a file is re-parsed upon changing)

## Preview

| before | after |
|-|-|
|![before renaming](https://github.com/user-attachments/assets/82ac9307-d19d-4e6d-b660-0779d8d42ead)|![after renaming](https://github.com/user-attachments/assets/bc793417-244f-458c-b949-7013b490f170)|