### PR TITLE
Extend version attribute

### DIFF
--- a/packages/java-edition/src/mcdocAttributes.ts
+++ b/packages/java-edition/src/mcdocAttributes.ts
@@ -33,6 +33,26 @@ export function registerMcdocAttributes(
 			return ReleaseVersion.cmp(release, config as ReleaseVersion) < 0
 		},
 	})
+	mcdoc.runtime.registerAttribute(meta, 'only', validator.string, {
+		filterElement: (config, ctx) => {
+			if (!config.startsWith('1.')) {
+				ctx.logger.warn(`Invalid mcdoc attribute for "until": ${config}`)
+				return true
+			}
+			return ReleaseVersion.cmp(release, config as ReleaseVersion) == 0
+		},
+	})
+	mcdoc.runtime.registerAttribute(meta, 'between', validator.string, {
+		filterElement: (config, ctx) => {
+			const range = config.split("-")
+			if (range.length != 2 || !range[0].startsWith('1.')|| !range[1].startsWith('1.')) {
+				ctx.logger.warn(`Invalid mcdoc attribute for "until": ${config}`)
+				return true
+			}
+			return ReleaseVersion.cmp(release, range[0] as ReleaseVersion) >= 0
+				&& ReleaseVersion.cmp(release, range[1] as ReleaseVersion) <= 0
+		},
+	})
 	mcdoc.runtime.registerAttribute(meta, 'deprecated', validator.optional(validator.string), {
 		mapField: (config, field, ctx) => {
 			if (config === undefined) {

--- a/packages/java-edition/src/mcdocAttributes.ts
+++ b/packages/java-edition/src/mcdocAttributes.ts
@@ -45,7 +45,7 @@ export function registerMcdocAttributes(
 	mcdoc.runtime.registerAttribute(meta, 'except', validator.string, {
 		filterElement: (config, ctx) => {
 			const range = config.split("-")
-			if (range.length !== 2 || !range[0].startsWith('1.')|| !range[1].startsWith('1.')) {
+			if (range.length !== 2 || !range[0].startsWith('1.') || !range[1].startsWith('1.')) {
 				ctx.logger.warn(`Invalid mcdoc attribute for "except": ${config}`)
 				return true
 			}

--- a/packages/java-edition/src/mcdocAttributes.ts
+++ b/packages/java-edition/src/mcdocAttributes.ts
@@ -42,15 +42,15 @@ export function registerMcdocAttributes(
 			return ReleaseVersion.cmp(release, config as ReleaseVersion) == 0
 		},
 	})
-	mcdoc.runtime.registerAttribute(meta, 'between', validator.string, {
+	mcdoc.runtime.registerAttribute(meta, 'except', validator.string, {
 		filterElement: (config, ctx) => {
 			const range = config.split("-")
 			if (range.length != 2 || !range[0].startsWith('1.')|| !range[1].startsWith('1.')) {
 				ctx.logger.warn(`Invalid mcdoc attribute for "until": ${config}`)
 				return true
 			}
-			return ReleaseVersion.cmp(release, range[0] as ReleaseVersion) >= 0
-				&& ReleaseVersion.cmp(release, range[1] as ReleaseVersion) <= 0
+			return ReleaseVersion.cmp(release, range[0] as ReleaseVersion) <= 0
+				|| ReleaseVersion.cmp(release, range[1] as ReleaseVersion) >= 0
 		},
 	})
 	mcdoc.runtime.registerAttribute(meta, 'deprecated', validator.optional(validator.string), {

--- a/packages/java-edition/src/mcdocAttributes.ts
+++ b/packages/java-edition/src/mcdocAttributes.ts
@@ -36,17 +36,17 @@ export function registerMcdocAttributes(
 	mcdoc.runtime.registerAttribute(meta, 'only', validator.string, {
 		filterElement: (config, ctx) => {
 			if (!config.startsWith('1.')) {
-				ctx.logger.warn(`Invalid mcdoc attribute for "until": ${config}`)
+				ctx.logger.warn(`Invalid mcdoc attribute for "only": ${config}`)
 				return true
 			}
-			return ReleaseVersion.cmp(release, config as ReleaseVersion) == 0
+			return ReleaseVersion.cmp(release, config as ReleaseVersion) === 0
 		},
 	})
 	mcdoc.runtime.registerAttribute(meta, 'except', validator.string, {
 		filterElement: (config, ctx) => {
 			const range = config.split("-")
-			if (range.length != 2 || !range[0].startsWith('1.')|| !range[1].startsWith('1.')) {
-				ctx.logger.warn(`Invalid mcdoc attribute for "until": ${config}`)
+			if (range.length !== 2 || !range[0].startsWith('1.')|| !range[1].startsWith('1.')) {
+				ctx.logger.warn(`Invalid mcdoc attribute for "except": ${config}`)
 				return true
 			}
 			return ReleaseVersion.cmp(release, range[0] as ReleaseVersion) <= 0

--- a/packages/java-edition/src/mcdocAttributes.ts
+++ b/packages/java-edition/src/mcdocAttributes.ts
@@ -44,7 +44,7 @@ export function registerMcdocAttributes(
 	})
 	mcdoc.runtime.registerAttribute(meta, 'except', validator.string, {
 		filterElement: (config, ctx) => {
-			const range = config.split("-")
+			const range = config.split('-')
 			if (range.length !== 2 || !range[0].startsWith('1.') || !range[1].startsWith('1.')) {
 				ctx.logger.warn(`Invalid mcdoc attribute for "except": ${config}`)
 				return true


### PR DESCRIPTION
Extends the attributes for versions adding
- `only`: To select a specific version
- `except`: To select a version range outside of the specified one. Syntax `min-max` 

Currently you can mimic `only` with `since` and `until` but not `except`.

see #1755
new due to branch stuff on fork