### PR TITLE
🐛 Only show undeclaredSymbol warnings for data pack file categories

### DIFF
--- a/packages/core/src/service/Config.ts
+++ b/packages/core/src/service/Config.ts
@@ -2,7 +2,7 @@ import rfdc from 'rfdc'
 import type { ExternalEventEmitter } from '../common/index.js'
 import { Arrayable, bufferToString, merge, TypePredicates } from '../common/index.js'
 import { ErrorSeverity } from '../source/index.js'
-import { FileCategories, RegistryCategories } from '../symbol/index.js'
+import { DataFileCategories, FileCategories, RegistryCategories } from '../symbol/index.js'
 import type { Project } from './Project.js'
 /* eslint-disable no-restricted-syntax */
 
@@ -421,7 +421,7 @@ export const VanillaConfig: Config = {
 			{
 				if: [
 					{ category: RegistryCategories, namespace: 'minecraft' },
-					{ category: [...FileCategories, 'bossbar', 'objective', 'team'] },
+					{ category: [...DataFileCategories, 'bossbar', 'objective', 'team'] },
 				],
 				then: { report: 'warning' },
 			},


### PR DESCRIPTION
This is a workaround to fix undeclared warnings in data packs when the resource pack is not loaded. 

- Fixes #1663

As a side effect this will also hide these warnings for references in side resource packs, but there is currently not a great way to fix this without altering the config structure of the `undeclaredSymbol` rule.