### PR TITLE
🐛 Fix completion inside unclosed records

### DIFF
--- a/__snapshots__/packages/core/test-out/parser/record.spec.js
+++ b/__snapshots__/packages/core/test-out/parser/record.spec.js
@@ -221,7 +221,11 @@ exports['record() record(no trailing comma) Parse "{ "foo" : "bar"   "baz" : "qu
           "quote": "\""
         }
       }
-    ]
+    ],
+    "innerRange": {
+      "start": 1,
+      "end": 32
+    }
   },
   "errors": [
     {
@@ -445,7 +449,11 @@ exports['record() record(no trailing comma) Parse "{ "foo" : "bar" , "baz" : "qu
           "end": 33
         }
       }
-    ]
+    ],
+    "innerRange": {
+      "start": 1,
+      "end": 34
+    }
   },
   "errors": [
     {
@@ -665,7 +673,11 @@ exports['record() record(no trailing comma) Parse "{ "foo" : "bar" , "baz" : "qu
           "quote": "\""
         }
       }
-    ]
+    ],
+    "innerRange": {
+      "start": 1,
+      "end": 32
+    }
   },
   "errors": []
 }
@@ -874,7 +886,11 @@ exports['record() record(no trailing comma) Parse "{ "foo" : "bar" , "baz" : }" 
           ]
         }
       }
-    ]
+    ],
+    "innerRange": {
+      "start": 1,
+      "end": 26
+    }
   },
   "errors": [
     {
@@ -1088,7 +1104,11 @@ exports['record() record(no trailing comma) Parse "{ "foo" : "bar" , "baz" }" 1'
           ]
         }
       }
-    ]
+    ],
+    "innerRange": {
+      "start": 1,
+      "end": 24
+    }
   },
   "errors": [
     {
@@ -1219,7 +1239,11 @@ exports['record() record(no trailing comma) Parse "{ "foo" : "bar" , }" 1'] = {
           "end": 17
         }
       }
-    ]
+    ],
+    "innerRange": {
+      "start": 1,
+      "end": 18
+    }
   },
   "errors": [
     {
@@ -1338,7 +1362,11 @@ exports['record() record(no trailing comma) Parse "{ "foo" : "bar" }" 1'] = {
           "quote": "\""
         }
       }
-    ]
+    ],
+    "innerRange": {
+      "start": 1,
+      "end": 16
+    }
   },
   "errors": []
 }
@@ -1446,7 +1474,11 @@ exports['record() record(no trailing comma) Parse "{ "foo" : }" 1'] = {
           ]
         }
       }
-    ]
+    ],
+    "innerRange": {
+      "start": 1,
+      "end": 10
+    }
   },
   "errors": [
     {
@@ -1559,7 +1591,11 @@ exports['record() record(no trailing comma) Parse "{ "foo" }" 1'] = {
           ]
         }
       }
-    ]
+    ],
+    "innerRange": {
+      "start": 1,
+      "end": 8
+    }
   },
   "errors": [
     {
@@ -1779,7 +1815,11 @@ exports['record() record(no trailing comma) Parse "{ , "foo" : "bar" }" 1'] = {
           "quote": "\""
         }
       }
-    ]
+    ],
+    "innerRange": {
+      "start": 1,
+      "end": 18
+    }
   },
   "errors": [
     {
@@ -1912,7 +1952,11 @@ exports['record() record(no trailing comma) Parse "{ : "bar" }" 1'] = {
           "quote": "\""
         }
       }
-    ]
+    ],
+    "innerRange": {
+      "start": 1,
+      "end": 10
+    }
   },
   "errors": [
     {
@@ -2027,7 +2071,11 @@ exports['record() record(no trailing comma) Parse "{ : }" 1'] = {
           ]
         }
       }
-    ]
+    ],
+    "innerRange": {
+      "start": 1,
+      "end": 4
+    }
   },
   "errors": [
     {
@@ -2056,7 +2104,11 @@ exports['record() record(no trailing comma) Parse "{ }" 1'] = {
       "start": 0,
       "end": 3
     },
-    "children": []
+    "children": [],
+    "innerRange": {
+      "start": 1,
+      "end": 2
+    }
   },
   "errors": []
 }
@@ -2068,7 +2120,11 @@ exports['record() record(no trailing comma) Parse "{" 1'] = {
       "start": 0,
       "end": 1
     },
-    "children": []
+    "children": [],
+    "innerRange": {
+      "start": 1,
+      "end": 1
+    }
   },
   "errors": [
     {
@@ -2292,7 +2348,11 @@ exports['record() record(trailing comma) Parse "{ "foo" : "bar" , "baz" : "qux" 
           "end": 33
         }
       }
-    ]
+    ],
+    "innerRange": {
+      "start": 1,
+      "end": 34
+    }
   },
   "errors": []
 }
@@ -2503,7 +2563,11 @@ exports['record() record(trailing comma) Parse "{ "foo" : "bar" , "baz" : "qux" 
           "quote": "\""
         }
       }
-    ]
+    ],
+    "innerRange": {
+      "start": 1,
+      "end": 32
+    }
   },
   "errors": []
 }
@@ -2617,7 +2681,11 @@ exports['record() record(trailing comma) Parse "{ "foo" : "bar" , }" 1'] = {
           "end": 17
         }
       }
-    ]
+    ],
+    "innerRange": {
+      "start": 1,
+      "end": 18
+    }
   },
   "errors": []
 }
@@ -2727,7 +2795,11 @@ exports['record() record(trailing comma) Parse "{ "foo" : "bar" }" 1'] = {
           "quote": "\""
         }
       }
-    ]
+    ],
+    "innerRange": {
+      "start": 1,
+      "end": 16
+    }
   },
   "errors": []
 }

--- a/__snapshots__/packages/java-edition/test-out/mcfunction/parser/argument/minecraftBlockPredicate.spec.js
+++ b/__snapshots__/packages/java-edition/test-out/mcfunction/parser/argument/minecraftBlockPredicate.spec.js
@@ -139,7 +139,11 @@ exports['mcfunction argument minecraft:block_predicate Parse "#stone[foo=bar]{ba
             ]
           }
         }
-      ]
+      ],
+      "innerRange": {
+        "start": 7,
+        "end": 14
+      }
     },
     "nbt": {
       "type": "nbt:compound",
@@ -241,7 +245,11 @@ exports['mcfunction argument minecraft:block_predicate Parse "#stone[foo=bar]{ba
             ]
           }
         }
-      ]
+      ],
+      "innerRange": {
+        "start": 16,
+        "end": 23
+      }
     },
     "isPredicate": true
   },
@@ -410,7 +418,11 @@ exports['mcfunction argument minecraft:block_predicate Parse "stone[foo=bar]" 1'
             ]
           }
         }
-      ]
+      ],
+      "innerRange": {
+        "start": 6,
+        "end": 13
+      }
     },
     "isPredicate": true
   },

--- a/__snapshots__/packages/java-edition/test-out/mcfunction/parser/argument/minecraftBlockState.spec.js
+++ b/__snapshots__/packages/java-edition/test-out/mcfunction/parser/argument/minecraftBlockState.spec.js
@@ -115,7 +115,11 @@ exports['mcfunction argument minecraft:block_state Parse "foo{bar:baz}" 1'] = {
             ]
           }
         }
-      ]
+      ],
+      "innerRange": {
+        "start": 4,
+        "end": 11
+      }
     },
     "isPredicate": false
   },
@@ -284,7 +288,11 @@ exports['mcfunction argument minecraft:block_state Parse "stone[foo=bar]" 1'] = 
             ]
           }
         }
-      ]
+      ],
+      "innerRange": {
+        "start": 6,
+        "end": 13
+      }
     },
     "isPredicate": false
   },

--- a/__snapshots__/packages/java-edition/test-out/mcfunction/parser/argument/minecraftComponent.spec.js
+++ b/__snapshots__/packages/java-edition/test-out/mcfunction/parser/argument/minecraftComponent.spec.js
@@ -263,7 +263,11 @@ exports['mcfunction argument minecraft:component Parse "{"text":"hello world"}" 
               "quote": "\""
             }
           }
-        ]
+        ],
+        "innerRange": {
+          "start": 1,
+          "end": 21
+        }
       }
     ],
     "targetType": {

--- a/__snapshots__/packages/java-edition/test-out/mcfunction/parser/argument/minecraftEntity.spec.js
+++ b/__snapshots__/packages/java-edition/test-out/mcfunction/parser/argument/minecraftEntity.spec.js
@@ -88,7 +88,11 @@ exports['mcfunction argument minecraft:entity Parse "@a[ ]" with {"amount":"mult
             "start": 2,
             "end": 5
           },
-          "children": []
+          "children": [],
+          "innerRange": {
+            "start": 3,
+            "end": 4
+          }
         }
       ],
       "variable": "a",
@@ -98,7 +102,11 @@ exports['mcfunction argument minecraft:entity Parse "@a[ ]" with {"amount":"mult
           "start": 2,
           "end": 5
         },
-        "children": []
+        "children": [],
+        "innerRange": {
+          "start": 3,
+          "end": 4
+        }
       },
       "currentEntity": false,
       "playersOnly": true,
@@ -312,7 +320,11 @@ exports['mcfunction argument minecraft:entity Parse "@a[ advancements = { minecr
                                 "end": 74
                               }
                             }
-                          ]
+                          ],
+                          "innerRange": {
+                            "start": 61,
+                            "end": 75
+                          }
                         }
                       ],
                       "key": {
@@ -386,14 +398,22 @@ exports['mcfunction argument minecraft:entity Parse "@a[ advancements = { minecr
                               "end": 74
                             }
                           }
-                        ]
+                        ],
+                        "innerRange": {
+                          "start": 61,
+                          "end": 75
+                        }
                       },
                       "end": {
                         "start": 77,
                         "end": 78
                       }
                     }
-                  ]
+                  ],
+                  "innerRange": {
+                    "start": 20,
+                    "end": 79
+                  }
                 }
               ],
               "key": {
@@ -566,7 +586,11 @@ exports['mcfunction argument minecraft:entity Parse "@a[ advancements = { minecr
                               "end": 74
                             }
                           }
-                        ]
+                        ],
+                        "innerRange": {
+                          "start": 61,
+                          "end": 75
+                        }
                       }
                     ],
                     "key": {
@@ -640,21 +664,33 @@ exports['mcfunction argument minecraft:entity Parse "@a[ advancements = { minecr
                             "end": 74
                           }
                         }
-                      ]
+                      ],
+                      "innerRange": {
+                        "start": 61,
+                        "end": 75
+                      }
                     },
                     "end": {
                       "start": 77,
                       "end": 78
                     }
                   }
-                ]
+                ],
+                "innerRange": {
+                  "start": 20,
+                  "end": 79
+                }
               },
               "end": {
                 "start": 81,
                 "end": 82
               }
             }
-          ]
+          ],
+          "innerRange": {
+            "start": 3,
+            "end": 83
+          }
         }
       ],
       "variable": "a",
@@ -838,7 +874,11 @@ exports['mcfunction argument minecraft:entity Parse "@a[ advancements = { minecr
                               "end": 74
                             }
                           }
-                        ]
+                        ],
+                        "innerRange": {
+                          "start": 61,
+                          "end": 75
+                        }
                       }
                     ],
                     "key": {
@@ -912,14 +952,22 @@ exports['mcfunction argument minecraft:entity Parse "@a[ advancements = { minecr
                             "end": 74
                           }
                         }
-                      ]
+                      ],
+                      "innerRange": {
+                        "start": 61,
+                        "end": 75
+                      }
                     },
                     "end": {
                       "start": 77,
                       "end": 78
                     }
                   }
-                ]
+                ],
+                "innerRange": {
+                  "start": 20,
+                  "end": 79
+                }
               }
             ],
             "key": {
@@ -1092,7 +1140,11 @@ exports['mcfunction argument minecraft:entity Parse "@a[ advancements = { minecr
                             "end": 74
                           }
                         }
-                      ]
+                      ],
+                      "innerRange": {
+                        "start": 61,
+                        "end": 75
+                      }
                     }
                   ],
                   "key": {
@@ -1166,21 +1218,33 @@ exports['mcfunction argument minecraft:entity Parse "@a[ advancements = { minecr
                           "end": 74
                         }
                       }
-                    ]
+                    ],
+                    "innerRange": {
+                      "start": 61,
+                      "end": 75
+                    }
                   },
                   "end": {
                     "start": 77,
                     "end": 78
                   }
                 }
-              ]
+              ],
+              "innerRange": {
+                "start": 20,
+                "end": 79
+              }
             },
             "end": {
               "start": 81,
               "end": 82
             }
           }
-        ]
+        ],
+        "innerRange": {
+          "start": 3,
+          "end": 83
+        }
       },
       "currentEntity": false,
       "playersOnly": true,
@@ -1264,7 +1328,11 @@ exports['mcfunction argument minecraft:entity Parse "@a[ advancements = { } , ad
                     "start": 19,
                     "end": 22
                   },
-                  "children": []
+                  "children": [],
+                  "innerRange": {
+                    "start": 20,
+                    "end": 21
+                  }
                 }
               ],
               "key": {
@@ -1307,7 +1375,11 @@ exports['mcfunction argument minecraft:entity Parse "@a[ advancements = { } , ad
                   "start": 19,
                   "end": 22
                 },
-                "children": []
+                "children": [],
+                "innerRange": {
+                  "start": 20,
+                  "end": 21
+                }
               },
               "end": {
                 "start": 23,
@@ -1357,7 +1429,11 @@ exports['mcfunction argument minecraft:entity Parse "@a[ advancements = { } , ad
                     "start": 40,
                     "end": 43
                   },
-                  "children": []
+                  "children": [],
+                  "innerRange": {
+                    "start": 41,
+                    "end": 42
+                  }
                 }
               ],
               "key": {
@@ -1400,14 +1476,22 @@ exports['mcfunction argument minecraft:entity Parse "@a[ advancements = { } , ad
                   "start": 40,
                   "end": 43
                 },
-                "children": []
+                "children": [],
+                "innerRange": {
+                  "start": 41,
+                  "end": 42
+                }
               },
               "end": {
                 "start": 44,
                 "end": 45
               }
             }
-          ]
+          ],
+          "innerRange": {
+            "start": 3,
+            "end": 46
+          }
         }
       ],
       "variable": "a",
@@ -1461,7 +1545,11 @@ exports['mcfunction argument minecraft:entity Parse "@a[ advancements = { } , ad
                   "start": 19,
                   "end": 22
                 },
-                "children": []
+                "children": [],
+                "innerRange": {
+                  "start": 20,
+                  "end": 21
+                }
               }
             ],
             "key": {
@@ -1504,7 +1592,11 @@ exports['mcfunction argument minecraft:entity Parse "@a[ advancements = { } , ad
                 "start": 19,
                 "end": 22
               },
-              "children": []
+              "children": [],
+              "innerRange": {
+                "start": 20,
+                "end": 21
+              }
             },
             "end": {
               "start": 23,
@@ -1554,7 +1646,11 @@ exports['mcfunction argument minecraft:entity Parse "@a[ advancements = { } , ad
                   "start": 40,
                   "end": 43
                 },
-                "children": []
+                "children": [],
+                "innerRange": {
+                  "start": 41,
+                  "end": 42
+                }
               }
             ],
             "key": {
@@ -1597,14 +1693,22 @@ exports['mcfunction argument minecraft:entity Parse "@a[ advancements = { } , ad
                 "start": 40,
                 "end": 43
               },
-              "children": []
+              "children": [],
+              "innerRange": {
+                "start": 41,
+                "end": 42
+              }
             },
             "end": {
               "start": 44,
               "end": 45
             }
           }
-        ]
+        ],
+        "innerRange": {
+          "start": 3,
+          "end": 46
+        }
       },
       "currentEntity": false,
       "playersOnly": true,
@@ -1940,7 +2044,11 @@ exports['mcfunction argument minecraft:entity Parse "@a[ distance = ..-1 , dista
                 "end": 39
               }
             }
-          ]
+          ],
+          "innerRange": {
+            "start": 3,
+            "end": 40
+          }
         }
       ],
       "variable": "a",
@@ -2237,7 +2345,11 @@ exports['mcfunction argument minecraft:entity Parse "@a[ distance = ..-1 , dista
               "end": 39
             }
           }
-        ]
+        ],
+        "innerRange": {
+          "start": 3,
+          "end": 40
+        }
       },
       "chunkLimited": false,
       "currentEntity": false,
@@ -2432,7 +2544,11 @@ exports['mcfunction argument minecraft:entity Parse "@a[ distance = ..1 , ]" wit
                 "end": 20
               }
             }
-          ]
+          ],
+          "innerRange": {
+            "start": 3,
+            "end": 21
+          }
         }
       ],
       "variable": "a",
@@ -2578,7 +2694,11 @@ exports['mcfunction argument minecraft:entity Parse "@a[ distance = ..1 , ]" wit
               "end": 20
             }
           }
-        ]
+        ],
+        "innerRange": {
+          "start": 3,
+          "end": 21
+        }
       },
       "chunkLimited": false,
       "currentEntity": false,
@@ -3087,7 +3207,11 @@ exports['mcfunction argument minecraft:entity Parse "@a[ gamemode = ! creative ,
                 "end": 52
               }
             }
-          ]
+          ],
+          "innerRange": {
+            "start": 3,
+            "end": 53
+          }
         }
       ],
       "variable": "a",
@@ -3564,7 +3688,11 @@ exports['mcfunction argument minecraft:entity Parse "@a[ gamemode = ! creative ,
               "end": 52
             }
           }
-        ]
+        ],
+        "innerRange": {
+          "start": 3,
+          "end": 53
+        }
       },
       "currentEntity": false,
       "playersOnly": true,
@@ -4039,7 +4167,11 @@ exports['mcfunction argument minecraft:entity Parse "@a[ gamemode = creative , g
                 "end": 46
               }
             }
-          ]
+          ],
+          "innerRange": {
+            "start": 3,
+            "end": 47
+          }
         }
       ],
       "variable": "a",
@@ -4484,7 +4616,11 @@ exports['mcfunction argument minecraft:entity Parse "@a[ gamemode = creative , g
               "end": 46
             }
           }
-        ]
+        ],
+        "innerRange": {
+          "start": 3,
+          "end": 47
+        }
       },
       "currentEntity": false,
       "playersOnly": true,
@@ -4780,7 +4916,11 @@ exports['mcfunction argument minecraft:entity Parse "@a[ level = -1 , level = -1
                 "end": 29
               }
             }
-          ]
+          ],
+          "innerRange": {
+            "start": 3,
+            "end": 30
+          }
         }
       ],
       "variable": "a",
@@ -5029,7 +5169,11 @@ exports['mcfunction argument minecraft:entity Parse "@a[ level = -1 , level = -1
               "end": 29
             }
           }
-        ]
+        ],
+        "innerRange": {
+          "start": 3,
+          "end": 30
+        }
       },
       "currentEntity": false,
       "playersOnly": true,
@@ -5230,7 +5374,11 @@ exports['mcfunction argument minecraft:entity Parse "@a[ level = 1.. , ]" with {
                 "end": 17
               }
             }
-          ]
+          ],
+          "innerRange": {
+            "start": 3,
+            "end": 18
+          }
         }
       ],
       "variable": "a",
@@ -5376,7 +5524,11 @@ exports['mcfunction argument minecraft:entity Parse "@a[ level = 1.. , ]" with {
               "end": 17
             }
           }
-        ]
+        ],
+        "innerRange": {
+          "start": 3,
+          "end": 18
+        }
       },
       "currentEntity": false,
       "playersOnly": true,
@@ -5510,7 +5662,11 @@ exports['mcfunction argument minecraft:entity Parse "@a[ limit = 1 , ]" with {"a
                 "end": 15
               }
             }
-          ]
+          ],
+          "innerRange": {
+            "start": 3,
+            "end": 16
+          }
         }
       ],
       "variable": "a",
@@ -5614,7 +5770,11 @@ exports['mcfunction argument minecraft:entity Parse "@a[ limit = 1 , ]" with {"a
               "end": 15
             }
           }
-        ]
+        ],
+        "innerRange": {
+          "start": 3,
+          "end": 16
+        }
       },
       "currentEntity": false,
       "playersOnly": true,
@@ -6242,7 +6402,11 @@ exports['mcfunction argument minecraft:entity Parse "@a[ name = ! "SPGoding" , "
                 "end": 58
               }
             }
-          ]
+          ],
+          "innerRange": {
+            "start": 3,
+            "end": 59
+          }
         }
       ],
       "variable": "a",
@@ -6840,7 +7004,11 @@ exports['mcfunction argument minecraft:entity Parse "@a[ name = ! "SPGoding" , "
               "end": 58
             }
           }
-        ]
+        ],
+        "innerRange": {
+          "start": 3,
+          "end": 59
+        }
       },
       "currentEntity": false,
       "playersOnly": true,
@@ -7420,7 +7588,11 @@ exports['mcfunction argument minecraft:entity Parse "@a[ name = "SPGoding" , "na
                 "end": 52
               }
             }
-          ]
+          ],
+          "innerRange": {
+            "start": 3,
+            "end": 53
+          }
         }
       ],
       "variable": "a",
@@ -7970,7 +8142,11 @@ exports['mcfunction argument minecraft:entity Parse "@a[ name = "SPGoding" , "na
               "end": 52
             }
           }
-        ]
+        ],
+        "innerRange": {
+          "start": 3,
+          "end": 53
+        }
       },
       "currentEntity": false,
       "playersOnly": true,
@@ -8078,7 +8254,11 @@ exports['mcfunction argument minecraft:entity Parse "@a[ nbt = {} , ]" with {"am
                         "start": 10,
                         "end": 12
                       },
-                      "children": []
+                      "children": [],
+                      "innerRange": {
+                        "start": 11,
+                        "end": 11
+                      }
                     }
                   ],
                   "inverted": false,
@@ -8088,7 +8268,11 @@ exports['mcfunction argument minecraft:entity Parse "@a[ nbt = {} , ]" with {"am
                       "start": 10,
                       "end": 12
                     },
-                    "children": []
+                    "children": [],
+                    "innerRange": {
+                      "start": 11,
+                      "end": 11
+                    }
                   }
                 }
               ],
@@ -8139,7 +8323,11 @@ exports['mcfunction argument minecraft:entity Parse "@a[ nbt = {} , ]" with {"am
                       "start": 10,
                       "end": 12
                     },
-                    "children": []
+                    "children": [],
+                    "innerRange": {
+                      "start": 11,
+                      "end": 11
+                    }
                   }
                 ],
                 "inverted": false,
@@ -8149,7 +8337,11 @@ exports['mcfunction argument minecraft:entity Parse "@a[ nbt = {} , ]" with {"am
                     "start": 10,
                     "end": 12
                   },
-                  "children": []
+                  "children": [],
+                  "innerRange": {
+                    "start": 11,
+                    "end": 11
+                  }
                 }
               },
               "end": {
@@ -8157,7 +8349,11 @@ exports['mcfunction argument minecraft:entity Parse "@a[ nbt = {} , ]" with {"am
                 "end": 14
               }
             }
-          ]
+          ],
+          "innerRange": {
+            "start": 3,
+            "end": 15
+          }
         }
       ],
       "variable": "a",
@@ -8218,7 +8414,11 @@ exports['mcfunction argument minecraft:entity Parse "@a[ nbt = {} , ]" with {"am
                       "start": 10,
                       "end": 12
                     },
-                    "children": []
+                    "children": [],
+                    "innerRange": {
+                      "start": 11,
+                      "end": 11
+                    }
                   }
                 ],
                 "inverted": false,
@@ -8228,7 +8428,11 @@ exports['mcfunction argument minecraft:entity Parse "@a[ nbt = {} , ]" with {"am
                     "start": 10,
                     "end": 12
                   },
-                  "children": []
+                  "children": [],
+                  "innerRange": {
+                    "start": 11,
+                    "end": 11
+                  }
                 }
               }
             ],
@@ -8279,7 +8483,11 @@ exports['mcfunction argument minecraft:entity Parse "@a[ nbt = {} , ]" with {"am
                     "start": 10,
                     "end": 12
                   },
-                  "children": []
+                  "children": [],
+                  "innerRange": {
+                    "start": 11,
+                    "end": 11
+                  }
                 }
               ],
               "inverted": false,
@@ -8289,7 +8497,11 @@ exports['mcfunction argument minecraft:entity Parse "@a[ nbt = {} , ]" with {"am
                   "start": 10,
                   "end": 12
                 },
-                "children": []
+                "children": [],
+                "innerRange": {
+                  "start": 11,
+                  "end": 11
+                }
               }
             },
             "end": {
@@ -8297,7 +8509,11 @@ exports['mcfunction argument minecraft:entity Parse "@a[ nbt = {} , ]" with {"am
               "end": 14
             }
           }
-        ]
+        ],
+        "innerRange": {
+          "start": 3,
+          "end": 15
+        }
       },
       "currentEntity": false,
       "playersOnly": true,
@@ -8636,7 +8852,11 @@ exports['mcfunction argument minecraft:entity Parse "@a[ predicate = spgoding:fo
                 "end": 59
               }
             }
-          ]
+          ],
+          "innerRange": {
+            "start": 3,
+            "end": 60
+          }
         }
       ],
       "variable": "a",
@@ -8945,7 +9165,11 @@ exports['mcfunction argument minecraft:entity Parse "@a[ predicate = spgoding:fo
               "end": 59
             }
           }
-        ]
+        ],
+        "innerRange": {
+          "start": 3,
+          "end": 60
+        }
       },
       "currentEntity": false,
       "playersOnly": true,
@@ -9075,7 +9299,11 @@ exports['mcfunction argument minecraft:entity Parse "@a[limit=1]" with {"amount"
                 "value": 1
               }
             }
-          ]
+          ],
+          "innerRange": {
+            "start": 3,
+            "end": 10
+          }
         }
       ],
       "variable": "a",
@@ -9175,7 +9403,11 @@ exports['mcfunction argument minecraft:entity Parse "@a[limit=1]" with {"amount"
               "value": 1
             }
           }
-        ]
+        ],
+        "innerRange": {
+          "start": 3,
+          "end": 10
+        }
       },
       "currentEntity": false,
       "playersOnly": true,
@@ -9396,7 +9628,11 @@ exports['mcfunction argument minecraft:entity Parse "@e[limit=1]" with {"amount"
                 "value": 1
               }
             }
-          ]
+          ],
+          "innerRange": {
+            "start": 3,
+            "end": 10
+          }
         }
       ],
       "variable": "e",
@@ -9496,7 +9732,11 @@ exports['mcfunction argument minecraft:entity Parse "@e[limit=1]" with {"amount"
               "value": 1
             }
           }
-        ]
+        ],
+        "innerRange": {
+          "start": 3,
+          "end": 10
+        }
       },
       "currentEntity": false,
       "playersOnly": false,
@@ -9682,7 +9922,11 @@ exports['mcfunction argument minecraft:entity Parse "@e[type=foo]" with {"amount
                 }
               }
             }
-          ]
+          ],
+          "innerRange": {
+            "start": 3,
+            "end": 11
+          }
         }
       ],
       "variable": "e",
@@ -9826,7 +10070,11 @@ exports['mcfunction argument minecraft:entity Parse "@e[type=foo]" with {"amount
               }
             }
           }
-        ]
+        ],
+        "innerRange": {
+          "start": 3,
+          "end": 11
+        }
       },
       "currentEntity": false,
       "playersOnly": false,
@@ -10078,7 +10326,11 @@ exports['mcfunction argument minecraft:entity Parse "@n[distance=..5]" with {"am
                 ]
               }
             }
-          ]
+          ],
+          "innerRange": {
+            "start": 3,
+            "end": 15
+          }
         }
       ],
       "variable": "n",
@@ -10220,7 +10472,11 @@ exports['mcfunction argument minecraft:entity Parse "@n[distance=..5]" with {"am
               ]
             }
           }
-        ]
+        ],
+        "innerRange": {
+          "start": 3,
+          "end": 15
+        }
       },
       "chunkLimited": true,
       "currentEntity": false,
@@ -10403,7 +10659,11 @@ exports['mcfunction argument minecraft:entity Parse "@n[distance=..5]" with {"am
                 ]
               }
             }
-          ]
+          ],
+          "innerRange": {
+            "start": 3,
+            "end": 15
+          }
         }
       ],
       "variable": "n",
@@ -10545,7 +10805,11 @@ exports['mcfunction argument minecraft:entity Parse "@n[distance=..5]" with {"am
               ]
             }
           }
-        ]
+        ],
+        "innerRange": {
+          "start": 3,
+          "end": 15
+        }
       },
       "chunkLimited": true,
       "currentEntity": false,
@@ -10721,7 +10985,11 @@ exports['mcfunction argument minecraft:entity Parse "@n[type=cow]" with {"amount
                 }
               }
             }
-          ]
+          ],
+          "innerRange": {
+            "start": 3,
+            "end": 11
+          }
         }
       ],
       "variable": "n",
@@ -10865,7 +11133,11 @@ exports['mcfunction argument minecraft:entity Parse "@n[type=cow]" with {"amount
               }
             }
           }
-        ]
+        ],
+        "innerRange": {
+          "start": 3,
+          "end": 11
+        }
       },
       "currentEntity": false,
       "playersOnly": false,
@@ -11048,7 +11320,11 @@ exports['mcfunction argument minecraft:entity Parse "@n[type=cow]" with {"amount
                 }
               }
             }
-          ]
+          ],
+          "innerRange": {
+            "start": 3,
+            "end": 11
+          }
         }
       ],
       "variable": "n",
@@ -11192,7 +11468,11 @@ exports['mcfunction argument minecraft:entity Parse "@n[type=cow]" with {"amount
               }
             }
           }
-        ]
+        ],
+        "innerRange": {
+          "start": 3,
+          "end": 11
+        }
       },
       "currentEntity": false,
       "playersOnly": false,
@@ -11453,7 +11733,11 @@ exports['mcfunction argument minecraft:entity Parse "@s[ limit = 0 , limit = 0 ,
                 "end": 27
               }
             }
-          ]
+          ],
+          "innerRange": {
+            "start": 3,
+            "end": 28
+          }
         }
       ],
       "variable": "s",
@@ -11650,7 +11934,11 @@ exports['mcfunction argument minecraft:entity Parse "@s[ limit = 0 , limit = 0 ,
               "end": 27
             }
           }
-        ]
+        ],
+        "innerRange": {
+          "start": 3,
+          "end": 28
+        }
       },
       "currentEntity": true,
       "playersOnly": false,

--- a/__snapshots__/packages/java-edition/test-out/mcfunction/parser/argument/minecraftItemPredicate.spec.js
+++ b/__snapshots__/packages/java-edition/test-out/mcfunction/parser/argument/minecraftItemPredicate.spec.js
@@ -138,7 +138,11 @@ exports['mcfunction argument minecraft:item_predicate Parse "#stick{foo:bar}" 1'
             ]
           }
         }
-      ]
+      ],
+      "innerRange": {
+        "start": 7,
+        "end": 14
+      }
     }
   },
   "errors": []

--- a/__snapshots__/packages/java-edition/test-out/mcfunction/parser/argument/minecraftItemStack.spec.js
+++ b/__snapshots__/packages/java-edition/test-out/mcfunction/parser/argument/minecraftItemStack.spec.js
@@ -51,7 +51,11 @@ exports['mcfunction argument minecraft:item_stack Parse "apple[!food]" in versio
             ]
           }
         }
-      ]
+      ],
+      "innerRange": {
+        "start": 6,
+        "end": 11
+      }
     }
   },
   "errors": [
@@ -151,7 +155,11 @@ exports['mcfunction argument minecraft:item_stack Parse "apple[!food]" in versio
             ]
           }
         }
-      ]
+      ],
+      "innerRange": {
+        "start": 6,
+        "end": 11
+      }
     }
   },
   "errors": []
@@ -204,7 +212,11 @@ exports['mcfunction argument minecraft:item_stack Parse "diamond_pickaxe[unbreak
                 "start": 28,
                 "end": 30
               },
-              "children": []
+              "children": [],
+              "innerRange": {
+                "start": 29,
+                "end": 29
+              }
             }
           ],
           "key": {
@@ -223,7 +235,11 @@ exports['mcfunction argument minecraft:item_stack Parse "diamond_pickaxe[unbreak
               "start": 28,
               "end": 30
             },
-            "children": []
+            "children": [],
+            "innerRange": {
+              "start": 29,
+              "end": 29
+            }
           }
         },
         {
@@ -295,7 +311,11 @@ exports['mcfunction argument minecraft:item_stack Parse "diamond_pickaxe[unbreak
             ]
           }
         }
-      ]
+      ],
+      "innerRange": {
+        "start": 16,
+        "end": 42
+      }
     }
   },
   "errors": []
@@ -348,7 +368,11 @@ exports['mcfunction argument minecraft:item_stack Parse "diamond_pickaxe[unbreak
                 "start": 28,
                 "end": 30
               },
-              "children": []
+              "children": [],
+              "innerRange": {
+                "start": 29,
+                "end": 29
+              }
             }
           ],
           "key": {
@@ -367,10 +391,18 @@ exports['mcfunction argument minecraft:item_stack Parse "diamond_pickaxe[unbreak
               "start": 28,
               "end": 30
             },
-            "children": []
+            "children": [],
+            "innerRange": {
+              "start": 29,
+              "end": 29
+            }
           }
         }
-      ]
+      ],
+      "innerRange": {
+        "start": 16,
+        "end": 30
+      }
     }
   },
   "errors": []
@@ -557,7 +589,11 @@ exports['mcfunction argument minecraft:item_stack Parse "stick{foo:bar}" 1'] = {
             ]
           }
         }
-      ]
+      ],
+      "innerRange": {
+        "start": 6,
+        "end": 13
+      }
     }
   },
   "errors": []

--- a/__snapshots__/packages/java-edition/test-out/mcfunction/parser/argument/minecraftLootModifier.spec.js
+++ b/__snapshots__/packages/java-edition/test-out/mcfunction/parser/argument/minecraftLootModifier.spec.js
@@ -122,7 +122,11 @@ exports['mcfunction argument minecraft:loot_modifier Parse "[{function:"furnace_
                       "quote": "\""
                     }
                   }
-                ]
+                ],
+                "innerRange": {
+                  "start": 2,
+                  "end": 26
+                }
               }
             ],
             "value": {
@@ -227,7 +231,11 @@ exports['mcfunction argument minecraft:loot_modifier Parse "[{function:"furnace_
                     "quote": "\""
                   }
                 }
-              ]
+              ],
+              "innerRange": {
+                "start": 2,
+                "end": 26
+              }
             }
           }
         ],

--- a/__snapshots__/packages/java-edition/test-out/mcfunction/parser/argument/minecraftLootPredicate.spec.js
+++ b/__snapshots__/packages/java-edition/test-out/mcfunction/parser/argument/minecraftLootPredicate.spec.js
@@ -196,7 +196,11 @@ exports['mcfunction argument minecraft:loot_predicate Parse "{condition:"random_
               "value": 0.2
             }
           }
-        ]
+        ],
+        "innerRange": {
+          "start": 1,
+          "end": 37
+        }
       }
     ],
     "category": "predicate"

--- a/__snapshots__/packages/java-edition/test-out/mcfunction/parser/argument/minecraftLootTable.spec.js
+++ b/__snapshots__/packages/java-edition/test-out/mcfunction/parser/argument/minecraftLootTable.spec.js
@@ -98,7 +98,11 @@ exports['mcfunction argument minecraft:loot_table Parse "{pools:[]}" 1'] = {
               "children": []
             }
           }
-        ]
+        ],
+        "innerRange": {
+          "start": 1,
+          "end": 9
+        }
       }
     ],
     "category": "loot_table"

--- a/__snapshots__/packages/java-edition/test-out/mcfunction/parser/argument/minecraftNbtCompoundTag.spec.js
+++ b/__snapshots__/packages/java-edition/test-out/mcfunction/parser/argument/minecraftNbtCompoundTag.spec.js
@@ -106,7 +106,11 @@ exports['mcfunction argument minecraft:nbt_compound_tag Parse "{foo:bar}" 1'] = 
               ]
             }
           }
-        ]
+        ],
+        "innerRange": {
+          "start": 1,
+          "end": 8
+        }
       }
     ]
   },
@@ -127,7 +131,11 @@ exports['mcfunction argument minecraft:nbt_compound_tag Parse "{}" 1'] = {
           "start": 0,
           "end": 2
         },
-        "children": []
+        "children": [],
+        "innerRange": {
+          "start": 1,
+          "end": 1
+        }
       }
     ]
   },

--- a/__snapshots__/packages/java-edition/test-out/mcfunction/parser/argument/minecraftNbtTag.spec.js
+++ b/__snapshots__/packages/java-edition/test-out/mcfunction/parser/argument/minecraftNbtTag.spec.js
@@ -224,7 +224,11 @@ exports['mcfunction argument minecraft:nbt_tag Parse "{foo:bar}" 1'] = {
               ]
             }
           }
-        ]
+        ],
+        "innerRange": {
+          "start": 1,
+          "end": 8
+        }
       }
     ]
   },

--- a/__snapshots__/packages/java-edition/test-out/mcfunction/parser/argument/minecraftParticle.spec.js
+++ b/__snapshots__/packages/java-edition/test-out/mcfunction/parser/argument/minecraftParticle.spec.js
@@ -228,7 +228,11 @@ exports['mcfunction argument minecraft:particle Parse "block{block_state:"diamon
                   "quote": "\""
                 }
               }
-            ]
+            ],
+            "innerRange": {
+              "start": 6,
+              "end": 33
+            }
           }
         ],
         "id": {
@@ -340,7 +344,11 @@ exports['mcfunction argument minecraft:particle Parse "block{block_state:"diamon
                 "quote": "\""
               }
             }
-          ]
+          ],
+          "innerRange": {
+            "start": 6,
+            "end": 33
+          }
         },
         "isPredicate": false
       }
@@ -496,7 +504,11 @@ exports['mcfunction argument minecraft:particle Parse "block{block_state:"diamon
               "quote": "\""
             }
           }
-        ]
+        ],
+        "innerRange": {
+          "start": 6,
+          "end": 33
+        }
       }
     ],
     "id": {
@@ -895,7 +907,11 @@ exports['mcfunction argument minecraft:particle Parse "end_rod{}" in version 1.2
           "start": 7,
           "end": 9
         },
-        "children": []
+        "children": [],
+        "innerRange": {
+          "start": 8,
+          "end": 8
+        }
       }
     ],
     "id": {

--- a/__snapshots__/packages/java-edition/test-out/mcfunction/parser/argument/minecraftScoreHolder.spec.js
+++ b/__snapshots__/packages/java-edition/test-out/mcfunction/parser/argument/minecraftScoreHolder.spec.js
@@ -180,7 +180,11 @@ exports['mcfunction argument minecraft:score_holder Parse "@a[ = 1 , ]" with {"a
                 "end": 9
               }
             }
-          ]
+          ],
+          "innerRange": {
+            "start": 3,
+            "end": 10
+          }
         }
       ],
       "variable": "a",
@@ -268,7 +272,11 @@ exports['mcfunction argument minecraft:score_holder Parse "@a[ = 1 , ]" with {"a
               "end": 9
             }
           }
-        ]
+        ],
+        "innerRange": {
+          "start": 3,
+          "end": 10
+        }
       },
       "currentEntity": false,
       "playersOnly": true,
@@ -461,7 +469,11 @@ exports['mcfunction argument minecraft:score_holder Parse "@a[ scores = { foo = 
                         "end": 26
                       }
                     }
-                  ]
+                  ],
+                  "innerRange": {
+                    "start": 14,
+                    "end": 27
+                  }
                 }
               ],
               "key": {
@@ -596,14 +608,22 @@ exports['mcfunction argument minecraft:score_holder Parse "@a[ scores = { foo = 
                       "end": 26
                     }
                   }
-                ]
+                ],
+                "innerRange": {
+                  "start": 14,
+                  "end": 27
+                }
               },
               "end": {
                 "start": 29,
                 "end": 30
               }
             }
-          ]
+          ],
+          "innerRange": {
+            "start": 3,
+            "end": 31
+          }
         }
       ],
       "variable": "a",
@@ -749,7 +769,11 @@ exports['mcfunction argument minecraft:score_holder Parse "@a[ scores = { foo = 
                       "end": 26
                     }
                   }
-                ]
+                ],
+                "innerRange": {
+                  "start": 14,
+                  "end": 27
+                }
               }
             ],
             "key": {
@@ -884,14 +908,22 @@ exports['mcfunction argument minecraft:score_holder Parse "@a[ scores = { foo = 
                     "end": 26
                   }
                 }
-              ]
+              ],
+              "innerRange": {
+                "start": 14,
+                "end": 27
+              }
             },
             "end": {
               "start": 29,
               "end": 30
             }
           }
-        ]
+        ],
+        "innerRange": {
+          "start": 3,
+          "end": 31
+        }
       },
       "currentEntity": false,
       "playersOnly": true,
@@ -975,7 +1007,11 @@ exports['mcfunction argument minecraft:score_holder Parse "@a[ scores = { } , sc
                     "start": 13,
                     "end": 16
                   },
-                  "children": []
+                  "children": [],
+                  "innerRange": {
+                    "start": 14,
+                    "end": 15
+                  }
                 }
               ],
               "key": {
@@ -1018,7 +1054,11 @@ exports['mcfunction argument minecraft:score_holder Parse "@a[ scores = { } , sc
                   "start": 13,
                   "end": 16
                 },
-                "children": []
+                "children": [],
+                "innerRange": {
+                  "start": 14,
+                  "end": 15
+                }
               },
               "end": {
                 "start": 17,
@@ -1068,7 +1108,11 @@ exports['mcfunction argument minecraft:score_holder Parse "@a[ scores = { } , sc
                     "start": 28,
                     "end": 31
                   },
-                  "children": []
+                  "children": [],
+                  "innerRange": {
+                    "start": 29,
+                    "end": 30
+                  }
                 }
               ],
               "key": {
@@ -1111,14 +1155,22 @@ exports['mcfunction argument minecraft:score_holder Parse "@a[ scores = { } , sc
                   "start": 28,
                   "end": 31
                 },
-                "children": []
+                "children": [],
+                "innerRange": {
+                  "start": 29,
+                  "end": 30
+                }
               },
               "end": {
                 "start": 32,
                 "end": 33
               }
             }
-          ]
+          ],
+          "innerRange": {
+            "start": 3,
+            "end": 34
+          }
         }
       ],
       "variable": "a",
@@ -1172,7 +1224,11 @@ exports['mcfunction argument minecraft:score_holder Parse "@a[ scores = { } , sc
                   "start": 13,
                   "end": 16
                 },
-                "children": []
+                "children": [],
+                "innerRange": {
+                  "start": 14,
+                  "end": 15
+                }
               }
             ],
             "key": {
@@ -1215,7 +1271,11 @@ exports['mcfunction argument minecraft:score_holder Parse "@a[ scores = { } , sc
                 "start": 13,
                 "end": 16
               },
-              "children": []
+              "children": [],
+              "innerRange": {
+                "start": 14,
+                "end": 15
+              }
             },
             "end": {
               "start": 17,
@@ -1265,7 +1325,11 @@ exports['mcfunction argument minecraft:score_holder Parse "@a[ scores = { } , sc
                   "start": 28,
                   "end": 31
                 },
-                "children": []
+                "children": [],
+                "innerRange": {
+                  "start": 29,
+                  "end": 30
+                }
               }
             ],
             "key": {
@@ -1308,14 +1372,22 @@ exports['mcfunction argument minecraft:score_holder Parse "@a[ scores = { } , sc
                 "start": 28,
                 "end": 31
               },
-              "children": []
+              "children": [],
+              "innerRange": {
+                "start": 29,
+                "end": 30
+              }
             },
             "end": {
               "start": 32,
               "end": 33
             }
           }
-        ]
+        ],
+        "innerRange": {
+          "start": 3,
+          "end": 34
+        }
       },
       "currentEntity": false,
       "playersOnly": true,
@@ -1502,7 +1574,11 @@ exports['mcfunction argument minecraft:score_holder Parse "@a[ sort = arbitrary 
                 "end": 22
               }
             }
-          ]
+          ],
+          "innerRange": {
+            "start": 3,
+            "end": 23
+          }
         }
       ],
       "variable": "a",
@@ -1650,7 +1726,11 @@ exports['mcfunction argument minecraft:score_holder Parse "@a[ sort = arbitrary 
               "end": 22
             }
           }
-        ]
+        ],
+        "innerRange": {
+          "start": 3,
+          "end": 23
+        }
       },
       "currentEntity": false,
       "playersOnly": true,
@@ -1965,7 +2045,11 @@ exports['mcfunction argument minecraft:score_holder Parse "@a[ tag = foo , tag =
                 "end": 29
               }
             }
-          ]
+          ],
+          "innerRange": {
+            "start": 3,
+            "end": 30
+          }
         }
       ],
       "variable": "a",
@@ -2250,7 +2334,11 @@ exports['mcfunction argument minecraft:score_holder Parse "@a[ tag = foo , tag =
               "end": 29
             }
           }
-        ]
+        ],
+        "innerRange": {
+          "start": 3,
+          "end": 30
+        }
       },
       "currentEntity": false,
       "playersOnly": true,
@@ -2581,7 +2669,11 @@ exports['mcfunction argument minecraft:score_holder Parse "@a[ team = ! foo , te
                 "end": 33
               }
             }
-          ]
+          ],
+          "innerRange": {
+            "start": 3,
+            "end": 34
+          }
         }
       ],
       "variable": "a",
@@ -2882,7 +2974,11 @@ exports['mcfunction argument minecraft:score_holder Parse "@a[ team = ! foo , te
               "end": 33
             }
           }
-        ]
+        ],
+        "innerRange": {
+          "start": 3,
+          "end": 34
+        }
       },
       "currentEntity": false,
       "playersOnly": true,
@@ -3181,7 +3277,11 @@ exports['mcfunction argument minecraft:score_holder Parse "@a[ team = foo , team
                 "end": 29
               }
             }
-          ]
+          ],
+          "innerRange": {
+            "start": 3,
+            "end": 30
+          }
         }
       ],
       "variable": "a",
@@ -3450,7 +3550,11 @@ exports['mcfunction argument minecraft:score_holder Parse "@a[ team = foo , team
               "end": 29
             }
           }
-        ]
+        ],
+        "innerRange": {
+          "start": 3,
+          "end": 30
+        }
       },
       "currentEntity": false,
       "playersOnly": true,
@@ -3633,7 +3737,11 @@ exports['mcfunction argument minecraft:score_holder Parse "@a[ type = zombie ]" 
                 }
               }
             }
-          ]
+          ],
+          "innerRange": {
+            "start": 3,
+            "end": 18
+          }
         }
       ],
       "variable": "a",
@@ -3777,7 +3885,11 @@ exports['mcfunction argument minecraft:score_holder Parse "@a[ type = zombie ]" 
               }
             }
           }
-        ]
+        ],
+        "innerRange": {
+          "start": 3,
+          "end": 18
+        }
       },
       "currentEntity": false,
       "playersOnly": true,
@@ -3904,7 +4016,11 @@ exports['mcfunction argument minecraft:score_holder Parse "@a[ unknown = 1 , ]" 
                 "end": 17
               }
             }
-          ]
+          ],
+          "innerRange": {
+            "start": 3,
+            "end": 18
+          }
         }
       ],
       "variable": "a",
@@ -3992,7 +4108,11 @@ exports['mcfunction argument minecraft:score_holder Parse "@a[ unknown = 1 , ]" 
               "end": 17
             }
           }
-        ]
+        ],
+        "innerRange": {
+          "start": 3,
+          "end": 18
+        }
       },
       "currentEntity": false,
       "playersOnly": true,
@@ -4422,7 +4542,11 @@ exports['mcfunction argument minecraft:score_holder Parse "@a[ x = 0.0 , x = 0.0
                 "end": 44
               }
             }
-          ]
+          ],
+          "innerRange": {
+            "start": 3,
+            "end": 45
+          }
         }
       ],
       "variable": "a",
@@ -4805,7 +4929,11 @@ exports['mcfunction argument minecraft:score_holder Parse "@a[ x = 0.0 , x = 0.0
               "end": 44
             }
           }
-        ]
+        ],
+        "innerRange": {
+          "start": 3,
+          "end": 45
+        }
       },
       "chunkLimited": false,
       "currentEntity": false,
@@ -5423,7 +5551,11 @@ exports['mcfunction argument minecraft:score_holder Parse "@a[ x = 0.0 , y = 0.0
                 "end": 66
               }
             }
-          ]
+          ],
+          "innerRange": {
+            "start": 3,
+            "end": 67
+          }
         }
       ],
       "variable": "a",
@@ -5992,7 +6124,11 @@ exports['mcfunction argument minecraft:score_holder Parse "@a[ x = 0.0 , y = 0.0
               "end": 66
             }
           }
-        ]
+        ],
+        "innerRange": {
+          "start": 3,
+          "end": 67
+        }
       },
       "chunkLimited": false,
       "currentEntity": false,
@@ -6337,7 +6473,11 @@ exports['mcfunction argument minecraft:score_holder Parse "@a[ x_rotation = 179.
                 "end": 62
               }
             }
-          ]
+          ],
+          "innerRange": {
+            "start": 3,
+            "end": 63
+          }
         }
       ],
       "variable": "a",
@@ -6650,7 +6790,11 @@ exports['mcfunction argument minecraft:score_holder Parse "@a[ x_rotation = 179.
               "end": 62
             }
           }
-        ]
+        ],
+        "innerRange": {
+          "start": 3,
+          "end": 63
+        }
       },
       "currentEntity": false,
       "playersOnly": true,
@@ -7002,7 +7146,11 @@ exports['mcfunction argument minecraft:score_holder Parse "@a[ x_rotation = 179.
                 "end": 62
               }
             }
-          ]
+          ],
+          "innerRange": {
+            "start": 3,
+            "end": 63
+          }
         }
       ],
       "variable": "a",
@@ -7315,7 +7463,11 @@ exports['mcfunction argument minecraft:score_holder Parse "@a[ x_rotation = 179.
               "end": 62
             }
           }
-        ]
+        ],
+        "innerRange": {
+          "start": 3,
+          "end": 63
+        }
       },
       "currentEntity": false,
       "playersOnly": true,
@@ -7745,7 +7897,11 @@ exports['mcfunction argument minecraft:score_holder Parse "@e[ type = ! skeleton
                 "end": 41
               }
             }
-          ]
+          ],
+          "innerRange": {
+            "start": 3,
+            "end": 42
+          }
         }
       ],
       "variable": "e",
@@ -8062,7 +8218,11 @@ exports['mcfunction argument minecraft:score_holder Parse "@e[ type = ! skeleton
               "end": 41
             }
           }
-        ]
+        ],
+        "innerRange": {
+          "start": 3,
+          "end": 42
+        }
       },
       "currentEntity": false,
       "playersOnly": false,
@@ -8388,7 +8548,11 @@ exports['mcfunction argument minecraft:score_holder Parse "@e[ type = #tag1 , ty
                 "end": 33
               }
             }
-          ]
+          ],
+          "innerRange": {
+            "start": 3,
+            "end": 34
+          }
         }
       ],
       "variable": "e",
@@ -8681,7 +8845,11 @@ exports['mcfunction argument minecraft:score_holder Parse "@e[ type = #tag1 , ty
               "end": 33
             }
           }
-        ]
+        ],
+        "innerRange": {
+          "start": 3,
+          "end": 34
+        }
       },
       "currentEntity": false,
       "playersOnly": false,
@@ -8858,7 +9026,11 @@ exports['mcfunction argument minecraft:score_holder Parse "@e[ type = player ]" 
                 }
               }
             }
-          ]
+          ],
+          "innerRange": {
+            "start": 3,
+            "end": 18
+          }
         }
       ],
       "variable": "e",
@@ -9002,7 +9174,11 @@ exports['mcfunction argument minecraft:score_holder Parse "@e[ type = player ]" 
               }
             }
           }
-        ]
+        ],
+        "innerRange": {
+          "start": 3,
+          "end": 18
+        }
       },
       "currentEntity": false,
       "playersOnly": true,
@@ -9320,7 +9496,11 @@ exports['mcfunction argument minecraft:score_holder Parse "@e[ type = skeleton ,
                 "end": 37
               }
             }
-          ]
+          ],
+          "innerRange": {
+            "start": 3,
+            "end": 38
+          }
         }
       ],
       "variable": "e",
@@ -9605,7 +9785,11 @@ exports['mcfunction argument minecraft:score_holder Parse "@e[ type = skeleton ,
               "end": 37
             }
           }
-        ]
+        ],
+        "innerRange": {
+          "start": 3,
+          "end": 38
+        }
       },
       "currentEntity": false,
       "playersOnly": false,
@@ -9932,7 +10116,11 @@ exports['mcfunction argument minecraft:score_holder Parse "@s[ sort = arbitrary 
                 "end": 39
               }
             }
-          ]
+          ],
+          "innerRange": {
+            "start": 3,
+            "end": 40
+          }
         }
       ],
       "variable": "s",
@@ -10217,7 +10405,11 @@ exports['mcfunction argument minecraft:score_holder Parse "@s[ sort = arbitrary 
               "end": 39
             }
           }
-        ]
+        ],
+        "innerRange": {
+          "start": 3,
+          "end": 40
+        }
       },
       "currentEntity": true,
       "playersOnly": false,

--- a/__snapshots__/packages/java-edition/test-out/mcfunction/parser/argument/minecraftStyle.spec.js
+++ b/__snapshots__/packages/java-edition/test-out/mcfunction/parser/argument/minecraftStyle.spec.js
@@ -185,7 +185,11 @@ exports['mcfunction argument minecraft:style Parse "{ "color": "red", "italic": 
               "value": true
             }
           }
-        ]
+        ],
+        "innerRange": {
+          "start": 1,
+          "end": 33
+        }
       }
     ],
     "targetType": {
@@ -282,7 +286,11 @@ exports['mcfunction argument minecraft:style Parse "{"bold": true}" 1'] = {
               "value": true
             }
           }
-        ]
+        ],
+        "innerRange": {
+          "start": 1,
+          "end": 13
+        }
       }
     ],
     "targetType": {

--- a/__snapshots__/packages/json/test-out/parser/object.spec.js
+++ b/__snapshots__/packages/json/test-out/parser/object.spec.js
@@ -225,7 +225,11 @@ exports['JSON object parser object() Parse "{"1": "2", "3": "4"}" 1'] = {
           "quote": "\""
         }
       }
-    ]
+    ],
+    "innerRange": {
+      "start": 1,
+      "end": 19
+    }
   },
   "errors": []
 }
@@ -335,7 +339,11 @@ exports['JSON object parser object() Parse "{"1": "2"}" 1'] = {
           "quote": "\""
         }
       }
-    ]
+    ],
+    "innerRange": {
+      "start": 1,
+      "end": 9
+    }
   },
   "errors": []
 }
@@ -480,7 +488,11 @@ exports['JSON object parser object() Parse "{"1": {"2": "3"}, {"4": "5"}}" 1'] =
                   "quote": "\""
                 }
               }
-            ]
+            ],
+            "innerRange": {
+              "start": 7,
+              "end": 15
+            }
           }
         ],
         "key": {
@@ -612,7 +624,11 @@ exports['JSON object parser object() Parse "{"1": {"2": "3"}, {"4": "5"}}" 1'] =
                 "quote": "\""
               }
             }
-          ]
+          ],
+          "innerRange": {
+            "start": 7,
+            "end": 15
+          }
         },
         "end": {
           "start": 16,
@@ -674,7 +690,11 @@ exports['JSON object parser object() Parse "{"1": {"2": "3"}, {"4": "5"}}" 1'] =
           "quote": "\""
         }
       }
-    ]
+    ],
+    "innerRange": {
+      "start": 1,
+      "end": 27
+    }
   },
   "errors": [
     {
@@ -793,7 +813,11 @@ exports['JSON object parser object() Parse "{"hey": "there"}" 1'] = {
           "quote": "\""
         }
       }
-    ]
+    ],
+    "innerRange": {
+      "start": 1,
+      "end": 15
+    }
   },
   "errors": []
 }
@@ -923,7 +947,11 @@ exports['JSON object parser object() Parse "{"test": "⧵u1z34"}" 1'] = {
           "quote": "\""
         }
       }
-    ]
+    ],
+    "innerRange": {
+      "start": 1,
+      "end": 17
+    }
   },
   "errors": [
     {
@@ -1082,7 +1110,11 @@ exports['JSON object parser object() Parse "{"⧵"": "⧵u1234"}" 1'] = {
           "quote": "\""
         }
       }
-    ]
+    ],
+    "innerRange": {
+      "start": 1,
+      "end": 15
+    }
   },
   "errors": []
 }
@@ -1212,7 +1244,11 @@ exports['JSON object parser object() Parse "{"⧵z": "ermm"}" 1'] = {
           "quote": "\""
         }
       }
-    ]
+    ],
+    "innerRange": {
+      "start": 1,
+      "end": 13
+    }
   },
   "errors": [
     {
@@ -1297,7 +1333,11 @@ exports['JSON object parser object() Parse "{1: 2}" 1'] = {
           }
         }
       }
-    ]
+    ],
+    "innerRange": {
+      "start": 1,
+      "end": 5
+    }
   },
   "errors": [
     {
@@ -1318,7 +1358,11 @@ exports['JSON object parser object() Parse "{}" 1'] = {
       "start": 0,
       "end": 2
     },
-    "children": []
+    "children": [],
+    "innerRange": {
+      "start": 1,
+      "end": 1
+    }
   },
   "errors": []
 }

--- a/__snapshots__/packages/nbt/test-out/parser/compound.spec.js
+++ b/__snapshots__/packages/nbt/test-out/parser/compound.spec.js
@@ -117,7 +117,11 @@ exports['nbt compound() Parse "{ foo: true }" 1'] = {
           "value": 1
         }
       }
-    ]
+    ],
+    "innerRange": {
+      "start": 1,
+      "end": 12
+    }
   },
   "errors": []
 }
@@ -129,7 +133,11 @@ exports['nbt compound() Parse "{}" 1'] = {
       "start": 0,
       "end": 2
     },
-    "children": []
+    "children": [],
+    "innerRange": {
+      "start": 1,
+      "end": 1
+    }
   },
   "errors": []
 }

--- a/__snapshots__/packages/nbt/test-out/parser/path.spec.js
+++ b/__snapshots__/packages/nbt/test-out/parser/path.spec.js
@@ -342,7 +342,11 @@ exports['nbt path() Parse "foo.{ }" 1'] = {
               "start": 4,
               "end": 7
             },
-            "children": []
+            "children": [],
+            "innerRange": {
+              "start": 5,
+              "end": 6
+            }
           }
         ]
       }
@@ -704,7 +708,11 @@ exports['nbt path() Parse "foo[ { } ]" 1'] = {
               "start": 5,
               "end": 8
             },
-            "children": []
+            "children": [],
+            "innerRange": {
+              "start": 6,
+              "end": 7
+            }
           }
         ],
         "range": {
@@ -767,7 +775,11 @@ exports['nbt path() Parse "foo{ }" 1'] = {
               "start": 3,
               "end": 6
             },
-            "children": []
+            "children": [],
+            "innerRange": {
+              "start": 4,
+              "end": 5
+            }
           }
         ]
       }
@@ -797,7 +809,11 @@ exports['nbt path() Parse "{ }" 1'] = {
               "start": 0,
               "end": 3
             },
-            "children": []
+            "children": [],
+            "innerRange": {
+              "start": 1,
+              "end": 2
+            }
           }
         ]
       }
@@ -827,7 +843,11 @@ exports['nbt path() Parse "{ }.foo" 1'] = {
               "start": 0,
               "end": 3
             },
-            "children": []
+            "children": [],
+            "innerRange": {
+              "start": 1,
+              "end": 2
+            }
           }
         ]
       },

--- a/packages/core/src/node/RecordNode.ts
+++ b/packages/core/src/node/RecordNode.ts
@@ -3,6 +3,7 @@ import type { AstNode } from './AstNode.js'
 
 export interface RecordBaseNode<K extends AstNode, V extends AstNode> extends AstNode {
 	readonly children: PairNode<K, V>[]
+	innerRange?: Range
 }
 
 export interface RecordNode<K extends AstNode, V extends AstNode> extends RecordBaseNode<K, V> {

--- a/packages/core/src/parser/record.ts
+++ b/packages/core/src/parser/record.ts
@@ -33,6 +33,7 @@ export function record<K extends AstNode, V extends AstNode>(
 		const ans: RecordNode<K, V> = { type: 'record', range: Range.create(src), children: [] }
 
 		if (src.trySkip(start)) {
+			ans.innerRange = Range.create(src)
 			src.skipWhitespace()
 
 			let requiresPairEnd = false
@@ -134,6 +135,7 @@ export function record<K extends AstNode, V extends AstNode>(
 			}
 
 			// End.
+			ans.innerRange.end = src.cursor
 			if (!src.trySkip(end)) {
 				ctx.err.report(localize('expected', localeQuote(end)), src)
 			}

--- a/packages/core/src/processor/completer/builtin.ts
+++ b/packages/core/src/processor/completer/builtin.ts
@@ -112,7 +112,7 @@ export function record<K extends AstNode, V extends AstNode, N extends RecordBas
 	o: RecordOptions<K, V, N>,
 ): Completer<N> {
 	return (node, ctx) => {
-		if (!Range.contains(Range.translate(node, 1, -1), ctx.offset, true)) {
+		if (!node.innerRange || !Range.contains(node.innerRange, ctx.offset, true)) {
 			return []
 		}
 

--- a/packages/java-edition/src/mcfunction/completer/argument.ts
+++ b/packages/java-edition/src/mcfunction/completer/argument.ts
@@ -225,10 +225,10 @@ const block: Completer<BlockNode> = (node, ctx) => {
 	if (Range.contains(node.id, ctx.offset, true)) {
 		ans.push(...completer.resourceLocation(node.id, ctx))
 	}
-	if (node.states && Range.contains(Range.translate(node.states, 1, -1), ctx.offset, true)) {
+	if (node.states?.innerRange && Range.contains(node.states.innerRange, ctx.offset, true)) {
 		ans.push(...blockStates(node.states, ctx))
 	}
-	if (node.nbt && Range.contains(Range.translate(node.nbt, 1, -1), ctx.offset, true)) {
+	if (node.nbt?.innerRange && Range.contains(node.nbt.innerRange, ctx.offset, true)) {
 		ans.push(...completer.dispatch(node.nbt, ctx))
 	}
 	return ans
@@ -275,7 +275,7 @@ const blockStates: Completer<BlockStatesNode> = (node, ctx) => {
 }
 
 const componentList: Completer<ComponentListNode> = (node, ctx) => {
-	if (!Range.contains(Range.translate(node, 1, -1), ctx.offset, true)) {
+	if (!node.innerRange || !Range.contains(node.innerRange, ctx.offset, true)) {
 		return []
 	}
 
@@ -446,7 +446,7 @@ const selector: Completer<EntitySelectorNode> = (node, ctx) => {
 	if (Range.contains(node.children[0], ctx.offset, true)) {
 		return completer.literal(node.children[0], ctx)
 	}
-	if (node.arguments && Range.contains(Range.translate(node.arguments, 1, -1), ctx.offset, true)) {
+	if (node.arguments?.innerRange && Range.contains(node.arguments.innerRange, ctx.offset, true)) {
 		return selectorArguments(node.arguments, ctx)
 	}
 	return []

--- a/packages/java-edition/src/mcfunction/node/argument.ts
+++ b/packages/java-edition/src/mcfunction/node/argument.ts
@@ -272,6 +272,7 @@ export namespace ItemStackNode {
 export interface ComponentListNode extends core.AstNode {
 	type: 'mcfunction:component_list'
 	children: (ComponentNode | ComponentRemovalNode)[]
+	innerRange?: core.Range
 }
 
 export namespace ComponentListNode {

--- a/packages/java-edition/src/mcfunction/parser/argument.ts
+++ b/packages/java-edition/src/mcfunction/parser/argument.ts
@@ -1599,6 +1599,7 @@ const components: core.Parser<ComponentListNode> = (src, ctx) => {
 	if (!src.trySkip('[')) {
 		return core.Failure
 	}
+	ans.innerRange = core.Range.create(src)
 	src.skipWhitespace()
 
 	while (src.canRead() && src.peek() !== ']') {
@@ -1655,6 +1656,7 @@ const components: core.Parser<ComponentListNode> = (src, ctx) => {
 	}
 
 	src.skipWhitespace()
+	ans.innerRange.end = src.cursor
 	core.literal(']')(src, ctx)
 
 	ans.range.end = src.cursor


### PR DESCRIPTION
The code used to assume that the first and last characters in the range of a record node are the brackets. No completions would be suggested for key-value pairs when the cursor is at either end of the range, as that is assumed to be outside the brackets. However, this assumption is violated when there is no closing bracket, which is a common occurrence during editing for users who do not rely on their editor to automatically close brackets. This commit fixes the issue by keeping track of the actual range inside the brackets.