### PR TITLE
✨ Add `exclude` option to `id` mcdoc attribute

### DIFF
--- a/packages/locales/src/locales/en.json
+++ b/packages/locales/src/locales/en.json
@@ -179,6 +179,7 @@
   "nbt.node.string": "a string tag",
   "nbt.path": "an NBT path",
   "nbt.parser.number.out-of-range": "This looks like %0%, but it is actually %1% due to the numeral value being out of [%2%, %3%]",
+  "not-allowed-here": "Value %0% is not allowed here",
   "not-matching-any-child": "Invalid argument type",
   "nothing": "nothing",
   "number": "a number",


### PR DESCRIPTION
Allows specifying a list of values that are not allowed in the `id` attribute, for example:
```rust
#[id(registry="item",exclude="air")] string
```
![image](https://github.com/user-attachments/assets/eadaa0bd-0b9b-4272-97ee-8c6a6fb1a953)

**Implementation note:**
I wasn't sure whether to put this in `ResourceLocationOptions` or not, so I decided to keep it exclusive to the `id` attribute handler for now. I'd be happy to move it though.