### PR TITLE
🐛 Ignore non-Minecraft JSON files

### DIFF
--- a/packages/core/src/service/CacheService.ts
+++ b/packages/core/src/service/CacheService.ts
@@ -3,6 +3,7 @@ import { Uri } from '../common/index.js'
 import type { PosRangeLanguageError } from '../source/index.js'
 import type { UnlinkedSymbolTable } from '../symbol/index.js'
 import { SymbolTable } from '../symbol/index.js'
+import { ArchiveUriSupporter } from './FileService.js'
 import type { RootUriString } from './fileUtil.js'
 import { fileUtil } from './fileUtil.js'
 import type { Project } from './Project.js'
@@ -66,7 +67,12 @@ export class CacheService {
 	 */
 	constructor(private readonly cacheRoot: RootUriString, private readonly project: Project) {
 		this.project.on('documentUpdated', async ({ doc }) => {
-			if (!this.#hasValidatedFiles) {
+			if (
+				!this.#hasValidatedFiles
+				// Do not save checksums for file schemes that we cannot map to disk (e.g. 'untitled:'
+				// for untitled files in VS Code)
+				|| !(doc.uri.startsWith(ArchiveUriSupporter.Protocol) || doc.uri.startsWith('file:'))
+			) {
 				return
 			}
 			try {

--- a/packages/core/src/service/Context.ts
+++ b/packages/core/src/service/Context.ts
@@ -249,3 +249,10 @@ export namespace UriBinderContext {
 		return { ...ContextBase.create(project), config: project.config, symbols: project.symbols }
 	}
 }
+
+export interface UriPredicateContext extends ContextBase {}
+export namespace UriPredicateContext {
+	export function create(project: ProjectData): UriPredicateContext {
+		return { ...ContextBase.create(project) }
+	}
+}

--- a/packages/core/src/service/FileService.ts
+++ b/packages/core/src/service/FileService.ts
@@ -290,12 +290,14 @@ export class ArchiveUriSupporter implements UriProtocolSupporter {
 	}
 
 	*listFiles() {
-		for (const [archiveName, files] of this.entries.entries()) {
+		for (const [archiveName, entries] of this.entries.entries()) {
 			this.logger.info(
-				`[ArchiveUriSupporter#listFiles] Listing ${files.size} files from ${archiveName}`,
+				`[ArchiveUriSupporter#listFiles] Listing ${entries.size} entries from ${archiveName}`,
 			)
-			for (const file of files.values()) {
-				yield ArchiveUriSupporter.getUri(archiveName, file.path)
+			for (const entry of entries.values()) {
+				if (entry.type === 'file') {
+					yield ArchiveUriSupporter.getUri(archiveName, entry.path)
+				}
 			}
 		}
 	}

--- a/packages/core/src/service/MetaRegistry.ts
+++ b/packages/core/src/service/MetaRegistry.ts
@@ -22,6 +22,7 @@ import {
 } from '../processor/index.js'
 import type { Linter } from '../processor/linter/Linter.js'
 import type { SignatureHelpProvider } from '../processor/SignatureHelpProvider.js'
+import type { UriPredicateContext } from '../service/index.js'
 import type { DependencyKey, DependencyProvider } from './Dependency.js'
 import type { FileExtension } from './fileUtil.js'
 import type { SymbolRegistrar } from './SymbolRegistrar.js'
@@ -33,11 +34,17 @@ export interface LanguageOptions {
 	 * An array of extensions of files corresponding to the language. Each extension should include the leading dot (`.`).
 	 */
 	extensions: FileExtension[]
+	/**
+	 * If specified, the URI of the file must pass the predicate for it to be considered to be a file
+	 * of this language.
+	 */
+	uriPredicate?: UriPredicate
 	triggerCharacters?: string[]
 	parser?: Parser<AstNode>
 	completer?: Completer<any>
 }
 
+export type UriPredicate = (uri: string, ctx: UriPredicateContext) => boolean
 interface LinterRegistration {
 	configValidator: (ruleName: string, ruleValue: unknown, logger: Logger) => unknown
 	linter: Linter<AstNode>

--- a/packages/core/src/service/MetaRegistry.ts
+++ b/packages/core/src/service/MetaRegistry.ts
@@ -45,6 +45,7 @@ export interface LanguageOptions {
 }
 
 export type UriPredicate = (uri: string, ctx: UriPredicateContext) => boolean
+
 interface LinterRegistration {
 	configValidator: (ruleName: string, ruleValue: unknown, logger: Logger) => unknown
 	linter: Linter<AstNode>
@@ -113,15 +114,8 @@ export class MetaRegistry {
 		return Array.from(this.#languages.keys())
 	}
 
-	public isSupportedLanguage(language: string): boolean {
-		return this.#languages.has(language)
-	}
-
-	/**
-	 * An array of file extensions (including the leading dot (`.`)) that are supported.
-	 */
-	public getSupportedFileExtensions(): FileExtension[] {
-		return [...this.#languages.values()].flatMap((v) => v.extensions)
+	public getLanguageOptions(language: string): LanguageOptions | undefined {
+		return this.#languages.get(language)
 	}
 
 	/**

--- a/packages/core/src/service/Project.ts
+++ b/packages/core/src/service/Project.ts
@@ -872,8 +872,8 @@ export class Project implements ExternalEventEmitter {
 		content: string,
 	): Promise<void> {
 		uri = this.normalizeUri(uri)
-		if (!fileUtil.isFileUri(uri)) {
-			return // We only accept `file:` scheme for client-managed URIs.
+		if (uri.startsWith(ArchiveUriSupporter.Protocol)) {
+			return // We do not accept `archive:` scheme for client-managed URIs.
 		}
 		if (this.shouldExclude(uri)) {
 			return
@@ -899,11 +899,10 @@ export class Project implements ExternalEventEmitter {
 	): Promise<void> {
 		uri = this.normalizeUri(uri)
 		this.#symbolUpToDateUris.delete(uri)
-		if (!fileUtil.isFileUri(uri)) {
-			return // We only accept `file:` scheme for client-managed URIs.
-		}
 		if (this.shouldExclude(uri)) {
 			return
+		if (uri.startsWith(ArchiveUriSupporter.Protocol)) {
+			return // We do not accept `archive:` scheme for client-managed URIs.
 		}
 		const doc = this.#clientManagedDocAndNodes.get(uri)?.doc
 		if (!doc) {
@@ -925,8 +924,8 @@ export class Project implements ExternalEventEmitter {
 	 */
 	onDidClose(uri: string): void {
 		uri = this.normalizeUri(uri)
-		if (!fileUtil.isFileUri(uri)) {
-			return // We only accept `file:` scheme for client-managed URIs.
+		if (uri.startsWith(ArchiveUriSupporter.Protocol)) {
+			return // We do not accept `archive:` scheme for client-managed URIs.
 		}
 		this.#clientManagedUris.delete(uri)
 		this.#clientManagedDocAndNodes.delete(uri)

--- a/packages/core/src/service/Project.ts
+++ b/packages/core/src/service/Project.ts
@@ -25,6 +25,7 @@ import {
 	LinterContext,
 	ParserContext,
 	UriBinderContext,
+	UriPredicateContext,
 } from './Context.js'
 import type { Dependency } from './Dependency.js'
 import { DependencyKey } from './Dependency.js'
@@ -287,10 +288,7 @@ export class Project implements ExternalEventEmitter {
 	 * are not loaded into the memory.
 	 */
 	getTrackedFiles(): string[] {
-		const extensions: string[] = this.meta.getSupportedFileExtensions()
-		this.logger.info(`[Project#getTrackedFiles] Supported file extensions: ${extensions}`)
 		const supportedFiles = [...this.#dependencyFiles ?? [], ...this.#watchedFiles]
-			.filter((file) => extensions.includes(fileUtil.extname(file) ?? ''))
 		this.logger.info(
 			`[Project#getTrackedFiles] Listed ${supportedFiles.length} supported files`,
 		)
@@ -525,7 +523,8 @@ export class Project implements ExternalEventEmitter {
 
 			await Promise.all([listDependencyFiles(), listProjectFiles()])
 
-			this.#dependencyFiles = new Set(this.fs.listFiles())
+			this.#dependencyFiles = new Set([...this.fs.listFiles()]
+				.filter((uri) => !this.shouldExclude(uri)))
 			this.#dependencyRoots = new Set(this.fs.listRoots())
 
 			this.updateRoots()
@@ -659,13 +658,9 @@ export class Project implements ExternalEventEmitter {
 		this.#textDocumentCache.delete(uri)
 	}
 	private async read(uri: string): Promise<TextDocument | undefined> {
-		const getLanguageID = (uri: string): string => {
-			const ext = fileUtil.extname(uri) ?? '.plaintext'
-			return this.meta.getLanguageID(ext) ?? ext.slice(1)
-		}
 		const createTextDocument = async (uri: string): Promise<TextDocument | undefined> => {
-			const languageId = getLanguageID(uri)
-			if (!this.meta.isSupportedLanguage(languageId)) {
+			const languageId = this.guessLanguageID(uri)
+			if (!this.isSupportedLanguage(uri, languageId)) {
 				return undefined
 			}
 
@@ -875,7 +870,7 @@ export class Project implements ExternalEventEmitter {
 		if (uri.startsWith(ArchiveUriSupporter.Protocol)) {
 			return // We do not accept `archive:` scheme for client-managed URIs.
 		}
-		if (this.shouldExclude(uri)) {
+		if (this.shouldExclude(uri, languageID)) {
 			return
 		}
 		const doc = TextDocument.create(uri, languageID, version, content)
@@ -899,16 +894,16 @@ export class Project implements ExternalEventEmitter {
 	): Promise<void> {
 		uri = this.normalizeUri(uri)
 		this.#symbolUpToDateUris.delete(uri)
-		if (this.shouldExclude(uri)) {
-			return
 		if (uri.startsWith(ArchiveUriSupporter.Protocol)) {
 			return // We do not accept `archive:` scheme for client-managed URIs.
 		}
 		const doc = this.#clientManagedDocAndNodes.get(uri)?.doc
-		if (!doc) {
-			throw new Error(
-				`TextDocument for ${uri} is not cached. This should not happen. Did the language client send a didChange notification without sending a didOpen one, or is there a logic error on our side resulting the 'read' function overriding the 'TextDocument' created in the 'didOpen' notification handler?`,
-			)
+		if (!doc || this.shouldExclude(uri, doc.languageId)) {
+			// If doc is undefined, it means the document was previously excluded by onDidOpen()
+			// based on the language ID supplied by the client, in which case we should return early.
+			// Otherwise, we perform the shouldExclude() check with the URI and the saved language ID
+			// as usual.
+			return
 		}
 		TextDocument.update(doc, changes, version)
 		const node = this.parse(doc)
@@ -966,7 +961,38 @@ export class Project implements ExternalEventEmitter {
 		}
 	}
 
-	public shouldExclude(uri: string): boolean {
+	/**
+	 * Returns true iff the URI should be excluded from all Spyglass language support.
+	 *
+	 * @param language Optional. If ommitted, a language will be derived from the URI according to
+	 *                 its file extension.
+	 */
+	public shouldExclude(uri: string, language?: string): boolean {
+		return !this.isSupportedLanguage(uri, language) || this.isUserExcluded(uri)
+	}
+
+	private isSupportedLanguage(uri: string, language?: string): boolean {
+		language ??= this.guessLanguageID(uri)
+
+		const languageOptions = this.meta.getLanguageOptions(language)
+		if (!languageOptions) {
+			// Unsupported language.
+			return false
+		}
+
+		const { uriPredicate } = languageOptions
+		return uriPredicate?.(uri, UriPredicateContext.create(this)) ?? true
+	}
+
+	/**
+	 * Guess a language ID from a URI. The guessed language ID may or may not actually be supported.
+	 */
+	private guessLanguageID(uri: string): string {
+		const ext = fileUtil.extname(uri) ?? '.spyglassmc-unknown'
+		return this.meta.getLanguageID(ext) ?? ext.slice(1)
+	}
+
+	private isUserExcluded(uri: string): boolean {
 		if (this.config.env.exclude.length === 0) {
 			return false
 		}

--- a/packages/java-edition/src/binder/index.ts
+++ b/packages/java-edition/src/binder/index.ts
@@ -8,6 +8,7 @@ import type {
 	UriBinder,
 	UriBinderContext,
 	UriBuilder,
+	UriPredicate,
 } from '@spyglassmc/core'
 import {
 	ErrorSeverity,
@@ -211,6 +212,58 @@ export function* getRoots(
 	return undefined
 }
 
+interface ResourceInstance extends Resource {
+	namespace: string
+	identifier: string
+}
+
+function getCandidateResourcesForRel(rel: string): ResourceInstance[] {
+	const parts = rel.split('/')
+	if (parts.length < 3) {
+		return []
+	}
+	const [pack, namespace, ...rest] = parts
+	if (pack !== 'data' && pack !== 'assets') {
+		return []
+	}
+	const candidateResources: ResourceInstance[] = []
+	if (rest.length === 1) {
+		const resources = Resources.get('')
+		for (const res of resources ?? []) {
+			if (res.pack !== pack) {
+				continue
+			}
+			let identifier = rest[0]
+			if (!identifier.endsWith(res.ext)) {
+				continue
+			}
+			identifier = identifier.slice(0, -res.ext.length)
+			if (res.identifier && identifier !== res.identifier) {
+				continue
+			}
+			candidateResources.push({ ...res, namespace, identifier })
+		}
+	}
+	for (let i = 1; i < rest.length; i += 1) {
+		const resources = Resources.get(rest.slice(0, i).join('/'))
+		for (const res of resources ?? []) {
+			if (res.pack !== pack) {
+				continue
+			}
+			let identifier = rest.slice(i).join('/')
+			if (!identifier.endsWith(res.ext)) {
+				continue
+			}
+			identifier = identifier.slice(0, -res.ext.length)
+			if (res.identifier && identifier !== res.identifier) {
+				continue
+			}
+			candidateResources.push({ ...res, namespace, identifier })
+		}
+	}
+	return candidateResources
+}
+
 export function dissectUri(uri: string, ctx: UriBinderContext) {
 	const rels = getRels(uri, ctx.roots)
 	const release = ctx.project['loadedVersion'] as ReleaseVersion | undefined
@@ -219,63 +272,21 @@ export function dissectUri(uri: string, ctx: UriBinderContext) {
 	}
 
 	for (const rel of rels) {
-		const parts = rel.split('/')
-		if (parts.length < 3) {
-			continue
-		}
-		const [pack, namespace, ...rest] = parts
-		if (pack !== 'data' && pack !== 'assets') {
-			continue
-		}
-		const candidateResources: [Resource, string][] = []
-		if (rest.length === 1) {
-			const resources = Resources.get('')
-			for (const res of resources ?? []) {
-				if (res.pack !== pack) {
-					continue
-				}
-				let identifier = rest[0]
-				if (!identifier.endsWith(res.ext)) {
-					continue
-				}
-				identifier = identifier.slice(0, -res.ext.length)
-				if (res.identifier && identifier !== res.identifier) {
-					continue
-				}
-				candidateResources.push([res, identifier])
-			}
-		}
-		for (let i = 1; i < rest.length; i += 1) {
-			const resources = Resources.get(rest.slice(0, i).join('/'))
-			for (const res of resources ?? []) {
-				if (res.pack !== pack) {
-					continue
-				}
-				let identifier = rest.slice(i).join('/')
-				if (!identifier.endsWith(res.ext)) {
-					continue
-				}
-				identifier = identifier.slice(0, -res.ext.length)
-				if (res.identifier && identifier !== res.identifier) {
-					continue
-				}
-				candidateResources.push([res, identifier])
-			}
-		}
+		const candidateResources = getCandidateResourcesForRel(rel)
 		if (candidateResources.length === 0) {
 			continue
 		}
 		// Finding the last, because that will be the deepest match
-		let res = candidateResources.findLast(([res]) => matchVersion(release, res.since, res.until))
+		let res = candidateResources.findLast((res) => matchVersion(release, res.since, res.until))
 		if (res !== undefined) {
-			return { ok: true, ...res[0], namespace, identifier: res[1], expected: undefined }
+			return { ok: true, ...res, expected: undefined }
 		}
 		// Try to find the expected path that matches the current version
 		res = candidateResources[candidateResources.length - 1]
 		let expected: string | undefined = undefined
 		for (const [path, others] of Resources) {
 			for (const other of others) {
-				if (other.category !== res[0].category) {
+				if (other.category !== res.category) {
 					continue
 				}
 				if (matchVersion(release, other.since, other.until)) {
@@ -284,7 +295,7 @@ export function dissectUri(uri: string, ctx: UriBinderContext) {
 				}
 			}
 		}
-		return { ok: false, ...res[0], namespace, identifier: res[1], expected }
+		return { ok: false, ...res, expected }
 	}
 
 	return undefined
@@ -386,4 +397,14 @@ export function registerUriBuilders(meta: MetaRegistry) {
 	for (const [category, resources] of resourcesByCategory.entries()) {
 		meta.registerUriBuilder(category, uriBuilder(resources))
 	}
+}
+
+/**
+ * Returns true for JSON file URIs that belong to any known resource category. No version check is
+ * performed as we would like to provide errors even for files in the wrong folder or files for the
+ * wrong version.
+ */
+export const jsonUriPredicate: UriPredicate = (uri, ctx) => {
+	const rels = [...getRels(uri, ctx.roots)]
+	return rels.some((rel) => getCandidateResourcesForRel(rel).length > 0)
 }

--- a/packages/java-edition/src/index.ts
+++ b/packages/java-edition/src/index.ts
@@ -2,7 +2,7 @@ import * as core from '@spyglassmc/core'
 import * as json from '@spyglassmc/json'
 import * as mcdoc from '@spyglassmc/mcdoc'
 import * as nbt from '@spyglassmc/nbt'
-import { registerUriBuilders, uriBinder } from './binder/index.js'
+import { jsonUriPredicate, registerUriBuilders, uriBinder } from './binder/index.js'
 import type { McmetaSummary, McmetaVersions, PackInfo } from './dependency/index.js'
 import {
 	getMcmetaSummary,
@@ -161,7 +161,6 @@ export const initialize: core.ProjectInitializer = async (ctx) => {
 
 	registerMcdocAttributes(meta, summary.commands, release)
 	registerPackFormatAttribute(meta, release, versions, packs)
-	registerPackFormatAttribute(meta, release, versions, packs)
 
 	meta.registerLanguage('zip', { extensions: ['.zip'] })
 	meta.registerLanguage('png', { extensions: ['.png'] })
@@ -171,7 +170,7 @@ export const initialize: core.ProjectInitializer = async (ctx) => {
 	meta.registerLanguage('fsh', { extensions: ['.fsh'] })
 	meta.registerLanguage('vsh', { extensions: ['.vsh'] })
 
-	json.initialize(ctx)
+	json.getInitializer(jsonUriPredicate)(ctx)
 	jeJson.initialize(ctx)
 	jeMcf.initialize(ctx, summary.commands, release)
 	nbt.initialize(ctx)

--- a/packages/java-edition/test/mcfunction/parser/argument.spec.ts
+++ b/packages/java-edition/test/mcfunction/parser/argument.spec.ts
@@ -223,7 +223,7 @@ describe('mcfunction argument parser', () => {
 					properties,
 				}
 				const project = mockProjectData({ ctx: { loadedVersion: version } })
-				json.initialize(project)
+				json.getInitializer()(project)
 				nbt.initialize(project)
 
 				for (const string of content) {

--- a/packages/json/src/index.ts
+++ b/packages/json/src/index.ts
@@ -14,22 +14,29 @@ export * as formatter from './formatter/index.js'
 export * from './node/index.js'
 export * as parser from './parser/index.js'
 
-export const initialize: core.SyncProjectInitializer = ({ meta }) => {
-	meta.registerLanguage('json', {
-		extensions: ['.json'],
-		triggerCharacters: ['\n', ':', '"'],
-		parser: parser.file,
-	})
-	meta.registerLanguage('mcmeta', {
-		extensions: ['.mcmeta'],
-		triggerCharacters: ['\n', ':', '"'],
-		parser: parser.file,
-	})
+/**
+ * @param jsonUriPredicate If provided, JSON file URIs must pass this predicate for them to be of
+ * proper `json` language.
+ */
+export function getInitializer(jsonUriPredicate?: core.UriPredicate): core.SyncProjectInitializer {
+	return ({ meta }) => {
+		meta.registerLanguage('json', {
+			extensions: ['.json'],
+			uriPredicate: jsonUriPredicate,
+			triggerCharacters: ['\n', ':', '"'],
+			parser: parser.file,
+		})
+		meta.registerLanguage('mcmeta', {
+			extensions: ['.mcmeta'],
+			triggerCharacters: ['\n', ':', '"'],
+			parser: parser.file,
+		})
 
-	meta.registerParser('json:entry' as any, parser.entry)
+		meta.registerParser('json:entry' as any, parser.entry)
 
-	checker.register(meta)
-	colorizer.register(meta)
-	completer.register(meta)
-	formatter.register(meta)
+		checker.register(meta)
+		colorizer.register(meta)
+		completer.register(meta)
+		formatter.register(meta)
+	}
 }


### PR DESCRIPTION
(This PR could have each commit individually merged instead of a squash merge since I separated units of change into four individually revertable commits. Well after a `git rebase --autosquash -i 3ea96b` that is)

This PR adds an additional `uriPredicate` option to `LanguageOptions` during language registration. The `json` language definition has been updated to include a `uriPredicate` to ensure the JSON file actually belongs to a data pack or a resource pack. This check is more accurate than the `DocumentFilter` implemented client side in the VS Code extension as it takes the roots and the available file categories into consideration. Additions have also been made to `Project.shouldExclude()` to make sure unsupported files never go into the document life cycle.

This PR also fixes two bugs I noticed while making the changes.