### PR TITLE
🐛 Add config to enable/disable mcdoc caching

### DIFF
--- a/packages/core/src/service/Config.ts
+++ b/packages/core/src/service/Config.ts
@@ -116,6 +116,12 @@ export interface EnvConfig {
 	permissionLevel: 1 | 2 | 3 | 4
 	plugins: string[]
 	/**
+	 * Whether to enable caching of mcdoc simplified types.
+	 *
+	 * May become corrupt after changing game versions, so this is currently disabled by default.
+	 */
+	enableMcdocCaching: boolean
+	/**
 	 * Makes the file-watcher use polling to watch for file changes.
 	 * Comes at a performance cost for very large datapacks.
 	 *
@@ -362,6 +368,7 @@ export const VanillaConfig: Config = {
 		permissionLevel: 2,
 		plugins: [],
 		mcmetaSummaryOverrides: {},
+		enableMcdocCaching: false,
 		useFilePolling: false,
 	},
 	format: {

--- a/packages/mcdoc/src/runtime/checker/index.ts
+++ b/packages/mcdoc/src/runtime/checker/index.ts
@@ -823,7 +823,7 @@ function simplifyReference<T>(
 		context.ctx.logger.warn(`Tried to access unknown reference ${typeDef.path}`)
 		return { typeDef: { kind: 'union', members: [] } }
 	}
-	if (data.simplifiedTypeDef) {
+	if (context.ctx.config.env.enableMcdocCaching && data.simplifiedTypeDef) {
 		return { typeDef: data.simplifiedTypeDef }
 	}
 	const simplifiedResult = simplify(data.typeDef, context)
@@ -833,7 +833,7 @@ function simplifyReference<T>(
 			attributes: [...typeDef.attributes, ...simplifiedResult.typeDef.attributes ?? []],
 		}
 	}
-	if (!simplifiedResult.dynamicData) {
+	if (context.ctx.config.env.enableMcdocCaching && !simplifiedResult.dynamicData) {
 		symbol.amend({
 			data: {
 				data: {
@@ -903,7 +903,7 @@ function resolveIndices<T>(
 	let dynamicData = false
 	let values: SimplifiedMcdocTypeNoUnion[] = []
 	function pushValue(key: string, data: TypeDefSymbolData) {
-		if (data.simplifiedTypeDef) {
+		if (context.ctx.config.env.enableMcdocCaching && data.simplifiedTypeDef) {
 			if (data.simplifiedTypeDef.kind === 'union') {
 				values.push(...data.simplifiedTypeDef.members)
 			} else {
@@ -913,7 +913,7 @@ function resolveIndices<T>(
 			const simplifiedResult = simplify(data.typeDef, context)
 			if (simplifiedResult.dynamicData) {
 				dynamicData = true
-			} else if (symbolQuery) {
+			} else if (context.ctx.config.env.enableMcdocCaching && symbolQuery) {
 				symbolQuery.member(
 					key,
 					s =>


### PR DESCRIPTION
- Fixes #1655

The config is disabled by default, because my estimate is that there are more people affected by corrupt caches than there are affected by performance issues due to huge NBT/JSON, since switching game versions is fairly common.