### PR TITLE
🐛 Ensure cache root exists before opening it

### DIFF
--- a/packages/core/src/service/Project.ts
+++ b/packages/core/src/service/Project.ts
@@ -963,6 +963,7 @@ export class Project implements ExternalEventEmitter {
 		}
 
 		try {
+			await fileUtil.ensureDir(this.externals, this.#cacheRoot)
 			await this.externals.fs.showFile(this.#cacheRoot)
 		} catch (e) {
 			this.logger.error('[Service#showCacheRoot]', e)


### PR DESCRIPTION
- Fixes #1563 