### PR TITLE
🐛 Fix float formatter

### DIFF
--- a/packages/core/src/processor/formatter/builtin.ts
+++ b/packages/core/src/processor/formatter/builtin.ts
@@ -42,12 +42,7 @@ export const comment: Formatter<CommentNode> = (node) => {
 }
 
 export const float: Formatter<FloatBaseNode> = (node) => {
-	const numberAsString = node.value.toString()
-	const hasNoDecimalPoint = Number.isInteger(node.value)
-	if (hasNoDecimalPoint) {
-		return numberAsString + '.0'
-	}
-	return numberAsString
+	return node.value.toString()
 }
 
 export const integer: Formatter<IntegerNode> = (node) => {

--- a/packages/mcdoc/test/formatter/suites/range.mcdoc
+++ b/packages/mcdoc/test/formatter/suites/range.mcdoc
@@ -1,1 +1,1 @@
-type MyType = float @ 0.00001..1.0
+type MyType = float @ 0.00001..1


### PR DESCRIPTION
The float formatter change introduced in #1820 can produce invalid JSON numbers. For example: `1.7976931348623157e+308.0`
(the trailing `.0` is not allowed)

Since mcdoc `type MyType = float @ 0.00001..1` is still allowed without the trailing `.0`, this fix does not break mcdoc formatting.

This issue was discovered through https://github.com/misode/misode.github.io/issues/777