### PR TITLE
🐛 Fix `block_crumble` and `trail` particles not allowing options

### DIFF
--- a/packages/java-edition/src/mcfunction/checker/index.ts
+++ b/packages/java-edition/src/mcfunction/checker/index.ts
@@ -308,17 +308,15 @@ const particle: core.SyncChecker<ParticleNode> = (node, ctx) => {
 		return
 	}
 	const options = node.children?.find(nbt.NbtCompoundNode.is)
-	if (ParticleNode.requiresOptions(id)) {
-		if (options) {
-			nbt.checker.index('minecraft:particle', core.ResourceLocation.lengthen(id))(options, ctx)
-		} else {
-			ctx.err.report(
-				localize('expected', localize('nbt.node.compound')),
-				core.Range.create(node.id.range.end, node.id.range.end + 1),
-			)
-		}
-	} else if (options) {
-		ctx.err.report(localize('expected', localize('nothing')), options)
+	if (options) {
+		// Even if particle isn't explicitly marked as requiring options,
+		// run the type checker anyways to allow an empty compound
+		nbt.checker.index('minecraft:particle', core.ResourceLocation.lengthen(id))(options, ctx)
+	} else if (ParticleNode.requiresOptions(id)) {
+		ctx.err.report(
+			localize('expected', localize('nbt.node.compound')),
+			core.Range.create(node.id.range.end, node.id.range.end + 1),
+		)
 	}
 }
 // #endregion

--- a/packages/java-edition/src/mcfunction/node/argument.ts
+++ b/packages/java-edition/src/mcfunction/node/argument.ts
@@ -536,8 +536,10 @@ export namespace ParticleNode {
 	const OptionTypes = new Set(
 		[
 			...SpecialTypes,
+			'block_crumble',
 			'dust_pillar',
 			'entity_effect',
+			'trail',
 		],
 	)
 	export type OptionType = typeof SpecialTypes extends Set<infer T> ? T : undefined


### PR DESCRIPTION
Adds these two types to the list of particles requiring options, and also changes the checker to handle this more gracefully in the future.

The reason why we need this hardcoded list, is that otherwise we'd need to query mcdoc to determine something outside of JSON and SNBT, which we currently don't do yet. This could be changed in the future, but this is good enough for now.