### PR TITLE
🐛 Fix canonical union filtering when combined with other attribute filters

### DIFF
--- a/packages/mcdoc/src/runtime/checker/index.ts
+++ b/packages/mcdoc/src/runtime/checker/index.ts
@@ -1060,14 +1060,9 @@ function simplifyUnion<T>(
 	context: SimplifyContext<T>,
 ): SimplifyResult<SimplifiedMcdocType> {
 	let dynamicData = false
-	const filterCanonical = context.ctx.requireCanonical
-		&& typeDef.members.some(m => m.attributes?.some(a => a.name === 'canonical'))
 
-	const validMembers = typeDef.members
+	let validMembers = typeDef.members
 		.filter(member => {
-			if (filterCanonical && !member.attributes?.some(a => a.name === 'canonical')) {
-				return false
-			}
 			let keep = true
 			handleAttributes(member.attributes, context.ctx, (handler, config) => {
 				if (!keep || !handler.filterElement) {
@@ -1079,6 +1074,14 @@ function simplifyUnion<T>(
 			})
 			return keep
 		})
+
+	const filterCanonical = context.ctx.requireCanonical
+		&& validMembers.some(m => m.attributes?.some(a => a.name === 'canonical'))
+	if (filterCanonical) {
+		validMembers = typeDef.members.filter(member =>
+			member.attributes?.some(a => a.name === 'canonical')
+		)
+	}
 
 	if (validMembers.length === 1) {
 		return simplify(validMembers[0], context)


### PR DESCRIPTION
The issue was that for a type like this:
```rust
type Foo = (
	#[until="1.21.5"] #[canonical] Enchantments |
	EnchantmentLevels |
)
```
The previous code would detect that one of the members has `#[canonical]` and filter out all the non-canonical members. This would end up simplifying the entire union to an empty union. The fix is to first filter members by other attributes (like `since` and `until`), and after that check if there are still canonical members.
