### PR TITLE
🐛 Handle when config.env.gameVersion is undefined

### DIFF
--- a/packages/java-edition/src/dependency/mcmeta.ts
+++ b/packages/java-edition/src/dependency/mcmeta.ts
@@ -14,6 +14,7 @@ export function resolveConfiguredVersion(
 	versions: McmetaVersions,
 	packMcmeta: PackMcmeta | undefined,
 	packType: 'assets' | 'data' | undefined,
+	logger: core.Logger,
 ): VersionInfo {
 	function findReleaseTarget(version: McmetaVersion): string {
 		if (version.release_target) {
@@ -49,7 +50,14 @@ export function resolveConfiguredVersion(
 		throw new Error('mcmeta version list is empty')
 	}
 
+	// This should never happen, but for some reason happens sometimes
+	// https://github.com/SpyglassMC/Spyglass/issues/1621
+	if (inputVersion === undefined) {
+		logger.warn('[resolveConfiguredVersion] Input version was undefined! Falling back to "auto"')
+		inputVersion = 'auto'
+	}
 	inputVersion = inputVersion.toLowerCase()
+
 	versions = versions.sort((a, b) => b.data_version - a.data_version)
 	const latestRelease = versions.find((v) => v.type === 'release')
 	if (inputVersion === 'auto') {

--- a/packages/java-edition/src/index.ts
+++ b/packages/java-edition/src/index.ts
@@ -61,6 +61,7 @@ export const initialize: core.ProjectInitializer = async (ctx) => {
 						versions,
 						packMcmeta,
 						type,
+						logger,
 					)
 					packs.push({ type, packRoot, packMcmeta, versionInfo })
 				}
@@ -86,7 +87,7 @@ export const initialize: core.ProjectInitializer = async (ctx) => {
 		const pack = packs.find(p => p.packMcmeta !== undefined && p.type === 'data')
 			?? packs.find(p => p.packMcmeta !== undefined && p.type === 'assets')
 		const version = pack === undefined
-			? resolveConfiguredVersion(config.env.gameVersion, versions, undefined, undefined)
+			? resolveConfiguredVersion(config.env.gameVersion, versions, undefined, undefined, logger)
 			: pack.versionInfo
 		const packMessage = pack === undefined
 			? 'Failed finding a valid pack.mcmeta'

--- a/packages/java-edition/test/dependency/mcmeta.spec.ts
+++ b/packages/java-edition/test/dependency/mcmeta.spec.ts
@@ -57,6 +57,7 @@ describe('mcmeta', () => {
 					Fixtures.Versions,
 					packMcmeta,
 					undefined,
+					console,
 				)
 				snapshot(actual)
 			})


### PR DESCRIPTION
- Fixes #1621

Doesn't fix the cause (some kind of config init failure?), but at least handles this gracefully.