### PR TITLE
🐛 Fix "archive has not been loaded in memory" log spam

### DIFF
--- a/packages/core/src/service/FileService.ts
+++ b/packages/core/src/service/FileService.ts
@@ -267,7 +267,10 @@ export class ArchiveUriSupporter implements UriProtocolSupporter {
 	private getDataInArchive(archiveName: string, pathInArchive: string): Uint8Array {
 		const entries = this.entries.get(archiveName)
 		if (!entries) {
-			throw new Error(`Archive “${archiveName}” has not been loaded into the memory`)
+			throw this.externals.error.createKind(
+				'ENOENT',
+				`Archive “${archiveName}” has not been loaded into the memory`,
+			)
 		}
 		const entry = entries.get(pathInArchive)
 		if (!entry) {

--- a/packages/java-edition/src/index.ts
+++ b/packages/java-edition/src/index.ts
@@ -21,6 +21,7 @@ import * as jeMcf from './mcfunction/index.js'
 export * as binder from './binder/index.js'
 export * as dependency from './dependency/index.js'
 export * as json from './json/index.js'
+export * from './mcdocAttributes.js'
 export * as mcf from './mcfunction/index.js'
 
 export const initialize: core.ProjectInitializer = async (ctx) => {


### PR DESCRIPTION
- Fixes #1213 

This happens when an archive (like `archive://mcmeta.tar.gz`) was previously in the symbol cache, but after a restart is no longer present. By treating this as an `ENOENT` error, it will prevent the log spam, and files will be treated as if they're not present.