### PR TITLE
🐛 Remove worldgen-only heightmaps from autocomplete

### DIFF
--- a/packages/java-edition/src/mcfunction/common/index.ts
+++ b/packages/java-edition/src/mcfunction/common/index.ts
@@ -89,9 +89,7 @@ export const HeightmapValues = [
 	'motion_blocking',
 	'motion_blocking_no_leaves',
 	'ocean_floor',
-	'ocean_floor_wg',
 	'world_surface',
-	'world_surface_wg',
 ]
 
 export const RotationValues = ['none', 'clockwise_90', '180', 'counterclockwise_90']


### PR DESCRIPTION
Fixes #1590 