### PR TITLE
✨ Improve pack format detection

### DIFF
--- a/__snapshots__/packages/java-edition/test-out/dependency/mcmeta.spec.js
+++ b/__snapshots__/packages/java-edition/test-out/dependency/mcmeta.spec.js
@@ -26,56 +26,49 @@ exports['mcmeta resolveConfiguredVersion() Should resolve "1.16.5" 1'] = {
   "id": "1.16.5",
   "name": "1.16.5",
   "release": "1.16.5",
-  "isLatest": false,
-  "reason": "config"
+  "isLatest": false
 }
 
 exports['mcmeta resolveConfiguredVersion() Should resolve "20w06a" 1'] = {
   "id": "20w06a",
   "name": "Snapshot 20w06a",
   "release": "1.16",
-  "isLatest": false,
-  "reason": "config"
+  "isLatest": false
 }
 
 exports['mcmeta resolveConfiguredVersion() Should resolve "22w03a" 1'] = {
   "id": "22w03a",
   "name": "22w03a",
   "release": "1.18.2",
-  "isLatest": true,
-  "reason": "config"
+  "isLatest": true
 }
 
 exports['mcmeta resolveConfiguredVersion() Should resolve "Auto" 1'] = {
   "id": "1.16.5",
   "name": "1.16.5",
   "release": "1.16.5",
-  "isLatest": false,
-  "reason": "auto"
+  "isLatest": false
 }
 
 exports['mcmeta resolveConfiguredVersion() Should resolve "Latest Release" 1'] = {
   "id": "1.18.1",
   "name": "1.18.1",
   "release": "1.18.1",
-  "isLatest": false,
-  "reason": "config"
+  "isLatest": false
 }
 
 exports['mcmeta resolveConfiguredVersion() Should resolve "Latest Snapshot" 1'] = {
   "id": "22w03a",
   "name": "22w03a",
   "release": "1.18.2",
-  "isLatest": true,
-  "reason": "config"
+  "isLatest": true
 }
 
 exports['mcmeta resolveConfiguredVersion() Should resolve "unknown" 1'] = {
   "id": "22w03a",
   "name": "22w03a",
   "release": "1.18.2",
-  "isLatest": true,
-  "reason": "config"
+  "isLatest": true
 }
 
 exports['mcmeta symbolRegistrar() Should register correctly 1'] = `

--- a/packages/java-edition/src/dependency/common.ts
+++ b/packages/java-edition/src/dependency/common.ts
@@ -25,25 +25,27 @@ export namespace ReleaseVersion {
 	}
 }
 
-export type VersionInfoReason = 'auto' | 'config' | 'fallback'
-
 export interface VersionInfo {
 	release: ReleaseVersion
 	id: string
 	name: string
 	isLatest: boolean
-	reason: VersionInfoReason
 }
 
-export interface PackMcmeta {
-	pack: { pack_format: number }
-}
 export namespace PackMcmeta {
-	export function assert(data: any): asserts data is PackMcmeta {
-		const format: string | undefined = data?.pack?.pack_format?.toString()
-		if (!format) {
-			throw new Error('“pack.pack_format” undefined')
+	export function readPackFormat(data: any): number {
+		const supported = data?.pack?.supported_formats
+		if (Array.isArray(supported) && supported.length === 2 && typeof supported[1] === 'number') {
+			return supported[1]
 		}
+		if (typeof supported === 'object' && typeof supported?.max_inclusive === 'number') {
+			return supported.max_inclusive
+		}
+		const format = data?.pack?.pack_format
+		if (typeof format === 'number') {
+			return format
+		}
+		throw new Error('“pack.pack_format” is not a number')
 	}
 
 	export async function getType(packRoot: string, externals: core.Externals) {
@@ -57,6 +59,5 @@ export namespace PackMcmeta {
 export interface PackInfo {
 	type: 'data' | 'assets'
 	packRoot: string
-	packMcmeta: PackMcmeta | undefined
-	versionInfo: VersionInfo
+	format: number
 }

--- a/packages/java-edition/src/dependency/mcmeta.ts
+++ b/packages/java-edition/src/dependency/mcmeta.ts
@@ -65,44 +65,25 @@ export function resolveConfiguredVersion(
 			)
 			return toVersionInfo(latestRelease)
 		}
-		const maxData = Math.max(...packs.filter(p => p.type === 'data').map(p => p.format))
-		const maxAssets = Math.max(...packs.filter(p => p.type === 'assets').map(p => p.format))
+		packs.sort((a, b) => b.format - a.format)
+		const maxData = packs.filter(p => p.type === 'data')[0]
+		const maxAssets = packs.filter(p => p.type === 'assets')[0]
 		// Look for versions from recent to oldest, picking the most recent release that matches
 		let oldestRelease = versions[0]
 		const releases = versions.filter(v => v.type === 'release')
 		for (const version of releases) {
 			// If we already passed the pack format, use the oldest release so far
-			if (maxData > version.data_pack_version) {
+			if (maxData && maxData.format > version.data_pack_version) {
 				logger.info(
-					`[resolveConfiguredVersion] Detected data pack format ${maxData} in ${
-						packs.find(p => p.type === 'data' && p.format === maxData)?.packRoot
-					}, selecting version ${oldestRelease.id}`,
+					`[resolveConfiguredVersion] Detected data pack format ${maxData.format} in ${maxData.packRoot}, selecting version ${oldestRelease.id}`,
 				)
 				return toVersionInfo(oldestRelease)
 			}
-			if (maxAssets > version.resource_pack_version) {
+			if (maxAssets && maxAssets.format > version.resource_pack_version) {
 				logger.info(
-					`[resolveConfiguredVersion] Detected resource pack format ${maxAssets} in ${
-						packs.find(p => p.type === 'assets' && p.format === maxAssets)?.packRoot
-					}, selecting version ${oldestRelease.id}`,
+					`[resolveConfiguredVersion] Detected resource pack format ${maxAssets.format} in ${maxAssets.packRoot}, selecting version ${oldestRelease.id}`,
 				)
 				return toVersionInfo(oldestRelease)
-			}
-			if (maxData === version.data_pack_version) {
-				logger.info(
-					`[resolveConfiguredVersion] Detected data pack format ${maxData} in ${
-						packs.find(p => p.type === 'data' && p.format === maxData)?.packRoot
-					}, selecting version ${version.id}`,
-				)
-				return toVersionInfo(version)
-			}
-			if (maxAssets === version.resource_pack_version) {
-				logger.info(
-					`[resolveConfiguredVersion] Detected resource pack format ${maxAssets} in ${
-						packs.find(p => p.type === 'assets' && p.format === maxAssets)?.packRoot
-					}, selecting version ${version.id}`,
-				)
-				return toVersionInfo(version)
 			}
 			oldestRelease = version
 		}

--- a/packages/java-edition/src/dependency/mcmeta.ts
+++ b/packages/java-edition/src/dependency/mcmeta.ts
@@ -85,6 +85,18 @@ export function resolveConfiguredVersion(
 				)
 				return toVersionInfo(oldestRelease)
 			}
+			if (maxData && maxData.format === version.data_pack_version) {
+				logger.info(
+					`[resolveConfiguredVersion] Detected data pack format ${maxData.format} in ${maxData.packRoot}, selecting version ${version.id}`,
+				)
+				return toVersionInfo(version)
+			}
+			if (maxAssets && maxAssets.format === version.resource_pack_version) {
+				logger.info(
+					`[resolveConfiguredVersion] Detected resource pack format ${maxAssets.format} in ${maxAssets.packRoot}, selecting version ${version.id}`,
+				)
+				return toVersionInfo(version)
+			}
 			oldestRelease = version
 		}
 		// If the pack format is still lower, use the oldest known release version

--- a/packages/java-edition/src/dependency/mcmeta.ts
+++ b/packages/java-edition/src/dependency/mcmeta.ts
@@ -1,6 +1,6 @@
 import * as core from '@spyglassmc/core'
 import type { TypeDefSymbolData } from '@spyglassmc/mcdoc/lib/binder/index.js'
-import type { PackMcmeta, VersionInfo, VersionInfoReason } from './common.js'
+import type { PackInfo, VersionInfo } from './common.js'
 import { ReleaseVersion } from './common.js'
 
 // DOCS: Update this when a new snapshot cycle begins
@@ -12,8 +12,7 @@ export const NEXT_RELEASE_VERSION = '1.21.6'
 export function resolveConfiguredVersion(
 	inputVersion: string,
 	versions: McmetaVersions,
-	packMcmeta: PackMcmeta | undefined,
-	packType: 'assets' | 'data' | undefined,
+	packs: PackInfo[],
 	logger: core.Logger,
 ): VersionInfo {
 	function findReleaseTarget(version: McmetaVersion): string {
@@ -34,7 +33,6 @@ export function resolveConfiguredVersion(
 
 	function toVersionInfo(
 		version: McmetaVersion | undefined,
-		reason: VersionInfoReason,
 	): VersionInfo {
 		version = version ?? versions[0]
 		return {
@@ -42,7 +40,6 @@ export function resolveConfiguredVersion(
 			name: version.name,
 			release: findReleaseTarget(version) as ReleaseVersion,
 			isLatest: version === versions[0],
-			reason,
 		}
 	}
 
@@ -61,54 +58,79 @@ export function resolveConfiguredVersion(
 	versions = versions.sort((a, b) => b.data_version - a.data_version)
 	const latestRelease = versions.find((v) => v.type === 'release')
 	if (inputVersion === 'auto') {
-		const packFormat = packMcmeta?.pack.pack_format
-		if (packFormat && latestRelease) {
-			// If the pack format is larger than the latest release, use the latest snapshot
-			if (
-				packFormat > (packType === 'assets'
-					? latestRelease.resource_pack_version
-					: latestRelease.data_pack_version)
-			) {
-				return toVersionInfo(versions[0], 'auto')
-			}
-			// Look for versions from recent to oldest, picking the most recent release that matches
-			let oldestRelease = undefined
-			for (const version of versions) {
-				if (version.type === 'release') {
-					// If we already passed the pack format, use the oldest release so far
-					if (
-						packFormat > (packType === 'assets'
-							? version.resource_pack_version
-							: version.data_pack_version)
-					) {
-						return toVersionInfo(oldestRelease, 'auto')
-					}
-					if (
-						packFormat === (packType === 'assets'
-							? version.resource_pack_version
-							: version.data_pack_version)
-					) {
-						return toVersionInfo(version, 'auto')
-					}
-					oldestRelease = version
-				}
-			}
-			// If the pack format is still lower, use the oldest known release version
-			return toVersionInfo(oldestRelease, 'auto')
+		if (packs.length === 0) {
+			// Fall back to the latest release if pack mcmeta is not available
+			logger.info(
+				`[resolveConfiguredVersion] No pack format detected, selecting latest release ${latestRelease?.id}`,
+			)
+			return toVersionInfo(latestRelease)
 		}
-		// Fall back to the latest release if pack mcmeta is not available
-		return toVersionInfo(latestRelease, 'fallback')
+		const maxData = Math.max(...packs.filter(p => p.type === 'data').map(p => p.format))
+		const maxAssets = Math.max(...packs.filter(p => p.type === 'assets').map(p => p.format))
+		// Look for versions from recent to oldest, picking the most recent release that matches
+		let oldestRelease = versions[0]
+		const releases = versions.filter(v => v.type === 'release')
+		for (const version of releases) {
+			// If we already passed the pack format, use the oldest release so far
+			if (maxData > version.data_pack_version) {
+				logger.info(
+					`[resolveConfiguredVersion] Detected data pack format ${maxData} in ${
+						packs.find(p => p.type === 'data' && p.format === maxData)?.packRoot
+					}, selecting version ${oldestRelease.id}`,
+				)
+				return toVersionInfo(oldestRelease)
+			}
+			if (maxAssets > version.resource_pack_version) {
+				logger.info(
+					`[resolveConfiguredVersion] Detected resource pack format ${maxAssets} in ${
+						packs.find(p => p.type === 'assets' && p.format === maxAssets)?.packRoot
+					}, selecting version ${oldestRelease.id}`,
+				)
+				return toVersionInfo(oldestRelease)
+			}
+			if (maxData === version.data_pack_version) {
+				logger.info(
+					`[resolveConfiguredVersion] Detected data pack format ${maxData} in ${
+						packs.find(p => p.type === 'data' && p.format === maxData)?.packRoot
+					}, selecting version ${version.id}`,
+				)
+				return toVersionInfo(version)
+			}
+			if (maxAssets === version.resource_pack_version) {
+				logger.info(
+					`[resolveConfiguredVersion] Detected resource pack format ${maxAssets} in ${
+						packs.find(p => p.type === 'assets' && p.format === maxAssets)?.packRoot
+					}, selecting version ${version.id}`,
+				)
+				return toVersionInfo(version)
+			}
+			oldestRelease = version
+		}
+		// If the pack format is still lower, use the oldest known release version
+		logger.info(
+			`[resolveConfiguredVersion] Detected pack format too low, selecting oldest supported release ${oldestRelease?.id}`,
+		)
+		return toVersionInfo(oldestRelease)
 	} else if (inputVersion === 'latest release') {
-		return toVersionInfo(latestRelease, 'config')
+		logger.info(
+			`[resolveConfiguredVersion] Using config "${inputVersion}", selecting version ${latestRelease?.id}`,
+		)
+		return toVersionInfo(latestRelease)
 	} else if (inputVersion === 'latest snapshot') {
-		return toVersionInfo(versions[0], 'config')
+		logger.info(
+			`[resolveConfiguredVersion] Using config "${inputVersion}", selecting version ${
+				versions[0]?.id
+			}`,
+		)
+		return toVersionInfo(versions[0])
 	}
-	return toVersionInfo(
-		versions.find((v) =>
-			inputVersion === v.id.toLowerCase() || inputVersion === v.name.toLowerCase()
-		),
-		'config',
+	const configVersion = versions.find((v) =>
+		inputVersion === v.id.toLowerCase() || inputVersion === v.name.toLowerCase()
 	)
+	logger.info(
+		`[resolveConfiguredVersion] Using config "${inputVersion}", selecting version ${configVersion?.id}`,
+	)
+	return toVersionInfo(configVersion)
 }
 
 const DataSources: Partial<Record<string, string>> = {

--- a/packages/java-edition/src/index.ts
+++ b/packages/java-edition/src/index.ts
@@ -132,7 +132,7 @@ export const initialize: core.ProjectInitializer = async (ctx) => {
 	})
 
 	registerMcdocAttributes(meta, summary.commands, release)
-	registerPackFormatAttribute(meta, release, versions, packs)
+	registerPackFormatAttribute(meta, versions, packs)
 
 	meta.registerLanguage('zip', { extensions: ['.zip'] })
 	meta.registerLanguage('png', { extensions: ['.png'] })

--- a/packages/java-edition/src/index.ts
+++ b/packages/java-edition/src/index.ts
@@ -27,11 +27,10 @@ export * as mcf from './mcfunction/index.js'
 export const initialize: core.ProjectInitializer = async (ctx) => {
 	const { config, downloader, externals, logger, meta, projectRoots } = ctx
 
-	async function readPackMcmeta(uri: string): Promise<PackMcmeta | undefined> {
+	async function readPackFormat(uri: string): Promise<number | undefined> {
 		try {
 			const data = await core.fileUtil.readJson(externals, uri)
-			PackMcmeta.assert(data)
-			return data
+			return PackMcmeta.readPackFormat(data)
 		} catch (e) {
 			if (!externals.error.isKind(e, 'ENOENT')) {
 				// `pack.mcmeta` exists but broken. Log an error.
@@ -41,7 +40,7 @@ export const initialize: core.ProjectInitializer = async (ctx) => {
 		return undefined
 	}
 
-	async function findPackMcmetas(versions: McmetaVersions): Promise<PackInfo[]> {
+	async function findPackMcmetas(): Promise<PackInfo[]> {
 		const searchedUris = new Set<string>()
 		const packs: PackInfo[] = []
 		for (let depth = 0; depth <= 2; depth += 1) {
@@ -53,18 +52,13 @@ export const initialize: core.ProjectInitializer = async (ctx) => {
 					}
 					searchedUris.add(uri)
 					const packRoot = core.fileUtil.dirname(uri)
-					const [packMcmeta, type] = await Promise.all([
-						readPackMcmeta(uri),
+					const [format, type] = await Promise.all([
+						readPackFormat(uri),
 						PackMcmeta.getType(packRoot, externals),
 					])
-					const versionInfo = resolveConfiguredVersion(
-						config.env.gameVersion,
-						versions,
-						packMcmeta,
-						type,
-						logger,
-					)
-					packs.push({ type, packRoot, packMcmeta, versionInfo })
+					if (format !== undefined) {
+						packs.push({ type, packRoot, format })
+					}
 				}
 			}
 		}
@@ -74,7 +68,10 @@ export const initialize: core.ProjectInitializer = async (ctx) => {
 	meta.registerUriBinder(uriBinder)
 	registerUriBuilders(meta)
 
-	const versions = await getVersions(ctx.externals, ctx.downloader)
+	const [versions, packs] = await Promise.all([
+		getVersions(ctx.externals, ctx.downloader),
+		findPackMcmetas(),
+	])
 	if (!versions) {
 		ctx.logger.error(
 			'[je-initialize] Failed loading game version list. Expect everything to be broken.',
@@ -82,32 +79,7 @@ export const initialize: core.ProjectInitializer = async (ctx) => {
 		return
 	}
 
-	const packs = await findPackMcmetas(versions)
-
-	function selectVersionInfo(packs: PackInfo[], versions: McmetaVersions) {
-		// Select the first valid pack.mcmeta, prioritizing data packs
-		const pack = packs.find(p => p.packMcmeta !== undefined && p.type === 'data')
-			?? packs.find(p => p.packMcmeta !== undefined && p.type === 'assets')
-		const version = pack === undefined
-			? resolveConfiguredVersion(config.env.gameVersion, versions, undefined, undefined, logger)
-			: pack.versionInfo
-		const packMessage = pack === undefined
-			? 'Failed finding a valid pack.mcmeta'
-			: `Found a valid pack.mcmeta ${pack.packRoot}/pack.mcmeta`
-		const reasonMessage = pack && version.reason === 'auto'
-			? `using ${pack.type} pack format ${pack.packMcmeta?.pack.pack_format} to select`
-			: version.reason === 'config'
-			? `but using config override "${config.env.gameVersion}" to select`
-			: version.reason === 'fallback'
-			? 'using fallback'
-			: 'impossible' // should never occur
-		const versionMessage = `version ${version.release}${
-			version.id === version.release ? '' : ` (${version.id})`
-		}`
-		ctx.logger.info(`[je.initialize] ${packMessage}, ${reasonMessage} ${versionMessage}`)
-		return version
-	}
-	const version = selectVersionInfo(packs, versions)
+	const version = resolveConfiguredVersion(config.env.gameVersion, versions, packs, logger)
 	const release = version.release
 
 	meta.registerDependencyProvider(

--- a/packages/java-edition/src/mcdocAttributes.ts
+++ b/packages/java-edition/src/mcdocAttributes.ts
@@ -1,5 +1,4 @@
 import * as core from '@spyglassmc/core'
-import { localize } from '@spyglassmc/locales'
 import * as mcdoc from '@spyglassmc/mcdoc'
 import { NEXT_RELEASE_VERSION, ReleaseVersion } from './dependency/index.js'
 import type { McmetaCommands, McmetaVersions, PackInfo } from './dependency/index.js'
@@ -75,7 +74,6 @@ export function registerMcdocAttributes(
 
 export function registerPackFormatAttribute(
 	meta: core.MetaRegistry,
-	release: ReleaseVersion,
 	versions: McmetaVersions,
 	packs: PackInfo[],
 ) {
@@ -102,28 +100,6 @@ export function registerPackFormatAttribute(
 		return thisPack?.type === 'assets' ? assetsFormats : dataFormats
 	}
 	mcdoc.runtime.registerAttribute(meta, 'pack_format', () => undefined, {
-		checker: (_, typeDef) => {
-			if (typeDef.kind !== 'literal' || typeof typeDef.value.value !== 'number') {
-				return undefined
-			}
-			const target = typeDef.value.value
-			return (node, ctx) => {
-				const targetVersions = getFormats(ctx.doc.uri).get(target)
-				if (!targetVersions) {
-					ctx.err.report(
-						localize('java-edition.pack-format.unsupported', target),
-						node,
-						core.ErrorSeverity.Warning,
-					)
-				} else if (!targetVersions.some(v => v === release)) {
-					ctx.err.report(
-						localize('java-edition.pack-format.not-loaded', target, release),
-						node,
-						core.ErrorSeverity.Warning,
-					)
-				}
-			}
-		},
 		numericCompleter: (_, ctx) => {
 			return [...getFormats(ctx.doc.uri).entries()].map(([k, v], i) => ({
 				range: core.Range.create(ctx.offset),

--- a/packages/java-edition/test/dependency/mcmeta.spec.ts
+++ b/packages/java-edition/test/dependency/mcmeta.spec.ts
@@ -5,7 +5,7 @@ import { describe, it } from 'mocha'
 import * as path from 'path'
 import snapshot from 'snap-shot-it'
 import url from 'url'
-import type { PackMcmeta } from '../../lib/dependency/common.js'
+import type { PackInfo, PackMcmeta } from '../../lib/dependency/common.js'
 import type { McmetaRegistries, McmetaStates, McmetaVersions } from '../../lib/dependency/mcmeta.js'
 import {
 	Fluids,
@@ -41,8 +41,8 @@ const Fixtures = {
 
 describe('mcmeta', () => {
 	describe('resolveConfiguredVersion()', () => {
-		const suites: { version: string; packMcmeta?: PackMcmeta | undefined }[] = [
-			{ version: 'Auto', packMcmeta: { pack: { pack_format: 6 } } },
+		const suites: { version: string; packs?: PackInfo[] | undefined }[] = [
+			{ version: 'Auto', packs: [{ type: 'data', format: 6, packRoot: 'file:///pack.mcmeta' }] },
 			{ version: 'Latest Release' },
 			{ version: 'Latest Snapshot' },
 			{ version: 'unknown' },
@@ -50,13 +50,12 @@ describe('mcmeta', () => {
 			{ version: '22w03a' },
 			{ version: '1.16.5' },
 		]
-		for (const { version, packMcmeta } of suites) {
+		for (const { version, packs } of suites) {
 			it(`Should resolve "${version}"`, async () => {
 				const actual = resolveConfiguredVersion(
 					version,
 					Fixtures.Versions,
-					packMcmeta,
-					undefined,
+					packs ?? [],
 					console,
 				)
 				snapshot(actual)

--- a/packages/locales/src/locales/en.json
+++ b/packages/locales/src/locales/en.json
@@ -51,8 +51,6 @@
   "mismatching-regex-pattern": "Value does not match regex: %0%",
   "java-edition.binder.wrong-folder": "Files in the %0% folder are not recognized in loaded version %1%, did you meant to use the %2% folder?",
   "java-edition.binder.wrong-version": "Files in the %0% folder are not recognized in loaded version %1%",
-  "java-edition.pack-format.unsupported": "Pack format %0% does not have a corresponding release version. Snapshot versions are unsupported.",
-  "java-edition.pack-format.not-loaded": "Pack format %0% does not match the actively loaded version %1%. You may need to reload Spyglass.",
   "java-edition.translation-value.percent-escape-hint": "%0%. If you want to display a literal percent sign, use “%%” instead",
   "json.doc.advancement.display": "Advancement display settings. If present, the advancement will be visible in the advancement tabs.",
   "json.checker.array.length-between": "%0% with length between %1% and %2%",


### PR DESCRIPTION
- Now also looks at `supported_formats` and uses the highest value
- Now looks at all the pack.mcmeta files and uses the highest one
- Removes the warnings on `#[pack_format]` mcdoc types
- Fixes #1740
