### PR TITLE
⚡️ provide `exclude` patterns to file watcher args

### DIFF
--- a/packages/core/src/common/externals/NodeJsExternals.ts
+++ b/packages/core/src/common/externals/NodeJsExternals.ts
@@ -114,9 +114,10 @@ export const NodeJsExternals: Externals = {
 		unlink(location) {
 			return fsp.unlink(toFsPathLike(location))
 		},
-		watch(locations, { usePolling = false } = {}) {
+		watch(locations, { ignored, usePolling } = {}) {
 			return new ChokidarWatcherWrapper(
 				chokidar.watch(locations.map(toPath), {
+					ignored,
 					usePolling,
 					disableGlobbing: true,
 				}),

--- a/packages/core/src/common/externals/index.ts
+++ b/packages/core/src/common/externals/index.ts
@@ -72,7 +72,10 @@ export interface ExternalFileSystem {
 	showFile(path: FsLocation): Promise<void>
 	stat(location: FsLocation): Promise<{ isDirectory(): boolean; isFile(): boolean }>
 	unlink(location: FsLocation): Promise<void>
-	watch(locations: FsLocation[], options: { usePolling?: boolean }): FsWatcher
+	watch(
+		locations: FsLocation[],
+		options: { ignored?: string[]; usePolling?: boolean },
+	): FsWatcher
 	/**
 	 * @param options `mode` - File mode bit mask (e.g. `0o775`).
 	 */

--- a/packages/core/src/common/externals/index.ts
+++ b/packages/core/src/common/externals/index.ts
@@ -1,3 +1,4 @@
+import type { WatchOptions } from 'chokidar'
 import type { Uri } from '../util.js'
 import type { ExternalDownloader } from './downloader.js'
 
@@ -74,7 +75,7 @@ export interface ExternalFileSystem {
 	unlink(location: FsLocation): Promise<void>
 	watch(
 		locations: FsLocation[],
-		options: { ignored?: string[]; usePolling?: boolean },
+		options: WatchOptions,
 	): FsWatcher
 	/**
 	 * @param options `mode` - File mode bit mask (e.g. `0o775`).

--- a/packages/core/src/service/Config.ts
+++ b/packages/core/src/service/Config.ts
@@ -330,7 +330,7 @@ export const VanillaConfig: Config = {
 	env: {
 		dataSource: 'GitHub',
 		dependencies: ['@vanilla-datapack', '@vanilla-mcdoc'],
-		exclude: ['@gitignore', '.vscode/', '.github/'],
+		exclude: ['@gitignore', '.*'],
 		customResources: {},
 		feature: {
 			codeActions: true,

--- a/packages/core/src/service/Project.ts
+++ b/packages/core/src/service/Project.ts
@@ -404,6 +404,7 @@ export class Project implements ExternalEventEmitter {
 		}
 
 		const parseExcludePaths = async () => {
+			const paths = []
 			for (const pattern of this.config.env.exclude) {
 				if (pattern === '@gitignore') {
 					const gitignore = await this.readGitignore()
@@ -411,12 +412,15 @@ export class Project implements ExternalEventEmitter {
 						const gitignoreLines = gitignore.split(/\r?\n/)
 						const gitignorePaths = gitignoreLines
 							.filter((line) => line !== '' && !line.startsWith('#'))
-						this.#excludePaths.push(...gitignorePaths)
+						paths.push(...gitignorePaths)
 					}
 				} else {
-					this.#excludePaths.push(pattern)
+					paths.push(pattern)
 				}
 			}
+			// Chokidar never matches paths with a trailing (back)slash, so fix any paths
+			// that may be specified as such
+			this.#excludePaths.push(...paths.map((path) => path.replace(/(\\|\/)$/, '')))
 		}
 		const callIntializers = async () => {
 			const initCtx: ProjectInitializerContext = {


### PR DESCRIPTION
right now we filter files for Spyglass to care about after we've already told chokidar to watch all our root directories.

chokidar ends up watching every file in the directory and is very slow, even if we later ignore certain files based on `config.env.exclude`.

not only that, but i couldn't get exclude patterns to work that you'd expect to work. for instance:

---

#### `datapacks/omega-flowey/data/*/test` wouldn't match the corresponding `test` directory relative to any of the project roots (mostly fixed ✅)

so i'd get lots of spyglass errors due to `packtest`'s non-vanilla commands just on project open

| before | after |
|-|-|
| ![image](https://github.com/user-attachments/assets/7bc994d6-ed81-4b2b-a159-5ae923de5e3b) |![image](https://github.com/user-attachments/assets/f052abc4-eef1-432e-b3b9-b8d10e8a40f0) |

Spyglass still shows errors if you open the file, but this is progress.

we could fix ^ by hooking the exclude config into `connection.onHover` (etc.) somewhere, but that's out of scope here

---

#### explicitly ignored datapack directories would still get parsed and show up in references/definitions (also mostly fixed ✅)

i have a `build` directory that is `.gitignored`, and this would still show up when i open a function's references.

on project load, these files are no longer bound to the function references, but they unfortunately still are bound again if you open the file. still an improvement though, and we can probably remedy further with similar methods to the `packtest` related stuff above

| before, project load -> parses the explicitly `.gitignore`'d directory |
|-|
| ![image](https://github.com/user-attachments/assets/1c15699b-d2e3-4fa3-b2e0-d9e715650827) |

| after, project load -> doesnt parse (still parses if opened though) |
|-|
| ![image](https://github.com/user-attachments/assets/d2b8a784-ceba-4f16-8b2a-a10df79fbf37) |

---

#### `resourcepack/pack.mcmeta` (from project root(s)) wouldn't match a RP pack.mcmeta; i'd still get pack version errors ⚠️ 

note that while the watcher is no longer watching this file if i add it to my exclude list, Spyglass still finds it because `findPackMcmeta` doesn't use the exclude config yet.

maybe less relevant though bc i know Misode's been working on improving that specific bug anyway

---

### major performance gain

regardless of the above issues being partially remedied, the biggest gain we get is from chokidar not recursively adding every file under every project root to the watched files list. with a properly formatted `ignored` list, chokidar stops early at a directory that matches an ignore pattern.

profile comparisons:

#### `#ready` time

| before, gitignore specified but broken parsing | after |
|-|-|
|![image](https://github.com/user-attachments/assets/f07c0fa2-2123-444c-a034-a235af661bcd)|![image](https://github.com/user-attachments/assets/a98f56a2-78fe-440f-a19d-3a82894bbd0d)|

#### watch file count

| before, gitignore specified but broken parsing | after |
|-|-|
|![image](https://github.com/user-attachments/assets/8b4f89a3-bcbb-4ccb-9e23-7a30503454f6)|![image](https://github.com/user-attachments/assets/10f26e4d-ea4c-46b0-8097-2103b7407676)|