### PR TITLE
🐛 Improve command literal parsing

### DIFF
--- a/__snapshots__/packages/java-edition/test-out/mcfunction/parser/argument/minecraftItemSlot.spec.js
+++ b/__snapshots__/packages/java-edition/test-out/mcfunction/parser/argument/minecraftItemSlot.spec.js
@@ -11,8 +11,24 @@ exports['mcfunction argument minecraft:item_slot Parse "container.5" 1'] = {
 }
 
 exports['mcfunction argument minecraft:item_slot Parse "contents" 1'] = {
-  "node": "FAILURE",
-  "errors": []
+  "node": {
+    "type": "literal",
+    "range": {
+      "start": 0,
+      "end": 8
+    },
+    "value": "contents"
+  },
+  "errors": [
+    {
+      "range": {
+        "start": 0,
+        "end": 0
+      },
+      "message": "Expected “weapon.mainhand”, “weapon.offhand”, “enderchest.10”, “enderchest.11”, “enderchest.12”, “enderchest.13”, “enderchest.14”, “enderchest.15”, “enderchest.16”, “enderchest.17”, “enderchest.18”, “enderchest.19”, “enderchest.20”, “enderchest.21”, “enderchest.22”, “enderchest.23”, “enderchest.24”, “enderchest.25”, “enderchest.26”, “container.10”, “container.11”, “container.12”, “container.13”, “container.14”, “container.15”, “container.16”, “container.17”, “container.18”, “container.19”, “container.20”, “container.21”, “container.22”, “container.23”, “container.24”, “container.25”, “container.26”, “container.27”, “container.28”, “container.29”, “container.30”, “container.31”, “container.32”, “container.33”, “container.34”, “container.35”, “container.36”, “container.37”, “container.38”, “container.39”, “container.40”, “container.41”, “container.42”, “container.43”, “container.44”, “container.45”, “container.46”, “container.47”, “container.48”, “container.49”, “container.50”, “container.51”, “container.52”, “container.53”, “enderchest.0”, “enderchest.1”, “enderchest.2”, “enderchest.3”, “enderchest.4”, “enderchest.5”, “enderchest.6”, “enderchest.7”, “enderchest.8”, “enderchest.9”, “inventory.10”, “inventory.11”, “inventory.12”, “inventory.13”, “inventory.14”, “inventory.15”, “inventory.16”, “inventory.17”, “inventory.18”, “inventory.19”, “inventory.20”, “inventory.21”, “inventory.22”, “inventory.23”, “inventory.24”, “inventory.25”, “inventory.26”, “horse.saddle”, “container.0”, “container.1”, “container.2”, “container.3”, “container.4”, “container.5”, “container.6”, “container.7”, “container.8”, “container.9”, “inventory.0”, “inventory.1”, “inventory.2”, “inventory.3”, “inventory.4”, “inventory.5”, “inventory.6”, “inventory.7”, “inventory.8”, “inventory.9”, “armor.chest”, “horse.chest”, “horse.armor”, “villager.0”, “villager.1”, “villager.2”, “villager.3”, “villager.4”, “villager.5”, “villager.6”, “villager.7”, “armor.feet”, “armor.head”, “armor.legs”, “horse.10”, “horse.11”, “horse.12”, “horse.13”, “horse.14”, “hotbar.0”, “hotbar.1”, “hotbar.2”, “hotbar.3”, “hotbar.4”, “hotbar.5”, “hotbar.6”, “hotbar.7”, “hotbar.8”, “horse.0”, “horse.1”, “horse.2”, “horse.3”, “horse.4”, “horse.5”, “horse.6”, “horse.7”, “horse.8”, “horse.9”, or “weapon”",
+      "severity": 3
+    }
+  ]
 }
 
 exports['mcfunction argument minecraft:item_slot Parse "contents" in version 1.20.5 1'] = {
@@ -28,8 +44,24 @@ exports['mcfunction argument minecraft:item_slot Parse "contents" in version 1.2
 }
 
 exports['mcfunction argument minecraft:item_slot Parse "horse.armor" in version 1.20.5 1'] = {
-  "node": "FAILURE",
-  "errors": []
+  "node": {
+    "type": "literal",
+    "range": {
+      "start": 0,
+      "end": 11
+    },
+    "value": "horse.armor"
+  },
+  "errors": [
+    {
+      "range": {
+        "start": 0,
+        "end": 0
+      },
+      "message": "Expected “player.crafting.0”, “player.crafting.1”, “player.crafting.2”, “player.crafting.3”, “weapon.mainhand”, “weapon.offhand”, “enderchest.10”, “enderchest.11”, “enderchest.12”, “enderchest.13”, “enderchest.14”, “enderchest.15”, “enderchest.16”, “enderchest.17”, “enderchest.18”, “enderchest.19”, “enderchest.20”, “enderchest.21”, “enderchest.22”, “enderchest.23”, “enderchest.24”, “enderchest.25”, “enderchest.26”, “player.cursor”, “container.10”, “container.11”, “container.12”, “container.13”, “container.14”, “container.15”, “container.16”, “container.17”, “container.18”, “container.19”, “container.20”, “container.21”, “container.22”, “container.23”, “container.24”, “container.25”, “container.26”, “container.27”, “container.28”, “container.29”, “container.30”, “container.31”, “container.32”, “container.33”, “container.34”, “container.35”, “container.36”, “container.37”, “container.38”, “container.39”, “container.40”, “container.41”, “container.42”, “container.43”, “container.44”, “container.45”, “container.46”, “container.47”, “container.48”, “container.49”, “container.50”, “container.51”, “container.52”, “container.53”, “enderchest.0”, “enderchest.1”, “enderchest.2”, “enderchest.3”, “enderchest.4”, “enderchest.5”, “enderchest.6”, “enderchest.7”, “enderchest.8”, “enderchest.9”, “inventory.10”, “inventory.11”, “inventory.12”, “inventory.13”, “inventory.14”, “inventory.15”, “inventory.16”, “inventory.17”, “inventory.18”, “inventory.19”, “inventory.20”, “inventory.21”, “inventory.22”, “inventory.23”, “inventory.24”, “inventory.25”, “inventory.26”, “horse.saddle”, “container.0”, “container.1”, “container.2”, “container.3”, “container.4”, “container.5”, “container.6”, “container.7”, “container.8”, “container.9”, “inventory.0”, “inventory.1”, “inventory.2”, “inventory.3”, “inventory.4”, “inventory.5”, “inventory.6”, “inventory.7”, “inventory.8”, “inventory.9”, “armor.chest”, “horse.chest”, “villager.0”, “villager.1”, “villager.2”, “villager.3”, “villager.4”, “villager.5”, “villager.6”, “villager.7”, “armor.feet”, “armor.head”, “armor.legs”, “armor.body”, “horse.10”, “horse.11”, “horse.12”, “horse.13”, “horse.14”, “hotbar.0”, “hotbar.1”, “hotbar.2”, “hotbar.3”, “hotbar.4”, “hotbar.5”, “hotbar.6”, “hotbar.7”, “hotbar.8”, “contents”, “horse.0”, “horse.1”, “horse.2”, “horse.3”, “horse.4”, “horse.5”, “horse.6”, “horse.7”, “horse.8”, “horse.9”, or “weapon”",
+      "severity": 3
+    }
+  ]
 }
 
 exports['mcfunction argument minecraft:item_slot Parse "weapon" 1'] = {

--- a/__snapshots__/packages/java-edition/test-out/mcfunction/parser/argument/minecraftScoreboardSlot.spec.js
+++ b/__snapshots__/packages/java-edition/test-out/mcfunction/parser/argument/minecraftScoreboardSlot.spec.js
@@ -11,13 +11,45 @@ exports['mcfunction argument minecraft:scoreboard_slot Parse "belowName" 1'] = {
 }
 
 exports['mcfunction argument minecraft:scoreboard_slot Parse "belowName" in version 1.20.2 1'] = {
-  "node": "FAILURE",
-  "errors": []
+  "node": {
+    "type": "literal",
+    "range": {
+      "start": 0,
+      "end": 9
+    },
+    "value": "belowName"
+  },
+  "errors": [
+    {
+      "range": {
+        "start": 0,
+        "end": 0
+      },
+      "message": "Expected “sidebar.team.light_purple”, “sidebar.team.dark_purple”, “sidebar.team.dark_green”, “sidebar.team.dark_aqua”, “sidebar.team.dark_blue”, “sidebar.team.dark_gray”, “sidebar.team.dark_red”, “sidebar.team.yellow”, “sidebar.team.black”, “sidebar.team.green”, “sidebar.team.white”, “sidebar.team.aqua”, “sidebar.team.blue”, “sidebar.team.gold”, “sidebar.team.gray”, “sidebar.team.red”, “below_name”, “sidebar”, or “list”",
+      "severity": 3
+    }
+  ]
 }
 
 exports['mcfunction argument minecraft:scoreboard_slot Parse "below_name" 1'] = {
-  "node": "FAILURE",
-  "errors": []
+  "node": {
+    "type": "literal",
+    "range": {
+      "start": 0,
+      "end": 10
+    },
+    "value": "below_name"
+  },
+  "errors": [
+    {
+      "range": {
+        "start": 0,
+        "end": 0
+      },
+      "message": "Expected “sidebar.team.light_purple”, “sidebar.team.dark_purple”, “sidebar.team.dark_green”, “sidebar.team.dark_aqua”, “sidebar.team.dark_blue”, “sidebar.team.dark_gray”, “sidebar.team.dark_red”, “sidebar.team.yellow”, “sidebar.team.black”, “sidebar.team.green”, “sidebar.team.white”, “sidebar.team.aqua”, “sidebar.team.blue”, “sidebar.team.gold”, “sidebar.team.gray”, “sidebar.team.red”, “belowName”, “sidebar”, or “list”",
+      "severity": 3
+    }
+  ]
 }
 
 exports['mcfunction argument minecraft:scoreboard_slot Parse "below_name" in version 1.20.2 1'] = {

--- a/packages/java-edition/src/mcfunction/mcdocAttributes.ts
+++ b/packages/java-edition/src/mcfunction/mcdocAttributes.ts
@@ -109,7 +109,7 @@ export function registerMcdocAttributes(meta: core.MetaRegistry, rootTreeNode: m
 			}),
 	})
 	mcdoc.runtime.registerAttribute(meta, 'item_slots', () => undefined, {
-		stringParser: () => parser.itemSlots,
+		stringParser: (_, __, ctx) => core.literal({ pool: getItemSlotsArgumentValues(ctx) }),
 		stringMocker: (_, __, ctx) =>
 			core.LiteralNode.mock(ctx.offset, { pool: getItemSlotsArgumentValues(ctx) }),
 	})


### PR DESCRIPTION
- Fixes #1685

Also improves error messages drastically in other literal arguments:
|Before|After|
|---|---|
|![image](https://github.com/user-attachments/assets/e7259414-a10f-42cd-870a-6379c7fd6f2c)|![image](https://github.com/user-attachments/assets/179c31d4-6c44-417f-ae17-5b40161caa9e)|
