### PR TITLE
🐛 Fix hash of binary files in cache service

### DIFF
--- a/packages/core/src/service/Project.ts
+++ b/packages/core/src/service/Project.ts
@@ -36,7 +36,7 @@ import { fileUtil } from './fileUtil.js'
 import { MetaRegistry } from './MetaRegistry.js'
 import { ProfilerFactory } from './Profiler.js'
 
-const CacheAutoSaveInterval = 600_000 // 10 Minutes.
+const CacheAutoSaveInterval = 300_000 // 5 Minutes.
 
 export type ProjectInitializerContext = Pick<
 	Project,
@@ -160,7 +160,7 @@ export class Project implements ExternalEventEmitter {
 
 	/** Prevent circular binding. */
 	readonly #bindingInProgressUris = new Set<string>()
-	readonly #cacheSaverIntervalId: IntervalId
+	#cacheSaverIntervalId: IntervalId | undefined = undefined
 	readonly cacheService: CacheService
 	/** URI of files that are currently managed by the language client. */
 	readonly #clientManagedUris = new Set<string>()
@@ -341,10 +341,6 @@ export class Project implements ExternalEventEmitter {
 
 		this.setInitPromise()
 		this.setReadyPromise()
-		this.#cacheSaverIntervalId = setInterval(
-			() => this.cacheService.save(),
-			CacheAutoSaveInterval,
-		)
 
 		this.on('documentUpdated', ({ doc, node }) => {
 			// if (!this.#isReady) {
@@ -586,6 +582,13 @@ export class Project implements ExternalEventEmitter {
 
 			__profiler.finalize()
 			this.emit('ready', {})
+
+			// Save the cache after ready and start the auto-cache interval
+			await this.cacheService.save()
+			this.#cacheSaverIntervalId = setInterval(
+				() => this.cacheService.save(),
+				CacheAutoSaveInterval,
+			)
 		}
 		this.#isReady = false
 		this.#readyPromise = ready()


### PR DESCRIPTION
- [x] Fixes #1706 
- [x] Also fixes the TODO not hashing on every file change
- [x] Flush the dirty files list every so often (once it reaches a limit for example), to avoid having to do all that work at once when saving the cache

Also slightly tweaks the auto-cache interval behavior. The timer will now only start when the project is ready, changed the interval from 10 minutes to 5 minutes, and the project will now be cached immediately after ready, instead of having to wait potentially 10 minutes.