### PR TITLE
 🐛Make `execute store ... score` define the score holder

### DIFF
--- a/packages/java-edition/src/mcfunction/tree/patch.ts
+++ b/packages/java-edition/src/mcfunction/tree/patch.ts
@@ -981,6 +981,22 @@ const ExecuteStoreTarget: PartialTreeNode = Object.freeze({
 				},
 			},
 		},
+		score: {
+			children: {
+				targets: {
+					properties: {
+						usageType: 'definition',
+					},
+					children: {
+						objective: {
+							properties: {
+								accessType: SymbolAccessType.Write,
+							},
+						},
+					},
+				},
+			},
+		},
 	},
 })
 


### PR DESCRIPTION
- Fixes #1521 

I think semantically this is not really a definition, it is just a reference with the "write" access type. But this seems to work the best for autocomplete for score holders