### PR TITLE
✨ Add support for implicit paths in `id` attribute

### DIFF
--- a/packages/core/src/node/ResourceLocationNode.ts
+++ b/packages/core/src/node/ResourceLocationNode.ts
@@ -16,6 +16,7 @@ export type ResourceLocationOptions =
 		requireCanonical?: boolean
 		usageType?: SymbolUsageType
 		namespacePathSep?: ':' | '.'
+		implicitPath?: string
 	}
 	& ({
 		category: ResourceLocationCategory

--- a/packages/core/src/processor/binder/builtin.ts
+++ b/packages/core/src/processor/binder/builtin.ts
@@ -138,11 +138,16 @@ export const dispatchSync = SyncBinder.create<AstNode>((node, ctx) => {
 
 export const resourceLocation = SyncBinder.create<ResourceLocationNode>((node, ctx) => {
 	const raw = ResourceLocationNode.toString(node, 'full')
-	const sanitizedRaw = ResourceLocation.lengthen(
+	let sanitizedRaw = ResourceLocation.lengthen(
 		node.options.namespacePathSep === '.'
 			? raw.replace(/\./g, ResourceLocation.NamespacePathSep)
 			: raw,
 	)
+	if (node.options.implicitPath) {
+		const sepIndex = sanitizedRaw.indexOf(ResourceLocation.NamespacePathSep)
+		sanitizedRaw = sanitizedRaw.substring(0, sepIndex + 1) + node.options.implicitPath
+			+ sanitizedRaw.substring(sepIndex + 1)
+	}
 	if (node.options.category) {
 		ctx.symbols.query(
 			ctx.doc,

--- a/packages/mcdoc/src/runtime/attribute/builtin.ts
+++ b/packages/mcdoc/src/runtime/attribute/builtin.ts
@@ -8,6 +8,7 @@ interface IdConfig {
 	tags?: 'allowed' | 'implicit' | 'required'
 	definition?: boolean
 	prefix?: '!'
+	path?: string
 	empty?: 'allowed'
 	exclude?: string[]
 }
@@ -19,6 +20,7 @@ const idValidator = validator.alternatives<IdConfig>(
 		tags: validator.optional(validator.options('allowed', 'implicit', 'required')),
 		definition: validator.optional(validator.boolean),
 		prefix: validator.optional(validator.options('!')),
+		path: validator.optional(validator.string),
 		empty: validator.optional(validator.options('allowed')),
 		exclude: validator.optional(validator.alternatives<string[]>(
 			validator.map(validator.string, v => [v]),
@@ -36,7 +38,7 @@ const idValidator = validator.alternatives<IdConfig>(
 )
 
 function getResourceLocationOptions(
-	{ registry, tags, definition }: IdConfig,
+	{ registry, tags, definition, path }: IdConfig,
 	requireCanonical: boolean,
 	ctx: core.ContextBase,
 	typeDef?: core.DeepReadonly<SimplifiedMcdocTypeNoUnion>,
@@ -66,6 +68,7 @@ function getResourceLocationOptions(
 				requireCanonical,
 				allowTag: true,
 				requireTag: tags === 'required',
+				implicitPath: path,
 			}
 		}
 	} else if (core.ResourceLocationCategory.is(registry)) {
@@ -73,6 +76,7 @@ function getResourceLocationOptions(
 			category: registry,
 			requireCanonical,
 			usageType: definition ? 'definition' : 'reference',
+			implicitPath: path,
 		}
 	}
 	ctx.logger.warn(`[mcdoc id] Unhandled registry ${registry}`)

--- a/packages/mcdoc/src/runtime/attribute/builtin.ts
+++ b/packages/mcdoc/src/runtime/attribute/builtin.ts
@@ -62,25 +62,20 @@ function getResourceLocationOptions(
 		registry = `tag/${registry}`
 	}
 	if (tags === 'allowed' || tags === 'required') {
-		if (core.TaggableResourceLocationCategory.is(registry)) {
-			return {
-				category: registry,
-				requireCanonical,
-				allowTag: true,
-				requireTag: tags === 'required',
-				implicitPath: path,
-			}
-		}
-	} else if (core.ResourceLocationCategory.is(registry)) {
 		return {
-			category: registry,
+			category: registry as core.TaggableResourceLocationCategory,
 			requireCanonical,
-			usageType: definition ? 'definition' : 'reference',
+			allowTag: true,
+			requireTag: tags === 'required',
 			implicitPath: path,
 		}
 	}
-	ctx.logger.warn(`[mcdoc id] Unhandled registry ${registry}`)
-	return undefined
+	return {
+		category: registry as core.ResourceLocationCategory,
+		requireCanonical,
+		usageType: definition ? 'definition' : 'reference',
+		implicitPath: path,
+	}
 }
 
 interface IntegerConfig {


### PR DESCRIPTION
Allows writing `#[id(registry="texture",path="entity/banner/")] string` to specify that the resource location's path should implicitly start in that folder.

Also removes the unnecessary restrictions to categories defined in `Symbol`. This will make it possible to reference custom resources defined in the config or entirely custom resources by using the API.