### PR TITLE
Add match regex attribute

### DIFF
--- a/packages/locales/src/locales/en.json
+++ b/packages/locales/src/locales/en.json
@@ -48,6 +48,7 @@
   "integer.between": "an integer between %0% and %1%",
   "invalid-key-combination": "Invalid combination of keys %0%",
   "invalid-regex-pattern": "Invalid regex pattern: %0%",
+  "mismatching-regex-pattern": "Value does not match regex: %0%",
   "java-edition.binder.wrong-folder": "Files in the %0% folder are not recognized in loaded version %1%, did you meant to use the %2% folder?",
   "java-edition.binder.wrong-version": "Files in the %0% folder are not recognized in loaded version %1%",
   "java-edition.pack-format.unsupported": "Pack format %0% does not have a corresponding release version. Snapshot versions are unsupported.",


### PR DESCRIPTION
Adds an attribute `match_regex` that allows for regex validation for string fields.
Regex config is required but error is not. If error is not provided will use a default error message instead.
`#[match_regex=(regex=foo, error="error")]`