### PR TITLE
✨ Mcdoc binding improvements

### DIFF
--- a/__snapshots__/packages/mcdoc/test-out/__fixture__/dispatcher/random_number_generator.spec.js
+++ b/__snapshots__/packages/mcdoc/test-out/__fixture__/dispatcher/random_number_generator.spec.js
@@ -734,48 +734,8 @@ exports['mcdoc __fixture__ dispatcher/random number generator 1'] = {
           "rng": {
             "data": {
               "typeDef": {
-                "kind": "struct",
-                "fields": [
-                  {
-                    "kind": "pair",
-                    "key": "type",
-                    "type": {
-                      "kind": "union",
-                      "members": [
-                        {
-                          "kind": "literal",
-                          "value": {
-                            "kind": "string",
-                            "value": "uniform"
-                          }
-                        },
-                        {
-                          "kind": "literal",
-                          "value": {
-                            "kind": "string",
-                            "value": "binomial"
-                          }
-                        }
-                      ]
-                    },
-                    "optional": true
-                  },
-                  {
-                    "kind": "spread",
-                    "type": {
-                      "kind": "dispatcher",
-                      "parallelIndices": [
-                        {
-                          "kind": "dynamic",
-                          "accessor": [
-                            "type"
-                          ]
-                        }
-                      ],
-                      "registry": "minecraft:rng"
-                    }
-                  }
-                ]
+                "kind": "reference",
+                "path": "::test::RNG"
               }
             },
             "definition": [

--- a/packages/json/src/completer/index.ts
+++ b/packages/json/src/completer/index.ts
@@ -39,6 +39,7 @@ const object = core.completer.record<JsonStringNode, JsonNode, JsonObjectNode>({
 				core.CompletionItem.create(key, pair?.key ?? range, {
 					kind: core.CompletionKind.Field,
 					detail: mcdoc.McdocType.toString(field.type as core.Mutable<mcdoc.McdocType>),
+					documentation: field.desc,
 					deprecated: field.deprecated,
 					sortText: field.optional ? '$b' : '$a', // sort above hardcoded $schema
 					filterText: `"${key}"`,
@@ -83,11 +84,14 @@ function getValues(
 	ctx: core.CompleterContext,
 ): core.CompletionItem[] {
 	return mcdoc.runtime.completer.getValues(typeDef, ctx)
-		.map(({ value, labelSuffix, detail, kind, completionKind, insertText, sortText }) =>
+		.map((
+			{ value, labelSuffix, detail, documentation, kind, completionKind, insertText, sortText },
+		) =>
 			core.CompletionItem.create(value, range, {
 				kind: completionKind ?? core.CompletionKind.Value,
 				labelSuffix,
 				detail,
+				documentation,
 				filterText: kind === 'string' ? `"${value}"` : value,
 				insertText: kind === 'string' ? `"${insertText ?? value}"` : insertText ?? value,
 				sortText,

--- a/packages/language-server/src/util/toLS.ts
+++ b/packages/language-server/src/util/toLS.ts
@@ -197,7 +197,7 @@ export function completionItem(
 		kind: completion.kind,
 		...(completion.labelSuffix ? { labelDetails: { detail: completion.labelSuffix } } : {}),
 		detail: completion.detail,
-		documentation: completion.documentation,
+		documentation: completion.documentation ? markupContent(completion.documentation) : undefined,
 		filterText: completion.filterText,
 		sortText: completion.sortText,
 		textEdit,

--- a/packages/mcdoc-cli/src/commands/locale.ts
+++ b/packages/mcdoc-cli/src/commands/locale.ts
@@ -48,11 +48,11 @@ export async function localeCommand(args: Args) {
 				collect(name, member)
 			})
 		} else if (type.kind === 'enum') {
-			// for (const field of type.values) {
-			// 	if (field.desc) {
-			// 		add(`${name}.${field.identifier}`, field.desc)
-			// 	}
-			// }
+			for (const field of type.values) {
+				if (field.desc) {
+					add(`${name}.${field.identifier}`, field.desc)
+				}
+			}
 		} else if (type.kind === 'list') {
 			collect(name, type.item)
 		} else if (type.kind === 'tuple') {

--- a/packages/mcdoc/src/binder/index.ts
+++ b/packages/mcdoc/src/binder/index.ts
@@ -862,9 +862,10 @@ function convertEnumBlock(node: EnumBlockNode, ctx: McdocBinderContext): EnumTyp
 }
 
 function convertEnumField(node: EnumFieldNode, ctx: McdocBinderContext): EnumTypeField {
-	const { attributes, identifier, value } = EnumFieldNode.destruct(node)
+	const { attributes, docComments, identifier, value } = EnumFieldNode.destruct(node)
 	return {
 		attributes: convertAttributes(attributes, ctx),
+		desc: DocCommentsNode.asText(docComments),
 		identifier: identifier.value,
 		value: convertEnumValue(value, ctx),
 	}

--- a/packages/mcdoc/src/binder/index.ts
+++ b/packages/mcdoc/src/binder/index.ts
@@ -852,7 +852,7 @@ function convertTypeArgBlock(node: TypeArgBlockNode, ctx: McdocBinderContext): M
 function convertEnum(node: EnumNode, ctx: McdocBinderContext): McdocType {
 	const { block, enumKind, identifier } = EnumNode.destruct(node)
 
-	// Return reference if the struct has been hoisted
+	// Return reference if the enum has been hoisted
 	if (identifier && !ctx.isHoisting) {
 		return { kind: 'reference', path: `${ctx.moduleIdentifier}::${identifier.value}` }
 	}

--- a/packages/mcdoc/src/common.ts
+++ b/packages/mcdoc/src/common.ts
@@ -13,7 +13,3 @@ export function identifierToSeg(identifier: string): Segments {
 export function segToIdentifier(seg: Segments): string {
 	return `::${seg.join('::')}`
 }
-
-export interface AdditionalContext {
-	moduleIdentifier: string
-}

--- a/packages/mcdoc/src/node/index.ts
+++ b/packages/mcdoc/src/node/index.ts
@@ -622,9 +622,15 @@ export interface EnumFieldNode extends AstNode {
 export namespace EnumFieldNode {
 	export function destruct(
 		node: EnumFieldNode,
-	): { attributes: AttributeNode[]; identifier: IdentifierNode; value: EnumValueNode } {
+	): {
+		attributes: AttributeNode[]
+		docComments?: DocCommentsNode
+		identifier: IdentifierNode
+		value: EnumValueNode
+	} {
 		return {
 			attributes: node.children.filter(AttributeNode.is),
+			docComments: node.children.find(DocCommentsNode.is),
 			identifier: node.children.find(IdentifierNode.is)!,
 			value: node.children.find(EnumValueNode.is)!,
 		}

--- a/packages/mcdoc/src/runtime/completer/index.ts
+++ b/packages/mcdoc/src/runtime/completer/index.ts
@@ -61,6 +61,7 @@ export function getFields(
 export type SimpleCompletionValue = {
 	value: string
 	detail?: string
+	documentation?: string
 	labelSuffix?: string
 	kind?: McdocType['kind']
 	completionKind?: core.CompletionKind
@@ -131,6 +132,7 @@ export function getValues(
 				value: `${v.value}`,
 				detail: v.identifier,
 				kind: typeDef.enumKind ?? 'string',
+				documentation: v.desc,
 			}))
 		case 'byte':
 		case 'short':

--- a/packages/mcdoc/src/type/index.ts
+++ b/packages/mcdoc/src/type/index.ts
@@ -612,7 +612,3 @@ export namespace McdocType {
 		return attributesString + typeString
 	}
 }
-
-export interface UseStatementBindingData {
-	target: readonly string[]
-}

--- a/packages/mcdoc/src/type/index.ts
+++ b/packages/mcdoc/src/type/index.ts
@@ -217,6 +217,7 @@ export interface EnumType extends McdocBaseType {
 export interface EnumTypeField extends McdocBaseType {
 	identifier: string
 	value: string | number
+	desc?: string
 }
 
 export interface ReferenceType extends McdocBaseType {

--- a/packages/nbt/src/completer/index.ts
+++ b/packages/nbt/src/completer/index.ts
@@ -44,6 +44,7 @@ const compound = core.completer.record<NbtStringNode, NbtNode, NbtCompoundNode>(
 				core.CompletionItem.create(key, pair?.key ?? range, {
 					kind: core.CompletionKind.Field,
 					detail: mcdoc.McdocType.toString(field.type as core.Mutable<mcdoc.McdocType>),
+					documentation: field.desc,
 					deprecated: field.deprecated,
 					sortText: field.optional ? '$b' : '$a', // sort above hardcoded $schema
 					filterText: formatKey(key, pair?.key?.quote),
@@ -126,6 +127,7 @@ function getPathKeys(
 			core.CompletionItem.create(key, range, {
 				kind: core.CompletionKind.Field,
 				detail: mcdoc.McdocType.toString(field.type as core.Mutable<mcdoc.McdocType>),
+				documentation: field.desc,
 				deprecated: field.deprecated,
 				sortText: field.optional ? '$b' : '$a', // sort above hardcoded $schema
 				filterText: formatKey(key, quote),
@@ -140,11 +142,14 @@ function getValues(
 	ctx: mcdoc.runtime.completer.McdocCompleterContext,
 ): core.CompletionItem[] {
 	return mcdoc.runtime.completer.getValues(typeDef, ctx)
-		.map(({ value, labelSuffix, detail, kind, completionKind, insertText, sortText }) =>
+		.map((
+			{ value, labelSuffix, detail, documentation, kind, completionKind, insertText, sortText },
+		) =>
 			core.CompletionItem.create(value, range, {
 				kind: completionKind ?? core.CompletionKind.Value,
 				labelSuffix,
 				detail,
+				documentation,
 				filterText: formatValue(value, kind),
 				insertText: formatValue(insertText ?? value, kind),
 				sortText,


### PR DESCRIPTION
## Changes
* Added a `desc` field to `McdocType` enum values containing their doc comment
* Replaced nested structs and enums with references during binding, because they are hoisted anyways
  * Reduces the symbol cache file from 15.3M characters (1043KB gzipped) -> 14.9M characters (1006KB gzipped)
  * Reduces the mcdoc-cli's export from 128K lines -> 88K lines

## New Features
* Field documentation now shows up in autocomplete
![image](https://github.com/user-attachments/assets/8447c546-797c-4c8f-a643-20544797895e)
