### PR TITLE
✨ Implement macro option in command mcdoc attribute

### DIFF
--- a/__snapshots__/packages/mcfunction/test-out/parser/entry.spec.js
+++ b/__snapshots__/packages/mcfunction/test-out/parser/entry.spec.js
@@ -126,6 +126,13 @@ exports['mcfunction parser entry() Parse "# this is a comment↓say hi↓$this i
         },
         "children": [
           {
+            "type": "mcfunction:macro/prefix",
+            "range": {
+              "start": 27,
+              "end": 28
+            }
+          },
+          {
             "type": "mcfunction:macro/other",
             "range": {
               "start": 28,
@@ -172,6 +179,13 @@ exports['mcfunction parser entry() Parse "$this is a $(macro) command" 1'] = {
         },
         "children": [
           {
+            "type": "mcfunction:macro/prefix",
+            "range": {
+              "start": 0,
+              "end": 1
+            }
+          },
+          {
             "type": "mcfunction:macro/other",
             "range": {
               "start": 1,
@@ -217,6 +231,13 @@ exports['mcfunction parser entry() Parse "$this is a $(macro) ⧵ ↓ this is $(
           "end": 48
         },
         "children": [
+          {
+            "type": "mcfunction:macro/prefix",
+            "range": {
+              "start": 0,
+              "end": 1
+            }
+          },
           {
             "type": "mcfunction:macro/other",
             "range": {
@@ -277,8 +298,7 @@ exports['mcfunction parser entry() Parse "$this is a macro command $(with_args)"
         "range": {
           "start": 0,
           "end": 37
-        },
-        "children": []
+        }
       }
     ]
   },
@@ -307,8 +327,7 @@ exports['mcfunction parser entry() Parse "$this is a macro command" without macr
         "range": {
           "start": 0,
           "end": 24
-        },
-        "children": []
+        }
       }
     ]
   },

--- a/__snapshots__/packages/mcfunction/test-out/parser/macro.spec.js
+++ b/__snapshots__/packages/mcfunction/test-out/parser/macro.spec.js
@@ -7,6 +7,13 @@ exports['mcfunction parser macro() Parse "$say $() bar" 1'] = {
     },
     "children": [
       {
+        "type": "mcfunction:macro/prefix",
+        "range": {
+          "start": 0,
+          "end": 1
+        }
+      },
+      {
         "type": "mcfunction:macro/other",
         "range": {
           "start": 1,
@@ -52,6 +59,13 @@ exports['mcfunction parser macro() Parse "$say $(foo bar" 1'] = {
       "end": 15
     },
     "children": [
+      {
+        "type": "mcfunction:macro/prefix",
+        "range": {
+          "start": 0,
+          "end": 1
+        }
+      },
       {
         "type": "mcfunction:macro/other",
         "range": {
@@ -99,6 +113,13 @@ exports['mcfunction parser macro() Parse "$say $(invalid.key) bar" 1'] = {
     },
     "children": [
       {
+        "type": "mcfunction:macro/prefix",
+        "range": {
+          "start": 0,
+          "end": 1
+        }
+      },
+      {
         "type": "mcfunction:macro/other",
         "range": {
           "start": 1,
@@ -145,6 +166,13 @@ exports['mcfunction parser macro() Parse "$say $(message)" 1'] = {
     },
     "children": [
       {
+        "type": "mcfunction:macro/prefix",
+        "range": {
+          "start": 0,
+          "end": 1
+        }
+      },
+      {
         "type": "mcfunction:macro/other",
         "range": {
           "start": 1,
@@ -173,6 +201,13 @@ exports['mcfunction parser macro() Parse "$say no macro argument specified" 1'] 
       "end": 32
     },
     "children": [
+      {
+        "type": "mcfunction:macro/prefix",
+        "range": {
+          "start": 0,
+          "end": 1
+        }
+      },
       {
         "type": "mcfunction:macro/other",
         "range": {
@@ -204,6 +239,13 @@ exports['mcfunction parser macro() Parse "$scoreboard players set $mode settings
     },
     "children": [
       {
+        "type": "mcfunction:macro/prefix",
+        "range": {
+          "start": 0,
+          "end": 1
+        }
+      },
+      {
         "type": "mcfunction:macro/other",
         "range": {
           "start": 1,
@@ -232,6 +274,13 @@ exports['mcfunction parser macro() Parse "$summon cow $(x).1 $(y)30.0 $(z).0" 1'
       "end": 34
     },
     "children": [
+      {
+        "type": "mcfunction:macro/prefix",
+        "range": {
+          "start": 0,
+          "end": 1
+        }
+      },
       {
         "type": "mcfunction:macro/other",
         "range": {
@@ -302,6 +351,13 @@ exports['mcfunction parser macro() Parse "$tag @s add $(tag)_40" 1'] = {
     },
     "children": [
       {
+        "type": "mcfunction:macro/prefix",
+        "range": {
+          "start": 0,
+          "end": 1
+        }
+      },
+      {
         "type": "mcfunction:macro/other",
         "range": {
           "start": 1,
@@ -338,6 +394,13 @@ exports['mcfunction parser macro() Parse "$tellraw $(player) $(text)" 1'] = {
       "end": 26
     },
     "children": [
+      {
+        "type": "mcfunction:macro/prefix",
+        "range": {
+          "start": 0,
+          "end": 1
+        }
+      },
       {
         "type": "mcfunction:macro/other",
         "range": {
@@ -383,6 +446,13 @@ exports['mcfunction parser macro() Parse "$tellraw $(players) ["$ Hello everyone
       "end": 43
     },
     "children": [
+      {
+        "type": "mcfunction:macro/prefix",
+        "range": {
+          "start": 0,
+          "end": 1
+        }
+      },
       {
         "type": "mcfunction:macro/other",
         "range": {

--- a/packages/mcfunction/src/colorizer/macro.ts
+++ b/packages/mcfunction/src/colorizer/macro.ts
@@ -3,11 +3,10 @@ import type { MacroNode } from '../node/macro.js'
 
 export const macro: core.Colorizer<MacroNode> = (node, ctx) => {
 	const tokens: core.ColorToken[] = []
-	tokens.push(
-		core.ColorToken.create(core.Range.create(node.range.start, node.range.start + 1), 'literal'),
-	) // Dollar Sign
 	for (const child of node.children) {
-		if (child.type === 'mcfunction:macro/other') {
+		if (child.type === 'mcfunction:macro/prefix') {
+			tokens.push(core.ColorToken.create(child.range, 'literal'))
+		} else if (child.type === 'mcfunction:macro/other') {
 			tokens.push(core.ColorToken.create(child.range, 'string'))
 		} else {
 			const { start, end } = child.range

--- a/packages/mcfunction/src/completer/index.ts
+++ b/packages/mcfunction/src/completer/index.ts
@@ -21,10 +21,10 @@ export function entry(
 ): core.Completer<McfunctionNode> {
 	return (node, ctx) => {
 		const childNode = core.AstNode.findChild(node, ctx.offset, true)
-		if (core.CommentNode.is(childNode) || MacroNode.is(childNode)) {
-			return []
-		} else {
+		if (CommandNode.is(childNode)) {
 			return command(tree, getMockNodes)(childNode ?? CommandNode.mock(ctx.offset), ctx)
+		} else {
+			return []
 		}
 	}
 }

--- a/packages/mcfunction/src/node/entry.ts
+++ b/packages/mcfunction/src/node/entry.ts
@@ -3,7 +3,7 @@ import type { CommandNode } from './command.js'
 import type { MacroNode } from './macro.js'
 
 export interface McfunctionNode
-	extends core.SequenceNode<CommandNode | MacroNode | core.CommentNode>
+	extends core.SequenceNode<CommandNode | MacroNode | core.CommentNode | core.ErrorNode>
 {
 	type: 'mcfunction:entry'
 }

--- a/packages/mcfunction/src/node/macro.ts
+++ b/packages/mcfunction/src/node/macro.ts
@@ -1,8 +1,10 @@
 import * as core from '@spyglassmc/core'
 
-export interface MacroNode extends core.SequenceNode<MacroOtherNode | MacroArgumentNode> {
+export interface MacroNode
+	extends core.SequenceNode<MacroPrefixNode | MacroOtherNode | MacroArgumentNode>
+{
 	type: 'mcfunction:macro'
-	children: (MacroOtherNode | MacroArgumentNode)[]
+	children: (MacroPrefixNode | MacroOtherNode | MacroArgumentNode)[]
 }
 export namespace MacroNode {
 	/* istanbul ignore next */
@@ -15,6 +17,10 @@ export namespace MacroNode {
 	export function mock(range: core.RangeLike): MacroNode {
 		return { type: 'mcfunction:macro', range: core.Range.get(range), children: [] }
 	}
+}
+
+export interface MacroPrefixNode extends core.AstNode {
+	type: 'mcfunction:macro/prefix'
 }
 
 export interface MacroOtherNode extends core.AstNode {


### PR DESCRIPTION
Adds support for `#[command(macro="implicit")]`. I had to modify the macro AST nodes to support macro nodes without the leading `$`.