### PR TITLE
🐛 Fix exclude config behavior

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13726,9 +13726,7 @@
 			"name": "@spyglassmc/java-edition",
 			"version": "0.1.0-PLACEHOLDER",
 			"license": "MIT",
-			"devDependencies": {
-				"fast-glob": "^3.2.5"
-			}
+			"devDependencies": {}
 		},
 		"packages/json": {
 			"name": "@spyglassmc/json",
@@ -15172,10 +15170,7 @@
 			}
 		},
 		"@spyglassmc/java-edition": {
-			"version": "file:packages/java-edition",
-			"requires": {
-				"fast-glob": "^3.2.5"
-			}
+			"version": "file:packages/java-edition"
 		},
 		"@spyglassmc/json": {
 			"version": "file:packages/json"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1852,6 +1852,12 @@
 			"integrity": "sha512-EDKtLYNMKrig22jEvhXq8TBFyFgVNSPmDF2b9UzJ7+eylPqdZVo17PCUMkn1jP6/1A/0u78VqYC6VrX6b8pDWA==",
 			"dev": true
 		},
+		"node_modules/@types/braces": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@types/braces/-/braces-3.0.4.tgz",
+			"integrity": "sha512-0WR3b8eaISjEW7RpZnclONaLFDf7buaowRHdqLp4vLj54AsSAYWfh3DRbfiYJY9XDxMgx1B4sE1Afw2PGpuHOA==",
+			"dev": true
+		},
 		"node_modules/@types/decompress": {
 			"version": "4.2.3",
 			"resolved": "https://registry.npmjs.org/@types/decompress/-/decompress-4.2.3.tgz",
@@ -1927,6 +1933,15 @@
 			"resolved": "https://registry.npmjs.org/@types/line-column/-/line-column-1.0.0.tgz",
 			"integrity": "sha512-wbw+IDRw/xY/RGy+BL6f4Eey4jsUgHQrMuA4Qj0CSG3x/7C2Oc57pmRoM2z3M4DkylWRz+G1pfX06sCXQm0J+w==",
 			"dev": true
+		},
+		"node_modules/@types/micromatch": {
+			"version": "4.0.9",
+			"resolved": "https://registry.npmjs.org/@types/micromatch/-/micromatch-4.0.9.tgz",
+			"integrity": "sha512-7V+8ncr22h4UoYRLnLXSpTxjQrNUXtWHGeMPRJt1nULXI57G9bIcpyrHlmrQ7QK24EyyuXvYcSSWAM8GA9nqCg==",
+			"dev": true,
+			"dependencies": {
+				"@types/braces": "*"
+			}
 		},
 		"node_modules/@types/mocha": {
 			"version": "10.0.1",
@@ -9074,7 +9089,6 @@
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
 			"integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-			"dev": true,
 			"dependencies": {
 				"braces": "^3.0.3",
 				"picomatch": "^2.3.1"
@@ -13660,6 +13674,7 @@
 				"chokidar": "^3.5.2",
 				"decompress": "^4.2.1",
 				"follow-redirects": "^1.14.8",
+				"micromatch": "^4.0.8",
 				"pako": "^2.0.4",
 				"rfdc": "^1.3.0",
 				"vscode-languageserver-textdocument": "^1.0.4",
@@ -13668,6 +13683,7 @@
 			"devDependencies": {
 				"@types/decompress": "^4.2.3",
 				"@types/follow-redirects": "^1.14.1",
+				"@types/micromatch": "^4.0.9",
 				"@types/pako": "^2.0.0",
 				"@types/whatwg-url": "^11.0.4"
 			}
@@ -15116,6 +15132,7 @@
 			"requires": {
 				"@types/decompress": "^4.2.3",
 				"@types/follow-redirects": "^1.14.1",
+				"@types/micromatch": "^4.0.9",
 				"@types/pako": "^2.0.0",
 				"@types/whatwg-url": "^11.0.4",
 				"base64-arraybuffer": "^1.0.2",
@@ -15123,6 +15140,7 @@
 				"chokidar": "^3.5.2",
 				"decompress": "^4.2.1",
 				"follow-redirects": "^1.14.8",
+				"micromatch": "^4.0.8",
 				"pako": "^2.0.4",
 				"rfdc": "^1.3.0",
 				"vscode-languageserver-textdocument": "^1.0.4",
@@ -15304,6 +15322,12 @@
 			"integrity": "sha512-EDKtLYNMKrig22jEvhXq8TBFyFgVNSPmDF2b9UzJ7+eylPqdZVo17PCUMkn1jP6/1A/0u78VqYC6VrX6b8pDWA==",
 			"dev": true
 		},
+		"@types/braces": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@types/braces/-/braces-3.0.4.tgz",
+			"integrity": "sha512-0WR3b8eaISjEW7RpZnclONaLFDf7buaowRHdqLp4vLj54AsSAYWfh3DRbfiYJY9XDxMgx1B4sE1Afw2PGpuHOA==",
+			"dev": true
+		},
 		"@types/decompress": {
 			"version": "4.2.3",
 			"resolved": "https://registry.npmjs.org/@types/decompress/-/decompress-4.2.3.tgz",
@@ -15379,6 +15403,15 @@
 			"resolved": "https://registry.npmjs.org/@types/line-column/-/line-column-1.0.0.tgz",
 			"integrity": "sha512-wbw+IDRw/xY/RGy+BL6f4Eey4jsUgHQrMuA4Qj0CSG3x/7C2Oc57pmRoM2z3M4DkylWRz+G1pfX06sCXQm0J+w==",
 			"dev": true
+		},
+		"@types/micromatch": {
+			"version": "4.0.9",
+			"resolved": "https://registry.npmjs.org/@types/micromatch/-/micromatch-4.0.9.tgz",
+			"integrity": "sha512-7V+8ncr22h4UoYRLnLXSpTxjQrNUXtWHGeMPRJt1nULXI57G9bIcpyrHlmrQ7QK24EyyuXvYcSSWAM8GA9nqCg==",
+			"dev": true,
+			"requires": {
+				"@types/braces": "*"
+			}
 		},
 		"@types/mocha": {
 			"version": "10.0.1",
@@ -20612,7 +20645,6 @@
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
 			"integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-			"dev": true,
 			"requires": {
 				"braces": "^3.0.3",
 				"picomatch": "^2.3.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -7566,6 +7566,7 @@
 			"version": "5.3.1",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
 			"integrity": "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==",
+			"dev": true,
 			"engines": {
 				"node": ">= 4"
 			}
@@ -13659,7 +13660,6 @@
 				"chokidar": "^3.5.2",
 				"decompress": "^4.2.1",
 				"follow-redirects": "^1.14.8",
-				"ignore": "^5.3.1",
 				"pako": "^2.0.4",
 				"rfdc": "^1.3.0",
 				"vscode-languageserver-textdocument": "^1.0.4",
@@ -15123,7 +15123,6 @@
 				"chokidar": "^3.5.2",
 				"decompress": "^4.2.1",
 				"follow-redirects": "^1.14.8",
-				"ignore": "^5.3.1",
 				"pako": "^2.0.4",
 				"rfdc": "^1.3.0",
 				"vscode-languageserver-textdocument": "^1.0.4",
@@ -19476,7 +19475,8 @@
 		"ignore": {
 			"version": "5.3.1",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
-			"integrity": "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw=="
+			"integrity": "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==",
+			"dev": true
 		},
 		"import-fresh": {
 			"version": "3.3.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,6 +19,7 @@
     "chokidar": "^3.5.2",
     "decompress": "^4.2.1",
     "follow-redirects": "^1.14.8",
+    "micromatch": "^4.0.8",
     "pako": "^2.0.4",
     "rfdc": "^1.3.0",
     "vscode-languageserver-textdocument": "^1.0.4",
@@ -27,6 +28,7 @@
   "devDependencies": {
     "@types/decompress": "^4.2.3",
     "@types/follow-redirects": "^1.14.1",
+    "@types/micromatch": "^4.0.9",
     "@types/pako": "^2.0.0",
     "@types/whatwg-url": "^11.0.4"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,7 +19,6 @@
     "chokidar": "^3.5.2",
     "decompress": "^4.2.1",
     "follow-redirects": "^1.14.8",
-    "ignore": "^5.3.1",
     "pako": "^2.0.4",
     "rfdc": "^1.3.0",
     "vscode-languageserver-textdocument": "^1.0.4",

--- a/packages/core/src/service/CacheService.ts
+++ b/packages/core/src/service/CacheService.ts
@@ -174,6 +174,10 @@ export class CacheService {
 				ans.unchangedFiles.push(uri)
 				continue
 			}
+			if (this.project.shouldExclude(uri)) {
+				ans.removedFiles.push(uri)
+				continue
+			}
 
 			try {
 				const hash = await this.project.fs.hash(uri)

--- a/packages/core/src/service/CacheService.ts
+++ b/packages/core/src/service/CacheService.ts
@@ -175,10 +175,6 @@ export class CacheService {
 				continue
 			}
 
-			if (this.project.ignore.ignores(uri)) {
-				ans.unchangedFiles.push(uri)
-				continue
-			}
 			try {
 				const hash = await this.project.fs.hash(uri)
 				if (hash === checksum) {

--- a/packages/core/src/service/Config.ts
+++ b/packages/core/src/service/Config.ts
@@ -65,7 +65,7 @@ export interface EnvConfig {
 	 */
 	dependencies: string[]
 	/**
-	 * A list of file patterns to exclude. Each value in this array can either be a glob pattern or the special string `@gitignore`.
+	 * A list of file patterns to exclude.
 	 */
 	exclude: string[]
 	/**
@@ -336,7 +336,7 @@ export const VanillaConfig: Config = {
 	env: {
 		dataSource: 'GitHub',
 		dependencies: ['@vanilla-datapack', '@vanilla-resourcepack', '@vanilla-mcdoc'],
-		exclude: ['@gitignore', '.vscode/', '.github/'],
+		exclude: [],
 		customResources: {},
 		feature: {
 			codeActions: true,

--- a/packages/core/src/service/Config.ts
+++ b/packages/core/src/service/Config.ts
@@ -336,7 +336,7 @@ export const VanillaConfig: Config = {
 	env: {
 		dataSource: 'GitHub',
 		dependencies: ['@vanilla-datapack', '@vanilla-resourcepack', '@vanilla-mcdoc'],
-		exclude: [],
+		exclude: ['.*/**'],
 		customResources: {},
 		feature: {
 			codeActions: true,

--- a/packages/java-edition/package.json
+++ b/packages/java-edition/package.json
@@ -17,9 +17,7 @@
     "release:dry": "npm publish --dry-run"
   },
   "dependencies": {},
-  "devDependencies": {
-    "fast-glob": "^3.2.5"
-  },
+  "devDependencies": {},
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
- [x] No longer excludes `.gitignore` by default
- [x] Fixes #1609 
- [x] Exclude only project files, not dependency files
- [x] Has a builtin config for common exclude patterns (such as `.git`)