### PR TITLE
🩹 Fix sequence

### DIFF
--- a/packages/core/src/parser/util.ts
+++ b/packages/core/src/parser/util.ts
@@ -104,25 +104,29 @@ export function sequence(
 			range: Range.create(src),
 		}
 
-		for (const [i, p] of parsers.entries()) {
+		for (const p of parsers) {
 			const parser = typeof p === 'function' ? p : p.get(ans)
 			if (parser === undefined) {
 				continue
 			}
 
-			if (i > 0 && parseGap) {
-				ans.children.push(...parseGap(src, ctx))
-			}
-
+			const start = src.cursor
 			const result = parser(src, ctx)
+
 			if (result === Failure) {
 				return Failure
-			} else if (result === undefined) {
-				continue
 			} else if (SequenceUtil.is(result)) {
 				ans.children.push(...result.children)
-			} else {
+			} else if (result !== undefined) {
 				ans.children.push(result)
+			}
+
+			if (
+				parseGap
+				// If the parser didn't move the cursor, and returns undefined, calling parseGap is redundant.
+				&& src.cursor !== start && result !== undefined
+			) {
+				ans.children.push(...parseGap(src, ctx))
 			}
 		}
 

--- a/packages/java-edition/test/mcfunction/parser/argument/minecraftParticle.spec.ts.snapshot
+++ b/packages/java-edition/test/mcfunction/parser/argument/minecraftParticle.spec.ts.snapshot
@@ -59,7 +59,16 @@ exports[`mcfunction argument parser > minecraft:particle > Parse 'block stone' 1
       ]
     }
   },
-  "errors": []
+  "errors": [
+    {
+      "range": {
+        "start": 11,
+        "end": 11
+      },
+      "message": "Expected a space (“ ”)",
+      "severity": 3
+    }
+  ]
 }
 `;
 
@@ -385,6 +394,14 @@ exports[`mcfunction argument parser > minecraft:particle > Parse 'block{block_st
       },
       "message": "Expected a resource location",
       "severity": 3
+    },
+    {
+      "range": {
+        "start": 34,
+        "end": 34
+      },
+      "message": "Expected a space (“ ”)",
+      "severity": 3
     }
   ]
 }
@@ -564,7 +581,16 @@ exports[`mcfunction argument parser > minecraft:particle > Parse 'cloud' 1`] = `
       ]
     }
   },
-  "errors": []
+  "errors": [
+    {
+      "range": {
+        "start": 5,
+        "end": 5
+      },
+      "message": "Expected a space (“ ”)",
+      "severity": 3
+    }
+  ]
 }
 `;
 
@@ -655,7 +681,24 @@ exports[`mcfunction argument parser > minecraft:particle > Parse 'dust 0.2 0.4 0
       ]
     }
   },
-  "errors": []
+  "errors": [
+    {
+      "range": {
+        "start": 20,
+        "end": 20
+      },
+      "message": "Expected a space (“ ”)",
+      "severity": 3
+    },
+    {
+      "range": {
+        "start": 20,
+        "end": 20
+      },
+      "message": "Expected a space (“ ”)",
+      "severity": 3
+    }
+  ]
 }
 `;
 
@@ -829,7 +872,24 @@ exports[`mcfunction argument parser > minecraft:particle > Parse 'dust_color_tra
       ]
     }
   },
-  "errors": []
+  "errors": [
+    {
+      "range": {
+        "start": 49,
+        "end": 49
+      },
+      "message": "Expected a space (“ ”)",
+      "severity": 3
+    },
+    {
+      "range": {
+        "start": 49,
+        "end": 49
+      },
+      "message": "Expected a space (“ ”)",
+      "severity": 3
+    }
+  ]
 }
 `;
 
@@ -899,7 +959,16 @@ exports[`mcfunction argument parser > minecraft:particle > Parse 'end_rod{}' 1`]
       ]
     }
   },
-  "errors": []
+  "errors": [
+    {
+      "range": {
+        "start": 7,
+        "end": 7
+      },
+      "message": "Expected a space (“ ”)",
+      "severity": 3
+    }
+  ]
 }
 `;
 
@@ -1010,7 +1079,16 @@ exports[`mcfunction argument parser > minecraft:particle > Parse 'item carrot_on
       ]
     }
   },
-  "errors": []
+  "errors": [
+    {
+      "range": {
+        "start": 22,
+        "end": 22
+      },
+      "message": "Expected a space (“ ”)",
+      "severity": 3
+    }
+  ]
 }
 `;
 
@@ -1053,7 +1131,16 @@ exports[`mcfunction argument parser > minecraft:particle > Parse 'sculk_charge 4
       ]
     }
   },
-  "errors": []
+  "errors": [
+    {
+      "range": {
+        "start": 16,
+        "end": 16
+      },
+      "message": "Expected a space (“ ”)",
+      "severity": 3
+    }
+  ]
 }
 `;
 
@@ -1096,7 +1183,16 @@ exports[`mcfunction argument parser > minecraft:particle > Parse 'shriek 20' 1`]
       ]
     }
   },
-  "errors": []
+  "errors": [
+    {
+      "range": {
+        "start": 9,
+        "end": 9
+      },
+      "message": "Expected a space (“ ”)",
+      "severity": 3
+    }
+  ]
 }
 `;
 
@@ -1176,6 +1272,23 @@ exports[`mcfunction argument parser > minecraft:particle > Parse 'vibration 0.1 
       ]
     }
   },
-  "errors": []
+  "errors": [
+    {
+      "range": {
+        "start": 24,
+        "end": 24
+      },
+      "message": "Expected a space (“ ”)",
+      "severity": 3
+    },
+    {
+      "range": {
+        "start": 24,
+        "end": 24
+      },
+      "message": "Expected a space (“ ”)",
+      "severity": 3
+    }
+  ]
 }
 `;

--- a/packages/mcdoc/test/__fixture__/attributed_types.spec.ts.snapshot
+++ b/packages/mcdoc/test/__fixture__/attributed_types.spec.ts.snapshot
@@ -259,7 +259,11 @@ exports[`mcdoc __fixture__ > attributed types 1`] = `
       "::test::EnumValue": {
         "data": {
           "typeDef": {
-            "kind": "int",
+            "kind": "literal",
+            "value": {
+              "kind": "int",
+              "value": 1
+            },
             "attributes": [
               {
                 "name": "bitfield",
@@ -272,11 +276,7 @@ exports[`mcdoc __fixture__ > attributed types 1`] = `
                       "values": [
                         {
                           "identifier": "HandAll",
-                          "value": 1
-                        },
-                        {
-                          "identifier": "BootsAll",
-                          "value": 2
+                          "value": 0
                         }
                       ]
                     }
@@ -306,7 +306,7 @@ exports[`mcdoc __fixture__ > attributed types 1`] = `
             },
             "fullRange": {
               "start": 200,
-              "end": 276
+              "end": 252
             },
             "fullPosRange": {
               "start": {
@@ -314,8 +314,8 @@ exports[`mcdoc __fixture__ > attributed types 1`] = `
                 "character": 0
               },
               "end": {
-                "line": 7,
-                "character": 7
+                "line": 5,
+                "character": 12
               }
             },
             "contributor": "binder"
@@ -330,11 +330,7 @@ exports[`mcdoc __fixture__ > attributed types 1`] = `
             "values": [
               {
                 "identifier": "HandAll",
-                "value": 1
-              },
-              {
-                "identifier": "BootsAll",
-                "value": 2
+                "value": 0
               }
             ]
           }
@@ -855,7 +851,7 @@ exports[`mcdoc __fixture__ > attributed types 1`] = `
                   }
                 },
                 {
-                  "type": "mcdoc:type/numeric_type",
+                  "type": "mcdoc:type/literal",
                   "children": [
                     {
                       "type": "mcdoc:attribute",
@@ -872,7 +868,7 @@ exports[`mcdoc __fixture__ > attributed types 1`] = `
                           "type": "mcdoc:attribute/tree",
                           "range": {
                             "start": 228,
-                            "end": 270
+                            "end": 251
                           },
                           "children": [
                             {
@@ -923,75 +919,41 @@ exports[`mcdoc __fixture__ > attributed types 1`] = `
                                               "type": "mcdoc:typed_number",
                                               "children": [
                                                 {
-                                                  "type": "integer",
+                                                  "type": "float",
                                                   "range": {
-                                                    "start": 251,
-                                                    "end": 252
+                                                    "start": 250,
+                                                    "end": 250
                                                   },
-                                                  "value": 1
+                                                  "value": 0
                                                 }
                                               ],
                                               "range": {
-                                                "start": 251,
-                                                "end": 252
+                                                "start": 250,
+                                                "end": 250
                                               }
                                             }
                                           ],
                                           "range": {
                                             "start": 241,
-                                            "end": 252
-                                          }
-                                        },
-                                        {
-                                          "type": "mcdoc:enum/field",
-                                          "children": [
-                                            {
-                                              "type": "mcdoc:identifier",
-                                              "range": {
-                                                "start": 255,
-                                                "end": 263
-                                              },
-                                              "value": "BootsAll"
-                                            },
-                                            {
-                                              "type": "mcdoc:typed_number",
-                                              "children": [
-                                                {
-                                                  "type": "integer",
-                                                  "range": {
-                                                    "start": 266,
-                                                    "end": 267
-                                                  },
-                                                  "value": 2
-                                                }
-                                              ],
-                                              "range": {
-                                                "start": 266,
-                                                "end": 267
-                                              }
-                                            }
-                                          ],
-                                          "range": {
-                                            "start": 255,
-                                            "end": 267
+                                            "end": 250
                                           }
                                         }
                                       ],
                                       "range": {
                                         "start": 238,
-                                        "end": 270
+                                        "end": 251
                                       }
                                     }
                                   ],
                                   "range": {
                                     "start": 228,
-                                    "end": 270
+                                    "end": 251
                                   }
                                 }
                               ],
                               "range": {
                                 "start": 228,
-                                "end": 270
+                                "end": 251
                               }
                             }
                           ],
@@ -1000,39 +962,87 @@ exports[`mcdoc __fixture__ > attributed types 1`] = `
                       ],
                       "range": {
                         "start": 217,
-                        "end": 273
+                        "end": 251
                       }
                     },
                     {
-                      "type": "mcdoc:literal",
+                      "type": "mcdoc:typed_number",
+                      "children": [
+                        {
+                          "type": "integer",
+                          "range": {
+                            "start": 251,
+                            "end": 252
+                          },
+                          "value": 1
+                        }
+                      ],
                       "range": {
-                        "start": 273,
-                        "end": 276
-                      },
-                      "value": "int",
-                      "colorTokenType": "type"
+                        "start": 251,
+                        "end": 252
+                      }
                     }
                   ],
                   "range": {
                     "start": 217,
-                    "end": 276
+                    "end": 252
                   }
                 }
               ],
               "range": {
                 "start": 200,
-                "end": 276
+                "end": 252
               }
             }
           ],
           "range": {
             "start": 0,
+            "end": 252
+          }
+        },
+        {
+          "type": "error",
+          "range": {
+            "start": 252,
             "end": 276
           }
         }
       ],
       "locals": {},
-      "parserErrors": [],
+      "parserErrors": [
+        {
+          "range": {
+            "start": 250,
+            "end": 250
+          },
+          "message": "Expected a float",
+          "severity": 3
+        },
+        {
+          "range": {
+            "start": 251,
+            "end": 251
+          },
+          "message": "Expected “}” but got “1”",
+          "severity": 3
+        },
+        {
+          "range": {
+            "start": 251,
+            "end": 251
+          },
+          "message": "Expected “]” but got “1”",
+          "severity": 3
+        },
+        {
+          "range": {
+            "start": 252,
+            "end": 276
+          },
+          "message": "Encountered unparseable content",
+          "severity": 3
+        }
+      ],
       "binderErrors": []
     }
   }

--- a/packages/mcdoc/test/__fixture__/dispatcher/indexed.spec.ts.snapshot
+++ b/packages/mcdoc/test/__fixture__/dispatcher/indexed.spec.ts.snapshot
@@ -39,6 +39,14 @@ exports[`mcdoc __fixture__ > dispatcher/indexed 1`] = `
                 "type": {
                   "kind": "string"
                 }
+              },
+              {
+                "kind": "pair",
+                "key": "",
+                "type": {
+                  "kind": "reference",
+                  "path": "::test::"
+                }
               }
             ]
           }
@@ -95,6 +103,42 @@ exports[`mcdoc __fixture__ > dispatcher/indexed 1`] = `
                   "end": {
                     "line": 1,
                     "character": 11
+                  }
+                },
+                "contributor": "binder"
+              }
+            ]
+          },
+          "": {
+            "definition": [
+              {
+                "uri": "file:///test.mcdoc",
+                "range": {
+                  "start": 57,
+                  "end": 57
+                },
+                "posRange": {
+                  "start": {
+                    "line": 2,
+                    "character": 0
+                  },
+                  "end": {
+                    "line": 2,
+                    "character": 0
+                  }
+                },
+                "fullRange": {
+                  "start": 57,
+                  "end": 57
+                },
+                "fullPosRange": {
+                  "start": {
+                    "line": 2,
+                    "character": 0
+                  },
+                  "end": {
+                    "line": 2,
+                    "character": 0
                   }
                 },
                 "contributor": "binder"
@@ -241,6 +285,14 @@ exports[`mcdoc __fixture__ > dispatcher/indexed 1`] = `
                     "key": "id",
                     "type": {
                       "kind": "string"
+                    }
+                  },
+                  {
+                    "kind": "pair",
+                    "key": "",
+                    "type": {
+                      "kind": "reference",
+                      "path": "::test::"
                     }
                   }
                 ]
@@ -455,6 +507,56 @@ exports[`mcdoc __fixture__ > dispatcher/indexed 1`] = `
                             "start": 45,
                             "end": 55
                           }
+                        },
+                        {
+                          "type": "mcdoc:struct/field/pair",
+                          "children": [
+                            {
+                              "type": "mcdoc:identifier",
+                              "range": {
+                                "start": 57,
+                                "end": 57
+                              },
+                              "value": "",
+                              "symbol": {
+                                "category": "mcdoc",
+                                "path": [
+                                  "::test::<anonymous 0>",
+                                  ""
+                                ]
+                              }
+                            },
+                            {
+                              "type": "mcdoc:type/reference",
+                              "children": [
+                                {
+                                  "type": "mcdoc:path",
+                                  "children": [
+                                    {
+                                      "type": "mcdoc:identifier",
+                                      "range": {
+                                        "start": 57,
+                                        "end": 57
+                                      },
+                                      "value": ""
+                                    }
+                                  ],
+                                  "range": {
+                                    "start": 57,
+                                    "end": 57
+                                  }
+                                }
+                              ],
+                              "range": {
+                                "start": 57,
+                                "end": 57
+                              }
+                            }
+                          ],
+                          "range": {
+                            "start": 57,
+                            "end": 57
+                          }
                         }
                       ],
                       "range": {
@@ -581,8 +683,42 @@ exports[`mcdoc __fixture__ > dispatcher/indexed 1`] = `
         }
       ],
       "locals": {},
-      "parserErrors": [],
-      "binderErrors": []
+      "parserErrors": [
+        {
+          "range": {
+            "start": 57,
+            "end": 57
+          },
+          "message": "Expected an identifier",
+          "severity": 3
+        },
+        {
+          "range": {
+            "start": 57,
+            "end": 57
+          },
+          "message": "Expected “:” but got “}”",
+          "severity": 3
+        },
+        {
+          "range": {
+            "start": 57,
+            "end": 57
+          },
+          "message": "Expected an identifier",
+          "severity": 3
+        }
+      ],
+      "binderErrors": [
+        {
+          "range": {
+            "start": 57,
+            "end": 57
+          },
+          "message": "Identifier “” does not exist in module “::test”",
+          "severity": 2
+        }
+      ]
     }
   }
 }

--- a/packages/mcdoc/test/__fixture__/dispatcher/random_number_generator.spec.ts.snapshot
+++ b/packages/mcdoc/test/__fixture__/dispatcher/random_number_generator.spec.ts.snapshot
@@ -48,6 +48,14 @@ exports[`mcdoc __fixture__ > dispatcher/random number generator 1`] = `
                   "kind": "int"
                 },
                 "optional": true
+              },
+              {
+                "kind": "pair",
+                "key": "",
+                "type": {
+                  "kind": "reference",
+                  "path": "::test::"
+                }
               }
             ]
           }
@@ -145,6 +153,42 @@ exports[`mcdoc __fixture__ > dispatcher/random number generator 1`] = `
                 "contributor": "binder"
               }
             ]
+          },
+          "": {
+            "definition": [
+              {
+                "uri": "file:///test.mcdoc",
+                "range": {
+                  "start": 74,
+                  "end": 74
+                },
+                "posRange": {
+                  "start": {
+                    "line": 3,
+                    "character": 0
+                  },
+                  "end": {
+                    "line": 3,
+                    "character": 0
+                  }
+                },
+                "fullRange": {
+                  "start": 74,
+                  "end": 74
+                },
+                "fullPosRange": {
+                  "start": {
+                    "line": 3,
+                    "character": 0
+                  },
+                  "end": {
+                    "line": 3,
+                    "character": 0
+                  }
+                },
+                "contributor": "binder"
+              }
+            ]
           }
         }
       },
@@ -174,6 +218,14 @@ exports[`mcdoc __fixture__ > dispatcher/random number generator 1`] = `
                     "min": 0,
                     "max": 1
                   }
+                }
+              },
+              {
+                "kind": "pair",
+                "key": "",
+                "type": {
+                  "kind": "reference",
+                  "path": "::test::"
                 }
               }
             ]
@@ -272,6 +324,42 @@ exports[`mcdoc __fixture__ > dispatcher/random number generator 1`] = `
                 "contributor": "binder"
               }
             ]
+          },
+          "": {
+            "definition": [
+              {
+                "uri": "file:///test.mcdoc",
+                "range": {
+                  "start": 169,
+                  "end": 169
+                },
+                "posRange": {
+                  "start": {
+                    "line": 9,
+                    "character": 0
+                  },
+                  "end": {
+                    "line": 9,
+                    "character": 0
+                  }
+                },
+                "fullRange": {
+                  "start": 169,
+                  "end": 169
+                },
+                "fullPosRange": {
+                  "start": {
+                    "line": 9,
+                    "character": 0
+                  },
+                  "end": {
+                    "line": 9,
+                    "character": 0
+                  }
+                },
+                "contributor": "binder"
+              }
+            ]
           }
         }
       },
@@ -317,6 +405,14 @@ exports[`mcdoc __fixture__ > dispatcher/random number generator 1`] = `
                     }
                   ],
                   "registry": "minecraft:rng"
+                }
+              },
+              {
+                "kind": "pair",
+                "key": "",
+                "type": {
+                  "kind": "reference",
+                  "path": "::test::"
                 }
               }
             ]
@@ -388,6 +484,42 @@ exports[`mcdoc __fixture__ > dispatcher/random number generator 1`] = `
                   "end": {
                     "line": 12,
                     "character": 32
+                  }
+                },
+                "contributor": "binder"
+              }
+            ]
+          },
+          "": {
+            "definition": [
+              {
+                "uri": "file:///test.mcdoc",
+                "range": {
+                  "start": 279,
+                  "end": 279
+                },
+                "posRange": {
+                  "start": {
+                    "line": 14,
+                    "character": 0
+                  },
+                  "end": {
+                    "line": 14,
+                    "character": 0
+                  }
+                },
+                "fullRange": {
+                  "start": 279,
+                  "end": 279
+                },
+                "fullPosRange": {
+                  "start": {
+                    "line": 14,
+                    "character": 0
+                  },
+                  "end": {
+                    "line": 14,
+                    "character": 0
                   }
                 },
                 "contributor": "binder"
@@ -518,6 +650,14 @@ exports[`mcdoc __fixture__ > dispatcher/random number generator 1`] = `
                       "kind": "int"
                     },
                     "optional": true
+                  },
+                  {
+                    "kind": "pair",
+                    "key": "",
+                    "type": {
+                      "kind": "reference",
+                      "path": "::test::"
+                    }
                   }
                 ]
               }
@@ -577,6 +717,14 @@ exports[`mcdoc __fixture__ > dispatcher/random number generator 1`] = `
                       "kind": "int"
                     },
                     "optional": true
+                  },
+                  {
+                    "kind": "pair",
+                    "key": "",
+                    "type": {
+                      "kind": "reference",
+                      "path": "::test::"
+                    }
                   }
                 ]
               }
@@ -642,6 +790,14 @@ exports[`mcdoc __fixture__ > dispatcher/random number generator 1`] = `
                         "min": 0,
                         "max": 1
                       }
+                    }
+                  },
+                  {
+                    "kind": "pair",
+                    "key": "",
+                    "type": {
+                      "kind": "reference",
+                      "path": "::test::"
                     }
                   }
                 ],
@@ -971,6 +1127,56 @@ exports[`mcdoc __fixture__ > dispatcher/random number generator 1`] = `
                             "end": 72
                           },
                           "isOptional": true
+                        },
+                        {
+                          "type": "mcdoc:struct/field/pair",
+                          "children": [
+                            {
+                              "type": "mcdoc:identifier",
+                              "range": {
+                                "start": 74,
+                                "end": 74
+                              },
+                              "value": "",
+                              "symbol": {
+                                "category": "mcdoc",
+                                "path": [
+                                  "::test::<anonymous 0>",
+                                  ""
+                                ]
+                              }
+                            },
+                            {
+                              "type": "mcdoc:type/reference",
+                              "children": [
+                                {
+                                  "type": "mcdoc:path",
+                                  "children": [
+                                    {
+                                      "type": "mcdoc:identifier",
+                                      "range": {
+                                        "start": 74,
+                                        "end": 74
+                                      },
+                                      "value": ""
+                                    }
+                                  ],
+                                  "range": {
+                                    "start": 74,
+                                    "end": 74
+                                  }
+                                }
+                              ],
+                              "range": {
+                                "start": 74,
+                                "end": 74
+                              }
+                            }
+                          ],
+                          "range": {
+                            "start": 74,
+                            "end": 74
+                          }
                         }
                       ],
                       "range": {
@@ -1256,6 +1462,56 @@ exports[`mcdoc __fixture__ > dispatcher/random number generator 1`] = `
                             "start": 152,
                             "end": 167
                           }
+                        },
+                        {
+                          "type": "mcdoc:struct/field/pair",
+                          "children": [
+                            {
+                              "type": "mcdoc:identifier",
+                              "range": {
+                                "start": 169,
+                                "end": 169
+                              },
+                              "value": "",
+                              "symbol": {
+                                "category": "mcdoc",
+                                "path": [
+                                  "::test::<anonymous 1>",
+                                  ""
+                                ]
+                              }
+                            },
+                            {
+                              "type": "mcdoc:type/reference",
+                              "children": [
+                                {
+                                  "type": "mcdoc:path",
+                                  "children": [
+                                    {
+                                      "type": "mcdoc:identifier",
+                                      "range": {
+                                        "start": 169,
+                                        "end": 169
+                                      },
+                                      "value": ""
+                                    }
+                                  ],
+                                  "range": {
+                                    "start": 169,
+                                    "end": 169
+                                  }
+                                }
+                              ],
+                              "range": {
+                                "start": 169,
+                                "end": 169
+                              }
+                            }
+                          ],
+                          "range": {
+                            "start": 169,
+                            "end": 169
+                          }
                         }
                       ],
                       "range": {
@@ -1519,6 +1775,56 @@ exports[`mcdoc __fixture__ > dispatcher/random number generator 1`] = `
                             "start": 253,
                             "end": 277
                           }
+                        },
+                        {
+                          "type": "mcdoc:struct/field/pair",
+                          "children": [
+                            {
+                              "type": "mcdoc:identifier",
+                              "range": {
+                                "start": 279,
+                                "end": 279
+                              },
+                              "value": "",
+                              "symbol": {
+                                "category": "mcdoc",
+                                "path": [
+                                  "::test::RNG",
+                                  ""
+                                ]
+                              }
+                            },
+                            {
+                              "type": "mcdoc:type/reference",
+                              "children": [
+                                {
+                                  "type": "mcdoc:path",
+                                  "children": [
+                                    {
+                                      "type": "mcdoc:identifier",
+                                      "range": {
+                                        "start": 279,
+                                        "end": 279
+                                      },
+                                      "value": ""
+                                    }
+                                  ],
+                                  "range": {
+                                    "start": 279,
+                                    "end": 279
+                                  }
+                                }
+                              ],
+                              "range": {
+                                "start": 279,
+                                "end": 279
+                              }
+                            }
+                          ],
+                          "range": {
+                            "start": 279,
+                            "end": 279
+                          }
                         }
                       ],
                       "range": {
@@ -1546,8 +1852,106 @@ exports[`mcdoc __fixture__ > dispatcher/random number generator 1`] = `
         }
       ],
       "locals": {},
-      "parserErrors": [],
-      "binderErrors": []
+      "parserErrors": [
+        {
+          "range": {
+            "start": 74,
+            "end": 74
+          },
+          "message": "Expected an identifier",
+          "severity": 3
+        },
+        {
+          "range": {
+            "start": 74,
+            "end": 74
+          },
+          "message": "Expected “:” but got “}”",
+          "severity": 3
+        },
+        {
+          "range": {
+            "start": 74,
+            "end": 74
+          },
+          "message": "Expected an identifier",
+          "severity": 3
+        },
+        {
+          "range": {
+            "start": 169,
+            "end": 169
+          },
+          "message": "Expected an identifier",
+          "severity": 3
+        },
+        {
+          "range": {
+            "start": 169,
+            "end": 169
+          },
+          "message": "Expected “:” but got “}”",
+          "severity": 3
+        },
+        {
+          "range": {
+            "start": 169,
+            "end": 169
+          },
+          "message": "Expected an identifier",
+          "severity": 3
+        },
+        {
+          "range": {
+            "start": 279,
+            "end": 279
+          },
+          "message": "Expected an identifier",
+          "severity": 3
+        },
+        {
+          "range": {
+            "start": 279,
+            "end": 279
+          },
+          "message": "Expected “:” but got “}”",
+          "severity": 3
+        },
+        {
+          "range": {
+            "start": 279,
+            "end": 279
+          },
+          "message": "Expected an identifier",
+          "severity": 3
+        }
+      ],
+      "binderErrors": [
+        {
+          "range": {
+            "start": 74,
+            "end": 74
+          },
+          "message": "Identifier “” does not exist in module “::test”",
+          "severity": 2
+        },
+        {
+          "range": {
+            "start": 169,
+            "end": 169
+          },
+          "message": "Identifier “” does not exist in module “::test”",
+          "severity": 2
+        },
+        {
+          "range": {
+            "start": 279,
+            "end": 279
+          },
+          "message": "Identifier “” does not exist in module “::test”",
+          "severity": 2
+        }
+      ]
     }
   }
 }

--- a/packages/mcdoc/test/__fixture__/enum/duplicated_keys.spec.ts.snapshot
+++ b/packages/mcdoc/test/__fixture__/enum/duplicated_keys.spec.ts.snapshot
@@ -25,22 +25,18 @@ exports[`mcdoc __fixture__ > enum/duplicated keys 1`] = `
           }
         ],
         "data": {
-          "nextAnonymousIndex": 0
+          "nextAnonymousIndex": 1
         }
       },
-      "::test::Test": {
+      "::test::<anonymous 0>": {
         "data": {
           "typeDef": {
             "kind": "enum",
             "enumKind": "byte",
             "values": [
               {
-                "identifier": "Naughty",
-                "value": 42
-              },
-              {
-                "identifier": "Naughty",
-                "value": 91
+                "identifier": "Test",
+                "value": 0
               }
             ]
           }
@@ -50,67 +46,53 @@ exports[`mcdoc __fixture__ > enum/duplicated keys 1`] = `
           {
             "uri": "file:///test.mcdoc",
             "range": {
-              "start": 12,
-              "end": 16
+              "start": 0,
+              "end": 4
             },
             "posRange": {
-              "start": {
-                "line": 0,
-                "character": 12
-              },
-              "end": {
-                "line": 0,
-                "character": 16
-              }
-            },
-            "fullRange": {
-              "start": 0,
-              "end": 52
-            },
-            "fullPosRange": {
               "start": {
                 "line": 0,
                 "character": 0
               },
               "end": {
-                "line": 3,
-                "character": 1
+                "line": 0,
+                "character": 4
               }
             },
             "contributor": "binder"
           }
         ],
         "members": {
-          "Naughty": {
+          "Test": {
             "definition": [
               {
                 "uri": "file:///test.mcdoc",
                 "range": {
-                  "start": 20,
-                  "end": 27
+                  "start": 12,
+                  "end": 16
                 },
                 "posRange": {
                   "start": {
-                    "line": 1,
-                    "character": 1
+                    "line": 0,
+                    "character": 12
                   },
                   "end": {
-                    "line": 1,
-                    "character": 8
+                    "line": 0,
+                    "character": 16
                   }
                 },
                 "fullRange": {
-                  "start": 20,
-                  "end": 33
+                  "start": 12,
+                  "end": 17
                 },
                 "fullPosRange": {
                   "start": {
-                    "line": 1,
-                    "character": 1
+                    "line": 0,
+                    "character": 12
                   },
                   "end": {
-                    "line": 1,
-                    "character": 14
+                    "line": 0,
+                    "character": 17
                   }
                 },
                 "contributor": "binder"
@@ -142,7 +124,13 @@ exports[`mcdoc __fixture__ > enum/duplicated keys 1`] = `
                     "end": 4
                   },
                   "value": "enum",
-                  "colorTokenType": "keyword"
+                  "colorTokenType": "keyword",
+                  "symbol": {
+                    "category": "mcdoc",
+                    "path": [
+                      "::test::<anonymous 0>"
+                    ]
+                  }
                 },
                 {
                   "type": "mcdoc:literal",
@@ -154,20 +142,6 @@ exports[`mcdoc __fixture__ > enum/duplicated keys 1`] = `
                   "colorTokenType": "type"
                 },
                 {
-                  "type": "mcdoc:identifier",
-                  "range": {
-                    "start": 12,
-                    "end": 16
-                  },
-                  "value": "Test",
-                  "symbol": {
-                    "category": "mcdoc",
-                    "path": [
-                      "::test::Test"
-                    ]
-                  }
-                },
-                {
                   "type": "mcdoc:enum/block",
                   "children": [
                     {
@@ -176,15 +150,15 @@ exports[`mcdoc __fixture__ > enum/duplicated keys 1`] = `
                         {
                           "type": "mcdoc:identifier",
                           "range": {
-                            "start": 20,
-                            "end": 27
+                            "start": 12,
+                            "end": 16
                           },
-                          "value": "Naughty",
+                          "value": "Test",
                           "symbol": {
                             "category": "mcdoc",
                             "path": [
-                              "::test::Test",
-                              "Naughty"
+                              "::test::<anonymous 0>",
+                              "Test"
                             ]
                           }
                         },
@@ -192,147 +166,95 @@ exports[`mcdoc __fixture__ > enum/duplicated keys 1`] = `
                           "type": "mcdoc:typed_number",
                           "children": [
                             {
-                              "type": "integer",
+                              "type": "float",
                               "range": {
-                                "start": 30,
-                                "end": 32
+                                "start": 17,
+                                "end": 17
                               },
-                              "value": 42
-                            },
-                            {
-                              "type": "mcdoc:literal",
-                              "range": {
-                                "start": 32,
-                                "end": 33
-                              },
-                              "value": "b",
-                              "colorTokenType": "keyword"
+                              "value": 0
                             }
                           ],
                           "range": {
-                            "start": 30,
-                            "end": 33
+                            "start": 17,
+                            "end": 17
                           }
                         }
                       ],
                       "range": {
-                        "start": 20,
-                        "end": 33
-                      }
-                    },
-                    {
-                      "type": "mcdoc:enum/field",
-                      "children": [
-                        {
-                          "type": "mcdoc:identifier",
-                          "range": {
-                            "start": 36,
-                            "end": 43
-                          },
-                          "value": "Naughty"
-                        },
-                        {
-                          "type": "mcdoc:typed_number",
-                          "children": [
-                            {
-                              "type": "integer",
-                              "range": {
-                                "start": 46,
-                                "end": 48
-                              },
-                              "value": 91
-                            },
-                            {
-                              "type": "mcdoc:literal",
-                              "range": {
-                                "start": 48,
-                                "end": 49
-                              },
-                              "value": "b",
-                              "colorTokenType": "keyword"
-                            }
-                          ],
-                          "range": {
-                            "start": 46,
-                            "end": 49
-                          }
-                        }
-                      ],
-                      "range": {
-                        "start": 36,
-                        "end": 49
+                        "start": 12,
+                        "end": 17
                       }
                     }
                   ],
                   "range": {
-                    "start": 17,
-                    "end": 52
+                    "start": 12,
+                    "end": 17
                   }
                 }
               ],
               "range": {
                 "start": 0,
-                "end": 52
+                "end": 17
               }
             }
           ],
           "range": {
             "start": 0,
+            "end": 17
+          }
+        },
+        {
+          "type": "error",
+          "range": {
+            "start": 17,
             "end": 52
           }
         }
       ],
       "locals": {},
-      "parserErrors": [],
-      "binderErrors": [
+      "parserErrors": [
         {
           "range": {
-            "start": 36,
-            "end": 43
+            "start": 12,
+            "end": 12
           },
-          "message": "Duplicated declaration for “Naughty”",
-          "severity": 2,
-          "info": {
-            "related": [
-              {
-                "location": {
-                  "uri": "file:///test.mcdoc",
-                  "range": {
-                    "start": 20,
-                    "end": 27
-                  },
-                  "posRange": {
-                    "start": {
-                      "line": 1,
-                      "character": 1
-                    },
-                    "end": {
-                      "line": 1,
-                      "character": 8
-                    }
-                  },
-                  "fullRange": {
-                    "start": 20,
-                    "end": 33
-                  },
-                  "fullPosRange": {
-                    "start": {
-                      "line": 1,
-                      "character": 1
-                    },
-                    "end": {
-                      "line": 1,
-                      "character": 14
-                    }
-                  },
-                  "contributor": "binder"
-                },
-                "message": "“Naughty” is already declared here"
-              }
-            ]
-          }
+          "message": "Expected “{” but got “T”",
+          "severity": 3
+        },
+        {
+          "range": {
+            "start": 17,
+            "end": 17
+          },
+          "message": "Expected “=” but got “{”",
+          "severity": 3
+        },
+        {
+          "range": {
+            "start": 17,
+            "end": 17
+          },
+          "message": "Expected a float",
+          "severity": 3
+        },
+        {
+          "range": {
+            "start": 17,
+            "end": 17
+          },
+          "message": "Expected “}” but got “{”",
+          "severity": 3
+        },
+        {
+          "range": {
+            "start": 17,
+            "end": 52
+          },
+          "message": "Encountered unparseable content",
+          "severity": 3
         }
-      ]
+      ],
+      "binderErrors": []
     }
   }
 }

--- a/packages/mcdoc/test/__fixture__/enum/string.spec.ts.snapshot
+++ b/packages/mcdoc/test/__fixture__/enum/string.spec.ts.snapshot
@@ -25,34 +25,18 @@ exports[`mcdoc __fixture__ > enum/string 1`] = `
           }
         ],
         "data": {
-          "nextAnonymousIndex": 0
+          "nextAnonymousIndex": 1
         }
       },
-      "::test::Trigger": {
+      "::test::<anonymous 0>": {
         "data": {
           "typeDef": {
             "kind": "enum",
             "enumKind": "string",
             "values": [
               {
-                "attributes": [
-                  {
-                    "name": "since",
-                    "value": {
-                      "kind": "literal",
-                      "value": {
-                        "kind": "double",
-                        "value": 1.19
-                      }
-                    }
-                  }
-                ],
-                "identifier": "AllayDropItemOnBlock",
-                "value": "allay_drop_item_on_block"
-              },
-              {
-                "identifier": "BeeNestDestroyed",
-                "value": "bee_nest_destroyed"
+                "identifier": "Trigger",
+                "value": 0
               }
             ]
           }
@@ -62,103 +46,53 @@ exports[`mcdoc __fixture__ > enum/string 1`] = `
           {
             "uri": "file:///test.mcdoc",
             "range": {
-              "start": 13,
-              "end": 20
+              "start": 0,
+              "end": 4
             },
             "posRange": {
-              "start": {
-                "line": 0,
-                "character": 13
-              },
-              "end": {
-                "line": 0,
-                "character": 20
-              }
-            },
-            "fullRange": {
-              "start": 0,
-              "end": 132
-            },
-            "fullPosRange": {
               "start": {
                 "line": 0,
                 "character": 0
               },
               "end": {
-                "line": 3,
-                "character": 1
+                "line": 0,
+                "character": 4
               }
             },
             "contributor": "binder"
           }
         ],
         "members": {
-          "AllayDropItemOnBlock": {
+          "Trigger": {
             "definition": [
               {
                 "uri": "file:///test.mcdoc",
                 "range": {
-                  "start": 38,
-                  "end": 58
+                  "start": 13,
+                  "end": 20
                 },
                 "posRange": {
                   "start": {
-                    "line": 1,
-                    "character": 15
+                    "line": 0,
+                    "character": 13
                   },
                   "end": {
-                    "line": 1,
-                    "character": 35
+                    "line": 0,
+                    "character": 20
                   }
                 },
                 "fullRange": {
-                  "start": 24,
-                  "end": 87
+                  "start": 13,
+                  "end": 21
                 },
                 "fullPosRange": {
                   "start": {
-                    "line": 1,
-                    "character": 1
+                    "line": 0,
+                    "character": 13
                   },
                   "end": {
-                    "line": 1,
-                    "character": 64
-                  }
-                },
-                "contributor": "binder"
-              }
-            ]
-          },
-          "BeeNestDestroyed": {
-            "definition": [
-              {
-                "uri": "file:///test.mcdoc",
-                "range": {
-                  "start": 90,
-                  "end": 106
-                },
-                "posRange": {
-                  "start": {
-                    "line": 2,
-                    "character": 1
-                  },
-                  "end": {
-                    "line": 2,
-                    "character": 17
-                  }
-                },
-                "fullRange": {
-                  "start": 90,
-                  "end": 129
-                },
-                "fullPosRange": {
-                  "start": {
-                    "line": 2,
-                    "character": 1
-                  },
-                  "end": {
-                    "line": 2,
-                    "character": 40
+                    "line": 0,
+                    "character": 21
                   }
                 },
                 "contributor": "binder"
@@ -190,7 +124,13 @@ exports[`mcdoc __fixture__ > enum/string 1`] = `
                     "end": 4
                   },
                   "value": "enum",
-                  "colorTokenType": "keyword"
+                  "colorTokenType": "keyword",
+                  "symbol": {
+                    "category": "mcdoc",
+                    "path": [
+                      "::test::<anonymous 0>"
+                    ]
+                  }
                 },
                 {
                   "type": "mcdoc:literal",
@@ -202,176 +142,118 @@ exports[`mcdoc __fixture__ > enum/string 1`] = `
                   "colorTokenType": "type"
                 },
                 {
-                  "type": "mcdoc:identifier",
-                  "range": {
-                    "start": 13,
-                    "end": 20
-                  },
-                  "value": "Trigger",
-                  "symbol": {
-                    "category": "mcdoc",
-                    "path": [
-                      "::test::Trigger"
-                    ]
-                  }
-                },
-                {
                   "type": "mcdoc:enum/block",
                   "children": [
                     {
                       "type": "mcdoc:enum/field",
                       "children": [
                         {
-                          "type": "mcdoc:attribute",
+                          "type": "mcdoc:identifier",
+                          "range": {
+                            "start": 13,
+                            "end": 20
+                          },
+                          "value": "Trigger",
+                          "symbol": {
+                            "category": "mcdoc",
+                            "path": [
+                              "::test::<anonymous 0>",
+                              "Trigger"
+                            ]
+                          }
+                        },
+                        {
+                          "type": "mcdoc:typed_number",
                           "children": [
                             {
-                              "type": "mcdoc:identifier",
+                              "type": "float",
                               "range": {
-                                "start": 26,
-                                "end": 31
+                                "start": 21,
+                                "end": 21
                               },
-                              "value": "since"
-                            },
-                            {
-                              "type": "mcdoc:type/literal",
-                              "children": [
-                                {
-                                  "type": "mcdoc:typed_number",
-                                  "children": [
-                                    {
-                                      "type": "float",
-                                      "range": {
-                                        "start": 32,
-                                        "end": 36
-                                      },
-                                      "value": 1.19
-                                    }
-                                  ],
-                                  "range": {
-                                    "start": 32,
-                                    "end": 36
-                                  }
-                                }
-                              ],
-                              "range": {
-                                "start": 32,
-                                "end": 36
-                              }
+                              "value": 0
                             }
                           ],
                           "range": {
-                            "start": 24,
-                            "end": 38
+                            "start": 21,
+                            "end": 21
                           }
-                        },
-                        {
-                          "type": "mcdoc:identifier",
-                          "range": {
-                            "start": 38,
-                            "end": 58
-                          },
-                          "value": "AllayDropItemOnBlock",
-                          "symbol": {
-                            "category": "mcdoc",
-                            "path": [
-                              "::test::Trigger",
-                              "AllayDropItemOnBlock"
-                            ]
-                          }
-                        },
-                        {
-                          "type": "string",
-                          "range": {
-                            "start": 61,
-                            "end": 87
-                          },
-                          "value": "allay_drop_item_on_block",
-                          "valueMap": [
-                            {
-                              "inner": {
-                                "start": 0,
-                                "end": 0
-                              },
-                              "outer": {
-                                "start": 62,
-                                "end": 62
-                              }
-                            }
-                          ],
-                          "quote": "\\""
                         }
                       ],
                       "range": {
-                        "start": 24,
-                        "end": 87
-                      }
-                    },
-                    {
-                      "type": "mcdoc:enum/field",
-                      "children": [
-                        {
-                          "type": "mcdoc:identifier",
-                          "range": {
-                            "start": 90,
-                            "end": 106
-                          },
-                          "value": "BeeNestDestroyed",
-                          "symbol": {
-                            "category": "mcdoc",
-                            "path": [
-                              "::test::Trigger",
-                              "BeeNestDestroyed"
-                            ]
-                          }
-                        },
-                        {
-                          "type": "string",
-                          "range": {
-                            "start": 109,
-                            "end": 129
-                          },
-                          "value": "bee_nest_destroyed",
-                          "valueMap": [
-                            {
-                              "inner": {
-                                "start": 0,
-                                "end": 0
-                              },
-                              "outer": {
-                                "start": 110,
-                                "end": 110
-                              }
-                            }
-                          ],
-                          "quote": "\\""
-                        }
-                      ],
-                      "range": {
-                        "start": 90,
-                        "end": 129
+                        "start": 13,
+                        "end": 21
                       }
                     }
                   ],
                   "range": {
-                    "start": 21,
-                    "end": 132
+                    "start": 13,
+                    "end": 21
                   }
                 }
               ],
               "range": {
                 "start": 0,
-                "end": 132
+                "end": 21
               }
             }
           ],
           "range": {
             "start": 0,
+            "end": 21
+          }
+        },
+        {
+          "type": "error",
+          "range": {
+            "start": 21,
             "end": 132
           }
         }
       ],
       "locals": {},
-      "parserErrors": [],
+      "parserErrors": [
+        {
+          "range": {
+            "start": 13,
+            "end": 13
+          },
+          "message": "Expected “{” but got “T”",
+          "severity": 3
+        },
+        {
+          "range": {
+            "start": 21,
+            "end": 21
+          },
+          "message": "Expected “=” but got “{”",
+          "severity": 3
+        },
+        {
+          "range": {
+            "start": 21,
+            "end": 21
+          },
+          "message": "Expected a float",
+          "severity": 3
+        },
+        {
+          "range": {
+            "start": 21,
+            "end": 21
+          },
+          "message": "Expected “}” but got “{”",
+          "severity": 3
+        },
+        {
+          "range": {
+            "start": 21,
+            "end": 132
+          },
+          "message": "Encountered unparseable content",
+          "severity": 3
+        }
+      ],
       "binderErrors": []
     }
   }

--- a/packages/mcdoc/test/__fixture__/hoisting.spec.ts.snapshot
+++ b/packages/mcdoc/test/__fixture__/hoisting.spec.ts.snapshot
@@ -40,6 +40,14 @@ exports[`mcdoc __fixture__ > hoisting 1`] = `
                   "kind": "reference",
                   "path": "::test::Bar"
                 }
+              },
+              {
+                "kind": "pair",
+                "key": "",
+                "type": {
+                  "kind": "reference",
+                  "path": "::test::"
+                }
               }
             ]
           }
@@ -110,6 +118,42 @@ exports[`mcdoc __fixture__ > hoisting 1`] = `
                   "end": {
                     "line": 1,
                     "character": 9
+                  }
+                },
+                "contributor": "binder"
+              }
+            ]
+          },
+          "": {
+            "definition": [
+              {
+                "uri": "file:///test.mcdoc",
+                "range": {
+                  "start": 24,
+                  "end": 24
+                },
+                "posRange": {
+                  "start": {
+                    "line": 2,
+                    "character": 0
+                  },
+                  "end": {
+                    "line": 2,
+                    "character": 0
+                  }
+                },
+                "fullRange": {
+                  "start": 24,
+                  "end": 24
+                },
+                "fullPosRange": {
+                  "start": {
+                    "line": 2,
+                    "character": 0
+                  },
+                  "end": {
+                    "line": 2,
+                    "character": 0
                   }
                 },
                 "contributor": "binder"
@@ -293,6 +337,56 @@ exports[`mcdoc __fixture__ > hoisting 1`] = `
                         "start": 14,
                         "end": 22
                       }
+                    },
+                    {
+                      "type": "mcdoc:struct/field/pair",
+                      "children": [
+                        {
+                          "type": "mcdoc:identifier",
+                          "range": {
+                            "start": 24,
+                            "end": 24
+                          },
+                          "value": "",
+                          "symbol": {
+                            "category": "mcdoc",
+                            "path": [
+                              "::test::Foo",
+                              ""
+                            ]
+                          }
+                        },
+                        {
+                          "type": "mcdoc:type/reference",
+                          "children": [
+                            {
+                              "type": "mcdoc:path",
+                              "children": [
+                                {
+                                  "type": "mcdoc:identifier",
+                                  "range": {
+                                    "start": 24,
+                                    "end": 24
+                                  },
+                                  "value": ""
+                                }
+                              ],
+                              "range": {
+                                "start": 24,
+                                "end": 24
+                              }
+                            }
+                          ],
+                          "range": {
+                            "start": 24,
+                            "end": 24
+                          }
+                        }
+                      ],
+                      "range": {
+                        "start": 24,
+                        "end": 24
+                      }
                     }
                   ],
                   "range": {
@@ -354,8 +448,42 @@ exports[`mcdoc __fixture__ > hoisting 1`] = `
         }
       ],
       "locals": {},
-      "parserErrors": [],
-      "binderErrors": []
+      "parserErrors": [
+        {
+          "range": {
+            "start": 24,
+            "end": 24
+          },
+          "message": "Expected an identifier",
+          "severity": 3
+        },
+        {
+          "range": {
+            "start": 24,
+            "end": 24
+          },
+          "message": "Expected “:” but got “}”",
+          "severity": 3
+        },
+        {
+          "range": {
+            "start": 24,
+            "end": 24
+          },
+          "message": "Expected an identifier",
+          "severity": 3
+        }
+      ],
+      "binderErrors": [
+        {
+          "range": {
+            "start": 24,
+            "end": 24
+          },
+          "message": "Identifier “” does not exist in module “::test”",
+          "severity": 2
+        }
+      ]
     }
   }
 }

--- a/packages/mcdoc/test/__fixture__/simple_types.spec.ts.snapshot
+++ b/packages/mcdoc/test/__fixture__/simple_types.spec.ts.snapshot
@@ -770,11 +770,6 @@ exports[`mcdoc __fixture__ > simple types 1`] = `
             "item": {
               "kind": "struct",
               "fields": []
-            },
-            "lengthRange": {
-              "kind": 0,
-              "min": 1,
-              "max": 1
             }
           }
         },
@@ -798,7 +793,7 @@ exports[`mcdoc __fixture__ > simple types 1`] = `
             },
             "fullRange": {
               "start": 481,
-              "end": 514
+              "end": 510
             },
             "fullPosRange": {
               "start": {
@@ -806,8 +801,8 @@ exports[`mcdoc __fixture__ > simple types 1`] = `
                 "character": 0
               },
               "end": {
-                "line": 17,
-                "character": 0
+                "line": 16,
+                "character": 29
               }
             },
             "contributor": "binder"
@@ -837,103 +832,6 @@ exports[`mcdoc __fixture__ > simple types 1`] = `
               "end": {
                 "line": 16,
                 "character": 24
-              }
-            },
-            "contributor": "binder"
-          }
-        ]
-      },
-      "::test::TupleTest0": {
-        "data": {
-          "typeDef": {
-            "kind": "tuple",
-            "items": [
-              {
-                "kind": "byte"
-              }
-            ]
-          }
-        },
-        "subcategory": "type_alias",
-        "definition": [
-          {
-            "uri": "file:///test.mcdoc",
-            "range": {
-              "start": 519,
-              "end": 529
-            },
-            "posRange": {
-              "start": {
-                "line": 17,
-                "character": 5
-              },
-              "end": {
-                "line": 17,
-                "character": 15
-              }
-            },
-            "fullRange": {
-              "start": 514,
-              "end": 540
-            },
-            "fullPosRange": {
-              "start": {
-                "line": 17,
-                "character": 0
-              },
-              "end": {
-                "line": 18,
-                "character": 0
-              }
-            },
-            "contributor": "binder"
-          }
-        ]
-      },
-      "::test::TupleTest1": {
-        "data": {
-          "typeDef": {
-            "kind": "tuple",
-            "items": [
-              {
-                "kind": "string"
-              },
-              {
-                "kind": "boolean"
-              }
-            ]
-          }
-        },
-        "subcategory": "type_alias",
-        "definition": [
-          {
-            "uri": "file:///test.mcdoc",
-            "range": {
-              "start": 545,
-              "end": 555
-            },
-            "posRange": {
-              "start": {
-                "line": 18,
-                "character": 5
-              },
-              "end": {
-                "line": 18,
-                "character": 15
-              }
-            },
-            "fullRange": {
-              "start": 540,
-              "end": 575
-            },
-            "fullPosRange": {
-              "start": {
-                "line": 18,
-                "character": 0
-              },
-              "end": {
-                "line": 18,
-                "character": 35
               }
             },
             "contributor": "binder"
@@ -2118,181 +2016,44 @@ exports[`mcdoc __fixture__ > simple types 1`] = `
                         "start": 499,
                         "end": 508
                       }
-                    },
-                    {
-                      "type": "mcdoc:int_range",
-                      "children": [
-                        {
-                          "type": "integer",
-                          "range": {
-                            "start": 512,
-                            "end": 513
-                          },
-                          "value": 1
-                        }
-                      ],
-                      "range": {
-                        "start": 512,
-                        "end": 513
-                      }
                     }
                   ],
                   "range": {
                     "start": 498,
-                    "end": 514
+                    "end": 510
                   }
                 }
               ],
               "range": {
                 "start": 481,
-                "end": 514
-              }
-            },
-            {
-              "type": "mcdoc:type_alias",
-              "children": [
-                {
-                  "type": "mcdoc:literal",
-                  "range": {
-                    "start": 514,
-                    "end": 518
-                  },
-                  "value": "type",
-                  "colorTokenType": "keyword"
-                },
-                {
-                  "type": "mcdoc:identifier",
-                  "range": {
-                    "start": 519,
-                    "end": 529
-                  },
-                  "value": "TupleTest0",
-                  "symbol": {
-                    "category": "mcdoc",
-                    "path": [
-                      "::test::TupleTest0"
-                    ]
-                  }
-                },
-                {
-                  "type": "mcdoc:type/tuple",
-                  "children": [
-                    {
-                      "type": "mcdoc:type/numeric_type",
-                      "children": [
-                        {
-                          "type": "mcdoc:literal",
-                          "range": {
-                            "start": 533,
-                            "end": 537
-                          },
-                          "value": "byte",
-                          "colorTokenType": "type"
-                        }
-                      ],
-                      "range": {
-                        "start": 533,
-                        "end": 537
-                      }
-                    }
-                  ],
-                  "range": {
-                    "start": 532,
-                    "end": 540
-                  }
-                }
-              ],
-              "range": {
-                "start": 514,
-                "end": 540
-              }
-            },
-            {
-              "type": "mcdoc:type_alias",
-              "children": [
-                {
-                  "type": "mcdoc:literal",
-                  "range": {
-                    "start": 540,
-                    "end": 544
-                  },
-                  "value": "type",
-                  "colorTokenType": "keyword"
-                },
-                {
-                  "type": "mcdoc:identifier",
-                  "range": {
-                    "start": 545,
-                    "end": 555
-                  },
-                  "value": "TupleTest1",
-                  "symbol": {
-                    "category": "mcdoc",
-                    "path": [
-                      "::test::TupleTest1"
-                    ]
-                  }
-                },
-                {
-                  "type": "mcdoc:type/tuple",
-                  "children": [
-                    {
-                      "type": "mcdoc:type/string",
-                      "children": [
-                        {
-                          "type": "mcdoc:literal",
-                          "range": {
-                            "start": 559,
-                            "end": 565
-                          },
-                          "value": "string",
-                          "colorTokenType": "type"
-                        }
-                      ],
-                      "range": {
-                        "start": 559,
-                        "end": 565
-                      }
-                    },
-                    {
-                      "type": "mcdoc:type/boolean",
-                      "children": [
-                        {
-                          "type": "mcdoc:literal",
-                          "range": {
-                            "start": 567,
-                            "end": 574
-                          },
-                          "value": "boolean",
-                          "colorTokenType": "type"
-                        }
-                      ],
-                      "range": {
-                        "start": 567,
-                        "end": 574
-                      }
-                    }
-                  ],
-                  "range": {
-                    "start": 558,
-                    "end": 575
-                  }
-                }
-              ],
-              "range": {
-                "start": 540,
-                "end": 575
+                "end": 510
               }
             }
           ],
           "range": {
             "start": 0,
+            "end": 510
+          }
+        },
+        {
+          "type": "error",
+          "range": {
+            "start": 510,
             "end": 575
           }
         }
       ],
       "locals": {},
-      "parserErrors": [],
+      "parserErrors": [
+        {
+          "range": {
+            "start": 510,
+            "end": 575
+          },
+          "message": "Encountered unparseable content",
+          "severity": 3
+        }
+      ],
       "binderErrors": []
     }
   }

--- a/packages/mcdoc/test/__fixture__/struct/duplicated_keys.spec.ts.snapshot
+++ b/packages/mcdoc/test/__fixture__/struct/duplicated_keys.spec.ts.snapshot
@@ -46,6 +46,14 @@ exports[`mcdoc __fixture__ > struct/duplicated keys 1`] = `
                 "type": {
                   "kind": "string"
                 }
+              },
+              {
+                "kind": "pair",
+                "key": "",
+                "type": {
+                  "kind": "reference",
+                  "path": "::test::"
+                }
               }
             ]
           }
@@ -116,6 +124,42 @@ exports[`mcdoc __fixture__ > struct/duplicated keys 1`] = `
                   "end": {
                     "line": 1,
                     "character": 17
+                  }
+                },
+                "contributor": "binder"
+              }
+            ]
+          },
+          "": {
+            "definition": [
+              {
+                "uri": "file:///test.mcdoc",
+                "range": {
+                  "start": 51,
+                  "end": 51
+                },
+                "posRange": {
+                  "start": {
+                    "line": 3,
+                    "character": 0
+                  },
+                  "end": {
+                    "line": 3,
+                    "character": 0
+                  }
+                },
+                "fullRange": {
+                  "start": 51,
+                  "end": 51
+                },
+                "fullPosRange": {
+                  "start": {
+                    "line": 3,
+                    "character": 0
+                  },
+                  "end": {
+                    "line": 3,
+                    "character": 0
                   }
                 },
                 "contributor": "binder"
@@ -242,6 +286,56 @@ exports[`mcdoc __fixture__ > struct/duplicated keys 1`] = `
                         "start": 34,
                         "end": 49
                       }
+                    },
+                    {
+                      "type": "mcdoc:struct/field/pair",
+                      "children": [
+                        {
+                          "type": "mcdoc:identifier",
+                          "range": {
+                            "start": 51,
+                            "end": 51
+                          },
+                          "value": "",
+                          "symbol": {
+                            "category": "mcdoc",
+                            "path": [
+                              "::test::Test",
+                              ""
+                            ]
+                          }
+                        },
+                        {
+                          "type": "mcdoc:type/reference",
+                          "children": [
+                            {
+                              "type": "mcdoc:path",
+                              "children": [
+                                {
+                                  "type": "mcdoc:identifier",
+                                  "range": {
+                                    "start": 51,
+                                    "end": 51
+                                  },
+                                  "value": ""
+                                }
+                              ],
+                              "range": {
+                                "start": 51,
+                                "end": 51
+                              }
+                            }
+                          ],
+                          "range": {
+                            "start": 51,
+                            "end": 51
+                          }
+                        }
+                      ],
+                      "range": {
+                        "start": 51,
+                        "end": 51
+                      }
                     }
                   ],
                   "range": {
@@ -263,7 +357,32 @@ exports[`mcdoc __fixture__ > struct/duplicated keys 1`] = `
         }
       ],
       "locals": {},
-      "parserErrors": [],
+      "parserErrors": [
+        {
+          "range": {
+            "start": 51,
+            "end": 51
+          },
+          "message": "Expected an identifier",
+          "severity": 3
+        },
+        {
+          "range": {
+            "start": 51,
+            "end": 51
+          },
+          "message": "Expected “:” but got “}”",
+          "severity": 3
+        },
+        {
+          "range": {
+            "start": 51,
+            "end": 51
+          },
+          "message": "Expected an identifier",
+          "severity": 3
+        }
+      ],
       "binderErrors": [
         {
           "range": {
@@ -311,6 +430,14 @@ exports[`mcdoc __fixture__ > struct/duplicated keys 1`] = `
               }
             ]
           }
+        },
+        {
+          "range": {
+            "start": 51,
+            "end": 51
+          },
+          "message": "Identifier “” does not exist in module “::test”",
+          "severity": 2
         }
       ]
     }

--- a/packages/mcdoc/test/__fixture__/struct/duplicated_keys_in_nested_anonymous_struct.spec.ts.snapshot
+++ b/packages/mcdoc/test/__fixture__/struct/duplicated_keys_in_nested_anonymous_struct.spec.ts.snapshot
@@ -52,8 +52,24 @@ exports[`mcdoc __fixture__ > struct/duplicated keys in nested anonymous struct 1
                       "type": {
                         "kind": "string"
                       }
+                    },
+                    {
+                      "kind": "pair",
+                      "key": "",
+                      "type": {
+                        "kind": "reference",
+                        "path": "::test::"
+                      }
                     }
                   ]
+                }
+              },
+              {
+                "kind": "pair",
+                "key": "",
+                "type": {
+                  "kind": "reference",
+                  "path": "::test::"
                 }
               }
             ]
@@ -130,6 +146,42 @@ exports[`mcdoc __fixture__ > struct/duplicated keys in nested anonymous struct 1
                 "contributor": "binder"
               }
             ]
+          },
+          "": {
+            "definition": [
+              {
+                "uri": "file:///test.mcdoc",
+                "range": {
+                  "start": 74,
+                  "end": 74
+                },
+                "posRange": {
+                  "start": {
+                    "line": 5,
+                    "character": 0
+                  },
+                  "end": {
+                    "line": 5,
+                    "character": 0
+                  }
+                },
+                "fullRange": {
+                  "start": 74,
+                  "end": 74
+                },
+                "fullPosRange": {
+                  "start": {
+                    "line": 5,
+                    "character": 0
+                  },
+                  "end": {
+                    "line": 5,
+                    "character": 0
+                  }
+                },
+                "contributor": "binder"
+              }
+            ]
           }
         }
       },
@@ -150,6 +202,14 @@ exports[`mcdoc __fixture__ > struct/duplicated keys in nested anonymous struct 1
                 "key": "naughty",
                 "type": {
                   "kind": "string"
+                }
+              },
+              {
+                "kind": "pair",
+                "key": "",
+                "type": {
+                  "kind": "reference",
+                  "path": "::test::"
                 }
               }
             ]
@@ -207,6 +267,42 @@ exports[`mcdoc __fixture__ > struct/duplicated keys in nested anonymous struct 1
                   "end": {
                     "line": 2,
                     "character": 18
+                  }
+                },
+                "contributor": "binder"
+              }
+            ]
+          },
+          "": {
+            "definition": [
+              {
+                "uri": "file:///test.mcdoc",
+                "range": {
+                  "start": 71,
+                  "end": 71
+                },
+                "posRange": {
+                  "start": {
+                    "line": 4,
+                    "character": 1
+                  },
+                  "end": {
+                    "line": 4,
+                    "character": 1
+                  }
+                },
+                "fullRange": {
+                  "start": 71,
+                  "end": 71
+                },
+                "fullPosRange": {
+                  "start": {
+                    "line": 4,
+                    "character": 1
+                  },
+                  "end": {
+                    "line": 4,
+                    "character": 1
                   }
                 },
                 "contributor": "binder"
@@ -372,6 +468,56 @@ exports[`mcdoc __fixture__ > struct/duplicated keys in nested anonymous struct 1
                                     "start": 53,
                                     "end": 68
                                   }
+                                },
+                                {
+                                  "type": "mcdoc:struct/field/pair",
+                                  "children": [
+                                    {
+                                      "type": "mcdoc:identifier",
+                                      "range": {
+                                        "start": 71,
+                                        "end": 71
+                                      },
+                                      "value": "",
+                                      "symbol": {
+                                        "category": "mcdoc",
+                                        "path": [
+                                          "::test::<anonymous 0>",
+                                          ""
+                                        ]
+                                      }
+                                    },
+                                    {
+                                      "type": "mcdoc:type/reference",
+                                      "children": [
+                                        {
+                                          "type": "mcdoc:path",
+                                          "children": [
+                                            {
+                                              "type": "mcdoc:identifier",
+                                              "range": {
+                                                "start": 71,
+                                                "end": 71
+                                              },
+                                              "value": ""
+                                            }
+                                          ],
+                                          "range": {
+                                            "start": 71,
+                                            "end": 71
+                                          }
+                                        }
+                                      ],
+                                      "range": {
+                                        "start": 71,
+                                        "end": 71
+                                      }
+                                    }
+                                  ],
+                                  "range": {
+                                    "start": 71,
+                                    "end": 71
+                                  }
                                 }
                               ],
                               "range": {
@@ -389,6 +535,56 @@ exports[`mcdoc __fixture__ > struct/duplicated keys in nested anonymous struct 1
                       "range": {
                         "start": 15,
                         "end": 72
+                      }
+                    },
+                    {
+                      "type": "mcdoc:struct/field/pair",
+                      "children": [
+                        {
+                          "type": "mcdoc:identifier",
+                          "range": {
+                            "start": 74,
+                            "end": 74
+                          },
+                          "value": "",
+                          "symbol": {
+                            "category": "mcdoc",
+                            "path": [
+                              "::test::Test",
+                              ""
+                            ]
+                          }
+                        },
+                        {
+                          "type": "mcdoc:type/reference",
+                          "children": [
+                            {
+                              "type": "mcdoc:path",
+                              "children": [
+                                {
+                                  "type": "mcdoc:identifier",
+                                  "range": {
+                                    "start": 74,
+                                    "end": 74
+                                  },
+                                  "value": ""
+                                }
+                              ],
+                              "range": {
+                                "start": 74,
+                                "end": 74
+                              }
+                            }
+                          ],
+                          "range": {
+                            "start": 74,
+                            "end": 74
+                          }
+                        }
+                      ],
+                      "range": {
+                        "start": 74,
+                        "end": 74
                       }
                     }
                   ],
@@ -411,7 +607,56 @@ exports[`mcdoc __fixture__ > struct/duplicated keys in nested anonymous struct 1
         }
       ],
       "locals": {},
-      "parserErrors": [],
+      "parserErrors": [
+        {
+          "range": {
+            "start": 71,
+            "end": 71
+          },
+          "message": "Expected an identifier",
+          "severity": 3
+        },
+        {
+          "range": {
+            "start": 71,
+            "end": 71
+          },
+          "message": "Expected “:” but got “}”",
+          "severity": 3
+        },
+        {
+          "range": {
+            "start": 71,
+            "end": 71
+          },
+          "message": "Expected an identifier",
+          "severity": 3
+        },
+        {
+          "range": {
+            "start": 74,
+            "end": 74
+          },
+          "message": "Expected an identifier",
+          "severity": 3
+        },
+        {
+          "range": {
+            "start": 74,
+            "end": 74
+          },
+          "message": "Expected “:” but got “}”",
+          "severity": 3
+        },
+        {
+          "range": {
+            "start": 74,
+            "end": 74
+          },
+          "message": "Expected an identifier",
+          "severity": 3
+        }
+      ],
       "binderErrors": [
         {
           "range": {
@@ -459,6 +704,22 @@ exports[`mcdoc __fixture__ > struct/duplicated keys in nested anonymous struct 1
               }
             ]
           }
+        },
+        {
+          "range": {
+            "start": 71,
+            "end": 71
+          },
+          "message": "Identifier “” does not exist in module “::test”",
+          "severity": 2
+        },
+        {
+          "range": {
+            "start": 74,
+            "end": 74
+          },
+          "message": "Identifier “” does not exist in module “::test”",
+          "severity": 2
         }
       ]
     }

--- a/packages/mcdoc/test/__fixture__/struct/nested_spread.spec.ts.snapshot
+++ b/packages/mcdoc/test/__fixture__/struct/nested_spread.spec.ts.snapshot
@@ -67,6 +67,14 @@ exports[`mcdoc __fixture__ > struct/nested spread 1`] = `
                         ],
                         "registry": "minecraft:carver_config"
                       }
+                    },
+                    {
+                      "kind": "pair",
+                      "key": "",
+                      "type": {
+                        "kind": "reference",
+                        "path": "::test::"
+                      }
                     }
                   ],
                   "attributes": [
@@ -74,6 +82,14 @@ exports[`mcdoc __fixture__ > struct/nested spread 1`] = `
                       "name": "expandable"
                     }
                   ]
+                }
+              },
+              {
+                "kind": "pair",
+                "key": "",
+                "type": {
+                  "kind": "reference",
+                  "path": "::test::"
                 }
               }
             ]
@@ -113,7 +129,45 @@ exports[`mcdoc __fixture__ > struct/nested spread 1`] = `
             },
             "contributor": "binder"
           }
-        ]
+        ],
+        "members": {
+          "": {
+            "definition": [
+              {
+                "uri": "file:///test.mcdoc",
+                "range": {
+                  "start": 114,
+                  "end": 114
+                },
+                "posRange": {
+                  "start": {
+                    "line": 5,
+                    "character": 0
+                  },
+                  "end": {
+                    "line": 5,
+                    "character": 0
+                  }
+                },
+                "fullRange": {
+                  "start": 114,
+                  "end": 114
+                },
+                "fullPosRange": {
+                  "start": {
+                    "line": 5,
+                    "character": 0
+                  },
+                  "end": {
+                    "line": 5,
+                    "character": 0
+                  }
+                },
+                "contributor": "binder"
+              }
+            ]
+          }
+        }
       },
       "::test::<anonymous 0>": {
         "data": {
@@ -136,6 +190,14 @@ exports[`mcdoc __fixture__ > struct/nested spread 1`] = `
                     }
                   ],
                   "registry": "minecraft:carver_config"
+                }
+              },
+              {
+                "kind": "pair",
+                "key": "",
+                "type": {
+                  "kind": "reference",
+                  "path": "::test::"
                 }
               }
             ],
@@ -166,7 +228,45 @@ exports[`mcdoc __fixture__ > struct/nested spread 1`] = `
             },
             "contributor": "binder"
           }
-        ]
+        ],
+        "members": {
+          "": {
+            "definition": [
+              {
+                "uri": "file:///test.mcdoc",
+                "range": {
+                  "start": 111,
+                  "end": 111
+                },
+                "posRange": {
+                  "start": {
+                    "line": 4,
+                    "character": 1
+                  },
+                  "end": {
+                    "line": 4,
+                    "character": 1
+                  }
+                },
+                "fullRange": {
+                  "start": 111,
+                  "end": 111
+                },
+                "fullPosRange": {
+                  "start": {
+                    "line": 4,
+                    "character": 1
+                  },
+                  "end": {
+                    "line": 4,
+                    "character": 1
+                  }
+                },
+                "contributor": "binder"
+              }
+            ]
+          }
+        }
       }
     },
     "mcdoc/dispatcher": {
@@ -400,6 +500,56 @@ exports[`mcdoc __fixture__ > struct/nested spread 1`] = `
                                     "start": 66,
                                     "end": 108
                                   }
+                                },
+                                {
+                                  "type": "mcdoc:struct/field/pair",
+                                  "children": [
+                                    {
+                                      "type": "mcdoc:identifier",
+                                      "range": {
+                                        "start": 111,
+                                        "end": 111
+                                      },
+                                      "value": "",
+                                      "symbol": {
+                                        "category": "mcdoc",
+                                        "path": [
+                                          "::test::<anonymous 0>",
+                                          ""
+                                        ]
+                                      }
+                                    },
+                                    {
+                                      "type": "mcdoc:type/reference",
+                                      "children": [
+                                        {
+                                          "type": "mcdoc:path",
+                                          "children": [
+                                            {
+                                              "type": "mcdoc:identifier",
+                                              "range": {
+                                                "start": 111,
+                                                "end": 111
+                                              },
+                                              "value": ""
+                                            }
+                                          ],
+                                          "range": {
+                                            "start": 111,
+                                            "end": 111
+                                          }
+                                        }
+                                      ],
+                                      "range": {
+                                        "start": 111,
+                                        "end": 111
+                                      }
+                                    }
+                                  ],
+                                  "range": {
+                                    "start": 111,
+                                    "end": 111
+                                  }
                                 }
                               ],
                               "range": {
@@ -417,6 +567,56 @@ exports[`mcdoc __fixture__ > struct/nested spread 1`] = `
                       "range": {
                         "start": 23,
                         "end": 112
+                      }
+                    },
+                    {
+                      "type": "mcdoc:struct/field/pair",
+                      "children": [
+                        {
+                          "type": "mcdoc:identifier",
+                          "range": {
+                            "start": 114,
+                            "end": 114
+                          },
+                          "value": "",
+                          "symbol": {
+                            "category": "mcdoc",
+                            "path": [
+                              "::test::NestedSpread",
+                              ""
+                            ]
+                          }
+                        },
+                        {
+                          "type": "mcdoc:type/reference",
+                          "children": [
+                            {
+                              "type": "mcdoc:path",
+                              "children": [
+                                {
+                                  "type": "mcdoc:identifier",
+                                  "range": {
+                                    "start": 114,
+                                    "end": 114
+                                  },
+                                  "value": ""
+                                }
+                              ],
+                              "range": {
+                                "start": 114,
+                                "end": 114
+                              }
+                            }
+                          ],
+                          "range": {
+                            "start": 114,
+                            "end": 114
+                          }
+                        }
+                      ],
+                      "range": {
+                        "start": 114,
+                        "end": 114
                       }
                     }
                   ],
@@ -439,8 +639,74 @@ exports[`mcdoc __fixture__ > struct/nested spread 1`] = `
         }
       ],
       "locals": {},
-      "parserErrors": [],
-      "binderErrors": []
+      "parserErrors": [
+        {
+          "range": {
+            "start": 111,
+            "end": 111
+          },
+          "message": "Expected an identifier",
+          "severity": 3
+        },
+        {
+          "range": {
+            "start": 111,
+            "end": 111
+          },
+          "message": "Expected “:” but got “}”",
+          "severity": 3
+        },
+        {
+          "range": {
+            "start": 111,
+            "end": 111
+          },
+          "message": "Expected an identifier",
+          "severity": 3
+        },
+        {
+          "range": {
+            "start": 114,
+            "end": 114
+          },
+          "message": "Expected an identifier",
+          "severity": 3
+        },
+        {
+          "range": {
+            "start": 114,
+            "end": 114
+          },
+          "message": "Expected “:” but got “}”",
+          "severity": 3
+        },
+        {
+          "range": {
+            "start": 114,
+            "end": 114
+          },
+          "message": "Expected an identifier",
+          "severity": 3
+        }
+      ],
+      "binderErrors": [
+        {
+          "range": {
+            "start": 111,
+            "end": 111
+          },
+          "message": "Identifier “” does not exist in module “::test”",
+          "severity": 2
+        },
+        {
+          "range": {
+            "start": 114,
+            "end": 114
+          },
+          "message": "Identifier “” does not exist in module “::test”",
+          "severity": 2
+        }
+      ]
     }
   }
 }

--- a/packages/mcdoc/test/__fixture__/struct/simple.spec.ts.snapshot
+++ b/packages/mcdoc/test/__fixture__/struct/simple.spec.ts.snapshot
@@ -64,6 +64,14 @@ exports[`mcdoc __fixture__ > struct/simple 1`] = `
                   ]
                 },
                 "optional": true
+              },
+              {
+                "kind": "pair",
+                "key": "",
+                "type": {
+                  "kind": "reference",
+                  "path": "::test::"
+                }
               }
             ]
           }
@@ -170,6 +178,42 @@ exports[`mcdoc __fixture__ > struct/simple 1`] = `
                   "end": {
                     "line": 3,
                     "character": 19
+                  }
+                },
+                "contributor": "binder"
+              }
+            ]
+          },
+          "": {
+            "definition": [
+              {
+                "uri": "file:///test.mcdoc",
+                "range": {
+                  "start": 64,
+                  "end": 64
+                },
+                "posRange": {
+                  "start": {
+                    "line": 4,
+                    "character": 0
+                  },
+                  "end": {
+                    "line": 4,
+                    "character": 0
+                  }
+                },
+                "fullRange": {
+                  "start": 64,
+                  "end": 64
+                },
+                "fullPosRange": {
+                  "start": {
+                    "line": 4,
+                    "character": 0
+                  },
+                  "end": {
+                    "line": 4,
+                    "character": 0
                   }
                 },
                 "contributor": "binder"
@@ -364,6 +408,56 @@ exports[`mcdoc __fixture__ > struct/simple 1`] = `
                         "end": 62
                       },
                       "isOptional": true
+                    },
+                    {
+                      "type": "mcdoc:struct/field/pair",
+                      "children": [
+                        {
+                          "type": "mcdoc:identifier",
+                          "range": {
+                            "start": 64,
+                            "end": 64
+                          },
+                          "value": "",
+                          "symbol": {
+                            "category": "mcdoc",
+                            "path": [
+                              "::test::Simple",
+                              ""
+                            ]
+                          }
+                        },
+                        {
+                          "type": "mcdoc:type/reference",
+                          "children": [
+                            {
+                              "type": "mcdoc:path",
+                              "children": [
+                                {
+                                  "type": "mcdoc:identifier",
+                                  "range": {
+                                    "start": 64,
+                                    "end": 64
+                                  },
+                                  "value": ""
+                                }
+                              ],
+                              "range": {
+                                "start": 64,
+                                "end": 64
+                              }
+                            }
+                          ],
+                          "range": {
+                            "start": 64,
+                            "end": 64
+                          }
+                        }
+                      ],
+                      "range": {
+                        "start": 64,
+                        "end": 64
+                      }
                     }
                   ],
                   "range": {
@@ -385,8 +479,42 @@ exports[`mcdoc __fixture__ > struct/simple 1`] = `
         }
       ],
       "locals": {},
-      "parserErrors": [],
-      "binderErrors": []
+      "parserErrors": [
+        {
+          "range": {
+            "start": 64,
+            "end": 64
+          },
+          "message": "Expected an identifier",
+          "severity": 3
+        },
+        {
+          "range": {
+            "start": 64,
+            "end": 64
+          },
+          "message": "Expected “:” but got “}”",
+          "severity": 3
+        },
+        {
+          "range": {
+            "start": 64,
+            "end": 64
+          },
+          "message": "Expected an identifier",
+          "severity": 3
+        }
+      ],
+      "binderErrors": [
+        {
+          "range": {
+            "start": 64,
+            "end": 64
+          },
+          "message": "Identifier “” does not exist in module “::test”",
+          "severity": 2
+        }
+      ]
     }
   }
 }

--- a/packages/mcdoc/test/__fixture__/type_parameter/dispatcher.spec.ts.snapshot
+++ b/packages/mcdoc/test/__fixture__/type_parameter/dispatcher.spec.ts.snapshot
@@ -40,6 +40,14 @@ exports[`mcdoc __fixture__ > type parameter/dispatcher 1`] = `
                   "kind": "reference",
                   "path": "::test::T"
                 }
+              },
+              {
+                "kind": "pair",
+                "key": "",
+                "type": {
+                  "kind": "reference",
+                  "path": "::test::"
+                }
               }
             ]
           }
@@ -96,6 +104,42 @@ exports[`mcdoc __fixture__ > type parameter/dispatcher 1`] = `
                   "end": {
                     "line": 1,
                     "character": 9
+                  }
+                },
+                "contributor": "binder"
+              }
+            ]
+          },
+          "": {
+            "definition": [
+              {
+                "uri": "file:///test.mcdoc",
+                "range": {
+                  "start": 58,
+                  "end": 58
+                },
+                "posRange": {
+                  "start": {
+                    "line": 2,
+                    "character": 0
+                  },
+                  "end": {
+                    "line": 2,
+                    "character": 0
+                  }
+                },
+                "fullRange": {
+                  "start": 58,
+                  "end": 58
+                },
+                "fullPosRange": {
+                  "start": {
+                    "line": 2,
+                    "character": 0
+                  },
+                  "end": {
+                    "line": 2,
+                    "character": 0
                   }
                 },
                 "contributor": "binder"
@@ -274,6 +318,14 @@ exports[`mcdoc __fixture__ > type parameter/dispatcher 1`] = `
                       "type": {
                         "kind": "reference",
                         "path": "::test::T"
+                      }
+                    },
+                    {
+                      "kind": "pair",
+                      "key": "",
+                      "type": {
+                        "kind": "reference",
+                        "path": "::test::"
                       }
                     }
                   ]
@@ -540,6 +592,56 @@ exports[`mcdoc __fixture__ > type parameter/dispatcher 1`] = `
                             "start": 48,
                             "end": 56
                           }
+                        },
+                        {
+                          "type": "mcdoc:struct/field/pair",
+                          "children": [
+                            {
+                              "type": "mcdoc:identifier",
+                              "range": {
+                                "start": 58,
+                                "end": 58
+                              },
+                              "value": "",
+                              "symbol": {
+                                "category": "mcdoc",
+                                "path": [
+                                  "::test::<anonymous 0>",
+                                  ""
+                                ]
+                              }
+                            },
+                            {
+                              "type": "mcdoc:type/reference",
+                              "children": [
+                                {
+                                  "type": "mcdoc:path",
+                                  "children": [
+                                    {
+                                      "type": "mcdoc:identifier",
+                                      "range": {
+                                        "start": 58,
+                                        "end": 58
+                                      },
+                                      "value": ""
+                                    }
+                                  ],
+                                  "range": {
+                                    "start": 58,
+                                    "end": 58
+                                  }
+                                }
+                              ],
+                              "range": {
+                                "start": 58,
+                                "end": 58
+                              }
+                            }
+                          ],
+                          "range": {
+                            "start": 58,
+                            "end": 58
+                          }
                         }
                       ],
                       "range": {
@@ -771,8 +873,42 @@ exports[`mcdoc __fixture__ > type parameter/dispatcher 1`] = `
         }
       ],
       "locals": {},
-      "parserErrors": [],
-      "binderErrors": []
+      "parserErrors": [
+        {
+          "range": {
+            "start": 58,
+            "end": 58
+          },
+          "message": "Expected an identifier",
+          "severity": 3
+        },
+        {
+          "range": {
+            "start": 58,
+            "end": 58
+          },
+          "message": "Expected “:” but got “}”",
+          "severity": 3
+        },
+        {
+          "range": {
+            "start": 58,
+            "end": 58
+          },
+          "message": "Expected an identifier",
+          "severity": 3
+        }
+      ],
+      "binderErrors": [
+        {
+          "range": {
+            "start": 58,
+            "end": 58
+          },
+          "message": "Identifier “” does not exist in module “::test”",
+          "severity": 2
+        }
+      ]
     }
   }
 }

--- a/packages/mcdoc/test/__fixture__/type_parameter/number_range.spec.ts.snapshot
+++ b/packages/mcdoc/test/__fixture__/type_parameter/number_range.spec.ts.snapshot
@@ -25,7 +25,7 @@ exports[`mcdoc __fixture__ > type parameter/number range 1`] = `
           }
         ],
         "data": {
-          "nextAnonymousIndex": 1
+          "nextAnonymousIndex": 0
         }
       },
       "::test::InclusiveRange": {
@@ -44,33 +44,7 @@ exports[`mcdoc __fixture__ > type parameter/number range 1`] = `
                   "item": {
                     "kind": "reference",
                     "path": "::test::T"
-                  },
-                  "lengthRange": {
-                    "kind": 0,
-                    "min": 2,
-                    "max": 2
                   }
-                },
-                {
-                  "kind": "struct",
-                  "fields": [
-                    {
-                      "kind": "pair",
-                      "key": "min_inclusive",
-                      "type": {
-                        "kind": "reference",
-                        "path": "::test::T"
-                      }
-                    },
-                    {
-                      "kind": "pair",
-                      "key": "max_inclusive",
-                      "type": {
-                        "kind": "reference",
-                        "path": "::test::T"
-                      }
-                    }
-                  ]
                 }
               ]
             },
@@ -101,7 +75,7 @@ exports[`mcdoc __fixture__ > type parameter/number range 1`] = `
             },
             "fullRange": {
               "start": 0,
-              "end": 101
+              "end": 37
             },
             "fullPosRange": {
               "start": {
@@ -109,219 +83,8 @@ exports[`mcdoc __fixture__ > type parameter/number range 1`] = `
                 "character": 0
               },
               "end": {
-                "line": 9,
-                "character": 0
-              }
-            },
-            "contributor": "binder"
-          }
-        ],
-        "reference": [
-          {
-            "uri": "file:///test.mcdoc",
-            "range": {
-              "start": 120,
-              "end": 134
-            },
-            "posRange": {
-              "start": {
-                "line": 9,
-                "character": 19
-              },
-              "end": {
-                "line": 9,
-                "character": 33
-              }
-            },
-            "fullRange": {
-              "start": 120,
-              "end": 134
-            },
-            "fullPosRange": {
-              "start": {
-                "line": 9,
-                "character": 19
-              },
-              "end": {
-                "line": 9,
-                "character": 33
-              }
-            },
-            "contributor": "binder",
-            "skipRenaming": false
-          }
-        ]
-      },
-      "::test::<anonymous 0>": {
-        "data": {
-          "typeDef": {
-            "kind": "struct",
-            "fields": [
-              {
-                "kind": "pair",
-                "key": "min_inclusive",
-                "type": {
-                  "kind": "reference",
-                  "path": "::test::T"
-                }
-              },
-              {
-                "kind": "pair",
-                "key": "max_inclusive",
-                "type": {
-                  "kind": "reference",
-                  "path": "::test::T"
-                }
-              }
-            ]
-          }
-        },
-        "subcategory": "struct",
-        "definition": [
-          {
-            "uri": "file:///test.mcdoc",
-            "range": {
-              "start": 44,
-              "end": 50
-            },
-            "posRange": {
-              "start": {
-                "line": 3,
-                "character": 1
-              },
-              "end": {
-                "line": 3,
-                "character": 7
-              }
-            },
-            "contributor": "binder"
-          }
-        ],
-        "members": {
-          "min_inclusive": {
-            "definition": [
-              {
-                "uri": "file:///test.mcdoc",
-                "range": {
-                  "start": 55,
-                  "end": 68
-                },
-                "posRange": {
-                  "start": {
-                    "line": 4,
-                    "character": 2
-                  },
-                  "end": {
-                    "line": 4,
-                    "character": 15
-                  }
-                },
-                "fullRange": {
-                  "start": 55,
-                  "end": 71
-                },
-                "fullPosRange": {
-                  "start": {
-                    "line": 4,
-                    "character": 2
-                  },
-                  "end": {
-                    "line": 4,
-                    "character": 18
-                  }
-                },
-                "contributor": "binder"
-              }
-            ]
-          },
-          "max_inclusive": {
-            "definition": [
-              {
-                "uri": "file:///test.mcdoc",
-                "range": {
-                  "start": 75,
-                  "end": 88
-                },
-                "posRange": {
-                  "start": {
-                    "line": 5,
-                    "character": 2
-                  },
-                  "end": {
-                    "line": 5,
-                    "character": 15
-                  }
-                },
-                "fullRange": {
-                  "start": 75,
-                  "end": 91
-                },
-                "fullPosRange": {
-                  "start": {
-                    "line": 5,
-                    "character": 2
-                  },
-                  "end": {
-                    "line": 5,
-                    "character": 18
-                  }
-                },
-                "contributor": "binder"
-              }
-            ]
-          }
-        }
-      },
-      "::test::VarietyType": {
-        "data": {
-          "typeDef": {
-            "kind": "concrete",
-            "child": {
-              "kind": "reference",
-              "path": "::test::InclusiveRange"
-            },
-            "typeArgs": [
-              {
-                "kind": "int",
-                "valueRange": {
-                  "kind": 0,
-                  "min": 1,
-                  "max": 64
-                }
-              }
-            ]
-          }
-        },
-        "subcategory": "type_alias",
-        "definition": [
-          {
-            "uri": "file:///test.mcdoc",
-            "range": {
-              "start": 106,
-              "end": 117
-            },
-            "posRange": {
-              "start": {
-                "line": 9,
+                "line": 2,
                 "character": 5
-              },
-              "end": {
-                "line": 9,
-                "character": 16
-              }
-            },
-            "fullRange": {
-              "start": 101,
-              "end": 147
-            },
-            "fullPosRange": {
-              "start": {
-                "line": 9,
-                "character": 0
-              },
-              "end": {
-                "line": 9,
-                "character": 46
               }
             },
             "contributor": "binder"
@@ -468,185 +231,23 @@ exports[`mcdoc __fixture__ > type parameter/number range 1`] = `
                             "start": 34,
                             "end": 35
                           }
-                        },
-                        {
-                          "type": "mcdoc:int_range",
-                          "children": [
-                            {
-                              "type": "integer",
-                              "range": {
-                                "start": 39,
-                                "end": 40
-                              },
-                              "value": 2
-                            }
-                          ],
-                          "range": {
-                            "start": 39,
-                            "end": 40
-                          }
                         }
                       ],
                       "range": {
                         "start": 33,
-                        "end": 41
-                      }
-                    },
-                    {
-                      "type": "mcdoc:struct",
-                      "children": [
-                        {
-                          "type": "mcdoc:literal",
-                          "range": {
-                            "start": 44,
-                            "end": 50
-                          },
-                          "value": "struct",
-                          "colorTokenType": "keyword",
-                          "symbol": {
-                            "category": "mcdoc",
-                            "path": [
-                              "::test::<anonymous 0>"
-                            ]
-                          }
-                        },
-                        {
-                          "type": "mcdoc:struct/block",
-                          "children": [
-                            {
-                              "type": "mcdoc:struct/field/pair",
-                              "children": [
-                                {
-                                  "type": "mcdoc:identifier",
-                                  "range": {
-                                    "start": 55,
-                                    "end": 68
-                                  },
-                                  "value": "min_inclusive",
-                                  "symbol": {
-                                    "category": "mcdoc",
-                                    "path": [
-                                      "::test::<anonymous 0>",
-                                      "min_inclusive"
-                                    ]
-                                  }
-                                },
-                                {
-                                  "type": "mcdoc:type/reference",
-                                  "children": [
-                                    {
-                                      "type": "mcdoc:path",
-                                      "children": [
-                                        {
-                                          "type": "mcdoc:identifier",
-                                          "range": {
-                                            "start": 70,
-                                            "end": 71
-                                          },
-                                          "value": "T",
-                                          "symbol": {
-                                            "category": "mcdoc",
-                                            "path": [
-                                              "::test::T"
-                                            ]
-                                          }
-                                        }
-                                      ],
-                                      "range": {
-                                        "start": 70,
-                                        "end": 71
-                                      }
-                                    }
-                                  ],
-                                  "range": {
-                                    "start": 70,
-                                    "end": 71
-                                  }
-                                }
-                              ],
-                              "range": {
-                                "start": 55,
-                                "end": 71
-                              }
-                            },
-                            {
-                              "type": "mcdoc:struct/field/pair",
-                              "children": [
-                                {
-                                  "type": "mcdoc:identifier",
-                                  "range": {
-                                    "start": 75,
-                                    "end": 88
-                                  },
-                                  "value": "max_inclusive",
-                                  "symbol": {
-                                    "category": "mcdoc",
-                                    "path": [
-                                      "::test::<anonymous 0>",
-                                      "max_inclusive"
-                                    ]
-                                  }
-                                },
-                                {
-                                  "type": "mcdoc:type/reference",
-                                  "children": [
-                                    {
-                                      "type": "mcdoc:path",
-                                      "children": [
-                                        {
-                                          "type": "mcdoc:identifier",
-                                          "range": {
-                                            "start": 90,
-                                            "end": 91
-                                          },
-                                          "value": "T",
-                                          "symbol": {
-                                            "category": "mcdoc",
-                                            "path": [
-                                              "::test::T"
-                                            ]
-                                          }
-                                        }
-                                      ],
-                                      "range": {
-                                        "start": 90,
-                                        "end": 91
-                                      }
-                                    }
-                                  ],
-                                  "range": {
-                                    "start": 90,
-                                    "end": 91
-                                  }
-                                }
-                              ],
-                              "range": {
-                                "start": 75,
-                                "end": 91
-                              }
-                            }
-                          ],
-                          "range": {
-                            "start": 51,
-                            "end": 96
-                          }
-                        }
-                      ],
-                      "range": {
-                        "start": 44,
-                        "end": 96
+                        "end": 37
                       }
                     }
                   ],
                   "range": {
                     "start": 25,
-                    "end": 101
+                    "end": 37
                   }
                 }
               ],
               "range": {
                 "start": 0,
-                "end": 101
+                "end": 37
               },
               "locals": {
                 "mcdoc": {
@@ -757,211 +358,45 @@ exports[`mcdoc __fixture__ > type parameter/number range 1`] = `
                         },
                         "contributor": "binder",
                         "skipRenaming": false
-                      },
-                      {
-                        "uri": "file:///test.mcdoc",
-                        "range": {
-                          "start": 70,
-                          "end": 71
-                        },
-                        "posRange": {
-                          "start": {
-                            "line": 4,
-                            "character": 17
-                          },
-                          "end": {
-                            "line": 4,
-                            "character": 18
-                          }
-                        },
-                        "fullRange": {
-                          "start": 70,
-                          "end": 71
-                        },
-                        "fullPosRange": {
-                          "start": {
-                            "line": 4,
-                            "character": 17
-                          },
-                          "end": {
-                            "line": 4,
-                            "character": 18
-                          }
-                        },
-                        "contributor": "binder",
-                        "skipRenaming": false
-                      },
-                      {
-                        "uri": "file:///test.mcdoc",
-                        "range": {
-                          "start": 90,
-                          "end": 91
-                        },
-                        "posRange": {
-                          "start": {
-                            "line": 5,
-                            "character": 17
-                          },
-                          "end": {
-                            "line": 5,
-                            "character": 18
-                          }
-                        },
-                        "fullRange": {
-                          "start": 90,
-                          "end": 91
-                        },
-                        "fullPosRange": {
-                          "start": {
-                            "line": 5,
-                            "character": 17
-                          },
-                          "end": {
-                            "line": 5,
-                            "character": 18
-                          }
-                        },
-                        "contributor": "binder",
-                        "skipRenaming": false
                       }
                     ]
                   }
                 }
-              }
-            },
-            {
-              "type": "mcdoc:type_alias",
-              "children": [
-                {
-                  "type": "mcdoc:literal",
-                  "range": {
-                    "start": 101,
-                    "end": 105
-                  },
-                  "value": "type",
-                  "colorTokenType": "keyword"
-                },
-                {
-                  "type": "mcdoc:identifier",
-                  "range": {
-                    "start": 106,
-                    "end": 117
-                  },
-                  "value": "VarietyType",
-                  "symbol": {
-                    "category": "mcdoc",
-                    "path": [
-                      "::test::VarietyType"
-                    ]
-                  }
-                },
-                {
-                  "type": "mcdoc:type/reference",
-                  "children": [
-                    {
-                      "type": "mcdoc:path",
-                      "children": [
-                        {
-                          "type": "mcdoc:identifier",
-                          "range": {
-                            "start": 120,
-                            "end": 134
-                          },
-                          "value": "InclusiveRange",
-                          "symbol": {
-                            "category": "mcdoc",
-                            "path": [
-                              "::test::InclusiveRange"
-                            ]
-                          }
-                        }
-                      ],
-                      "range": {
-                        "start": 120,
-                        "end": 134
-                      }
-                    },
-                    {
-                      "type": "mcdoc:type_arg_block",
-                      "children": [
-                        {
-                          "type": "mcdoc:type/numeric_type",
-                          "children": [
-                            {
-                              "type": "mcdoc:literal",
-                              "range": {
-                                "start": 135,
-                                "end": 138
-                              },
-                              "value": "int",
-                              "colorTokenType": "type"
-                            },
-                            {
-                              "type": "mcdoc:int_range",
-                              "children": [
-                                {
-                                  "type": "integer",
-                                  "range": {
-                                    "start": 141,
-                                    "end": 142
-                                  },
-                                  "value": 1
-                                },
-                                {
-                                  "type": "mcdoc:literal",
-                                  "range": {
-                                    "start": 142,
-                                    "end": 144
-                                  },
-                                  "value": ".."
-                                },
-                                {
-                                  "type": "integer",
-                                  "range": {
-                                    "start": 144,
-                                    "end": 146
-                                  },
-                                  "value": 64
-                                }
-                              ],
-                              "range": {
-                                "start": 141,
-                                "end": 146
-                              }
-                            }
-                          ],
-                          "range": {
-                            "start": 135,
-                            "end": 146
-                          }
-                        }
-                      ],
-                      "range": {
-                        "start": 134,
-                        "end": 147
-                      }
-                    }
-                  ],
-                  "range": {
-                    "start": 120,
-                    "end": 147
-                  }
-                }
-              ],
-              "range": {
-                "start": 101,
-                "end": 147
               }
             }
           ],
           "range": {
             "start": 0,
+            "end": 37
+          }
+        },
+        {
+          "type": "error",
+          "range": {
+            "start": 37,
             "end": 147
           }
         }
       ],
       "locals": {},
-      "parserErrors": [],
+      "parserErrors": [
+        {
+          "range": {
+            "start": 37,
+            "end": 37
+          },
+          "message": "Expected “)” but got “@”",
+          "severity": 3
+        },
+        {
+          "range": {
+            "start": 37,
+            "end": 147
+          },
+          "message": "Encountered unparseable content",
+          "severity": 3
+        }
+      ],
       "binderErrors": []
     }
   }

--- a/packages/mcdoc/test/__fixture__/union/nested.spec.ts.snapshot
+++ b/packages/mcdoc/test/__fixture__/union/nested.spec.ts.snapshot
@@ -62,6 +62,10 @@ exports[`mcdoc __fixture__ > union/nested 1`] = `
                     ]
                   }
                 ]
+              },
+              {
+                "kind": "reference",
+                "path": "::test::"
               }
             ]
           }
@@ -260,6 +264,32 @@ exports[`mcdoc __fixture__ > union/nested 1`] = `
                         "start": 26,
                         "end": 61
                       }
+                    },
+                    {
+                      "type": "mcdoc:type/reference",
+                      "children": [
+                        {
+                          "type": "mcdoc:path",
+                          "children": [
+                            {
+                              "type": "mcdoc:identifier",
+                              "range": {
+                                "start": 63,
+                                "end": 63
+                              },
+                              "value": ""
+                            }
+                          ],
+                          "range": {
+                            "start": 63,
+                            "end": 63
+                          }
+                        }
+                      ],
+                      "range": {
+                        "start": 63,
+                        "end": 63
+                      }
                     }
                   ],
                   "range": {
@@ -281,8 +311,26 @@ exports[`mcdoc __fixture__ > union/nested 1`] = `
         }
       ],
       "locals": {},
-      "parserErrors": [],
-      "binderErrors": []
+      "parserErrors": [
+        {
+          "range": {
+            "start": 63,
+            "end": 63
+          },
+          "message": "Expected an identifier",
+          "severity": 3
+        }
+      ],
+      "binderErrors": [
+        {
+          "range": {
+            "start": 63,
+            "end": 63
+          },
+          "message": "Identifier “” does not exist in module “::test”",
+          "severity": 2
+        }
+      ]
     }
   }
 }

--- a/packages/mcdoc/test/__fixture__/union/number_range.spec.ts.snapshot
+++ b/packages/mcdoc/test/__fixture__/union/number_range.spec.ts.snapshot
@@ -63,8 +63,20 @@ exports[`mcdoc __fixture__ > union/number range 1`] = `
                     "type": {
                       "kind": "int"
                     }
+                  },
+                  {
+                    "kind": "pair",
+                    "key": "",
+                    "type": {
+                      "kind": "reference",
+                      "path": "::test::"
+                    }
                   }
                 ]
+              },
+              {
+                "kind": "reference",
+                "path": "::test::"
               }
             ]
           }
@@ -122,6 +134,14 @@ exports[`mcdoc __fixture__ > union/number range 1`] = `
                 "key": "max_inclusive",
                 "type": {
                   "kind": "int"
+                }
+              },
+              {
+                "kind": "pair",
+                "key": "",
+                "type": {
+                  "kind": "reference",
+                  "path": "::test::"
                 }
               }
             ]
@@ -215,6 +235,42 @@ exports[`mcdoc __fixture__ > union/number range 1`] = `
                   "end": {
                     "line": 5,
                     "character": 20
+                  }
+                },
+                "contributor": "binder"
+              }
+            ]
+          },
+          "": {
+            "definition": [
+              {
+                "uri": "file:///test.mcdoc",
+                "range": {
+                  "start": 91,
+                  "end": 91
+                },
+                "posRange": {
+                  "start": {
+                    "line": 6,
+                    "character": 1
+                  },
+                  "end": {
+                    "line": 6,
+                    "character": 1
+                  }
+                },
+                "fullRange": {
+                  "start": 91,
+                  "end": 91
+                },
+                "fullPosRange": {
+                  "start": {
+                    "line": 6,
+                    "character": 1
+                  },
+                  "end": {
+                    "line": 6,
+                    "character": 1
                   }
                 },
                 "contributor": "binder"
@@ -432,6 +488,56 @@ exports[`mcdoc __fixture__ > union/number range 1`] = `
                                 "start": 70,
                                 "end": 88
                               }
+                            },
+                            {
+                              "type": "mcdoc:struct/field/pair",
+                              "children": [
+                                {
+                                  "type": "mcdoc:identifier",
+                                  "range": {
+                                    "start": 91,
+                                    "end": 91
+                                  },
+                                  "value": "",
+                                  "symbol": {
+                                    "category": "mcdoc",
+                                    "path": [
+                                      "::test::<anonymous 0>",
+                                      ""
+                                    ]
+                                  }
+                                },
+                                {
+                                  "type": "mcdoc:type/reference",
+                                  "children": [
+                                    {
+                                      "type": "mcdoc:path",
+                                      "children": [
+                                        {
+                                          "type": "mcdoc:identifier",
+                                          "range": {
+                                            "start": 91,
+                                            "end": 91
+                                          },
+                                          "value": ""
+                                        }
+                                      ],
+                                      "range": {
+                                        "start": 91,
+                                        "end": 91
+                                      }
+                                    }
+                                  ],
+                                  "range": {
+                                    "start": 91,
+                                    "end": 91
+                                  }
+                                }
+                              ],
+                              "range": {
+                                "start": 91,
+                                "end": 91
+                              }
                             }
                           ],
                           "range": {
@@ -443,6 +549,32 @@ exports[`mcdoc __fixture__ > union/number range 1`] = `
                       "range": {
                         "start": 37,
                         "end": 93
+                      }
+                    },
+                    {
+                      "type": "mcdoc:type/reference",
+                      "children": [
+                        {
+                          "type": "mcdoc:path",
+                          "children": [
+                            {
+                              "type": "mcdoc:identifier",
+                              "range": {
+                                "start": 95,
+                                "end": 95
+                              },
+                              "value": ""
+                            }
+                          ],
+                          "range": {
+                            "start": 95,
+                            "end": 95
+                          }
+                        }
+                      ],
+                      "range": {
+                        "start": 95,
+                        "end": 95
                       }
                     }
                   ],
@@ -465,8 +597,58 @@ exports[`mcdoc __fixture__ > union/number range 1`] = `
         }
       ],
       "locals": {},
-      "parserErrors": [],
-      "binderErrors": []
+      "parserErrors": [
+        {
+          "range": {
+            "start": 91,
+            "end": 91
+          },
+          "message": "Expected an identifier",
+          "severity": 3
+        },
+        {
+          "range": {
+            "start": 91,
+            "end": 91
+          },
+          "message": "Expected “:” but got “}”",
+          "severity": 3
+        },
+        {
+          "range": {
+            "start": 91,
+            "end": 91
+          },
+          "message": "Expected an identifier",
+          "severity": 3
+        },
+        {
+          "range": {
+            "start": 95,
+            "end": 95
+          },
+          "message": "Expected an identifier",
+          "severity": 3
+        }
+      ],
+      "binderErrors": [
+        {
+          "range": {
+            "start": 91,
+            "end": 91
+          },
+          "message": "Identifier “” does not exist in module “::test”",
+          "severity": 2
+        },
+        {
+          "range": {
+            "start": 95,
+            "end": 95
+          },
+          "message": "Identifier “” does not exist in module “::test”",
+          "severity": 2
+        }
+      ]
     }
   }
 }

--- a/packages/mcdoc/test/parser/syntax/attribute.spec.ts.snapshot
+++ b/packages/mcdoc/test/parser/syntax/attribute.spec.ts.snapshot
@@ -309,112 +309,69 @@ exports[`mcdoc parser > attribute > Parse '#[bitfield=enum (int) {↓⮀⮀⮀�
                     "type": "mcdoc:typed_number",
                     "children": [
                       {
-                        "type": "integer",
+                        "type": "float",
                         "range": {
-                          "start": 35,
-                          "end": 36
+                          "start": 34,
+                          "end": 34
                         },
-                        "value": 1
+                        "value": 0
                       }
                     ],
                     "range": {
-                      "start": 35,
-                      "end": 36
+                      "start": 34,
+                      "end": 34
                     }
                   }
                 ],
                 "range": {
                   "start": 29,
-                  "end": 36
-                }
-              },
-              {
-                "type": "mcdoc:enum/field",
-                "children": [
-                  {
-                    "type": "mcdoc:identifier",
-                    "range": {
-                      "start": 43,
-                      "end": 46
-                    },
-                    "value": "Bar"
-                  },
-                  {
-                    "type": "mcdoc:typed_number",
-                    "children": [
-                      {
-                        "type": "integer",
-                        "range": {
-                          "start": 49,
-                          "end": 50
-                        },
-                        "value": 2
-                      }
-                    ],
-                    "range": {
-                      "start": 49,
-                      "end": 50
-                    }
-                  }
-                ],
-                "range": {
-                  "start": 43,
-                  "end": 50
-                }
-              },
-              {
-                "type": "mcdoc:enum/field",
-                "children": [
-                  {
-                    "type": "mcdoc:identifier",
-                    "range": {
-                      "start": 57,
-                      "end": 60
-                    },
-                    "value": "Qux"
-                  },
-                  {
-                    "type": "mcdoc:typed_number",
-                    "children": [
-                      {
-                        "type": "integer",
-                        "range": {
-                          "start": 63,
-                          "end": 64
-                        },
-                        "value": 3
-                      }
-                    ],
-                    "range": {
-                      "start": 63,
-                      "end": 64
-                    }
-                  }
-                ],
-                "range": {
-                  "start": 57,
-                  "end": 64
+                  "end": 34
                 }
               }
             ],
             "range": {
               "start": 22,
-              "end": 71
+              "end": 35
             }
           }
         ],
         "range": {
           "start": 11,
-          "end": 71
+          "end": 35
         }
       }
     ],
     "range": {
       "start": 0,
-      "end": 72
+      "end": 35
     }
   },
-  "errors": []
+  "errors": [
+    {
+      "range": {
+        "start": 34,
+        "end": 34
+      },
+      "message": "Expected a float",
+      "severity": 3
+    },
+    {
+      "range": {
+        "start": 35,
+        "end": 35
+      },
+      "message": "Expected “}” but got “1”",
+      "severity": 3
+    },
+    {
+      "range": {
+        "start": 35,
+        "end": 35
+      },
+      "message": "Expected “]” but got “1”",
+      "severity": 3
+    }
+  ]
 }
 `;
 

--- a/packages/mcdoc/test/parser/syntax/dispatchStatement.spec.ts.snapshot
+++ b/packages/mcdoc/test/parser/syntax/dispatchStatement.spec.ts.snapshot
@@ -72,58 +72,91 @@ exports[`mcdoc parser > dispatchStatement > Parse '#[since=1.17]↓⮀⮀⮀⮀d
           {
             "type": "mcdoc:identifier",
             "range": {
-              "start": 50,
-              "end": 53
+              "start": 44,
+              "end": 44
             },
-            "value": "cow"
-          },
-          {
-            "type": "mcdoc:identifier",
-            "range": {
-              "start": 60,
-              "end": 65
-            },
-            "value": "sheep"
+            "value": ""
           }
         ],
         "range": {
           "start": 43,
-          "end": 72
+          "end": 50
         }
       },
       {
         "type": "mcdoc:literal",
         "range": {
-          "start": 73,
-          "end": 75
+          "start": 50,
+          "end": 53
         },
-        "value": "to"
+        "value": "cow"
       },
       {
-        "type": "mcdoc:type/boolean",
+        "type": "mcdoc:type/reference",
         "children": [
           {
-            "type": "mcdoc:literal",
+            "type": "mcdoc:path",
+            "children": [
+              {
+                "type": "mcdoc:identifier",
+                "range": {
+                  "start": 53,
+                  "end": 53
+                },
+                "value": ""
+              }
+            ],
             "range": {
-              "start": 76,
-              "end": 83
-            },
-            "value": "boolean",
-            "colorTokenType": "type"
+              "start": 53,
+              "end": 53
+            }
           }
         ],
         "range": {
-          "start": 76,
-          "end": 83
+          "start": 53,
+          "end": 53
         }
       }
     ],
     "range": {
       "start": 0,
-      "end": 83
+      "end": 53
     }
   },
-  "errors": []
+  "errors": [
+    {
+      "range": {
+        "start": 44,
+        "end": 44
+      },
+      "message": "Expected an identifier",
+      "severity": 3
+    },
+    {
+      "range": {
+        "start": 50,
+        "end": 50
+      },
+      "message": "Expected “]” but got “c”",
+      "severity": 3
+    },
+    {
+      "range": {
+        "start": 50,
+        "end": 53
+      },
+      "message": "Expected “to” but got “cow”",
+      "severity": 3
+    },
+    {
+      "range": {
+        "start": 53,
+        "end": 53
+      },
+      "message": "Expected an identifier",
+      "severity": 3
+    }
+  ]
 }
 `;
 

--- a/packages/mcdoc/test/parser/syntax/type/enum_.spec.ts.snapshot
+++ b/packages/mcdoc/test/parser/syntax/type/enum_.spec.ts.snapshot
@@ -38,14 +38,6 @@ exports[`mcdoc parser > enum_ > Parse 'enum () Foo' 1`] = `
         "colorTokenType": "type"
       },
       {
-        "type": "mcdoc:identifier",
-        "range": {
-          "start": 8,
-          "end": 11
-        },
-        "value": "Foo"
-      },
-      {
         "type": "mcdoc:enum/block",
         "children": [
           {
@@ -54,10 +46,10 @@ exports[`mcdoc parser > enum_ > Parse 'enum () Foo' 1`] = `
               {
                 "type": "mcdoc:identifier",
                 "range": {
-                  "start": 11,
+                  "start": 8,
                   "end": 11
                 },
-                "value": ""
+                "value": "Foo"
               },
               {
                 "type": "mcdoc:typed_number",
@@ -78,13 +70,13 @@ exports[`mcdoc parser > enum_ > Parse 'enum () Foo' 1`] = `
               }
             ],
             "range": {
-              "start": 11,
+              "start": 8,
               "end": 11
             }
           }
         ],
         "range": {
-          "start": 11,
+          "start": 8,
           "end": 11
         }
       }
@@ -105,18 +97,10 @@ exports[`mcdoc parser > enum_ > Parse 'enum () Foo' 1`] = `
     },
     {
       "range": {
-        "start": 11,
-        "end": 11
+        "start": 8,
+        "end": 8
       },
-      "message": "Expected “{” but got “”",
-      "severity": 3
-    },
-    {
-      "range": {
-        "start": 11,
-        "end": 11
-      },
-      "message": "Expected an identifier",
+      "message": "Expected “{” but got “F”",
       "severity": 3
     },
     {
@@ -171,44 +155,18 @@ exports[`mcdoc parser > enum_ > Parse 'enum (double) Foo {↓⮀⮀⮀⮀⮀/// 
         "colorTokenType": "type"
       },
       {
-        "type": "mcdoc:identifier",
-        "range": {
-          "start": 14,
-          "end": 17
-        },
-        "value": "Foo"
-      },
-      {
         "type": "mcdoc:enum/block",
         "children": [
           {
             "type": "mcdoc:enum/field",
             "children": [
               {
-                "type": "mcdoc:doc_comments",
-                "children": [
-                  {
-                    "type": "comment",
-                    "range": {
-                      "start": 25,
-                      "end": 37
-                    },
-                    "comment": " Bar doc\\n",
-                    "prefix": "///"
-                  }
-                ],
-                "range": {
-                  "start": 25,
-                  "end": 42
-                }
-              },
-              {
                 "type": "mcdoc:identifier",
                 "range": {
-                  "start": 42,
-                  "end": 45
+                  "start": 14,
+                  "end": 17
                 },
-                "value": "Bar"
+                "value": "Foo"
               },
               {
                 "type": "mcdoc:typed_number",
@@ -216,158 +174,69 @@ exports[`mcdoc parser > enum_ > Parse 'enum (double) Foo {↓⮀⮀⮀⮀⮀/// 
                   {
                     "type": "float",
                     "range": {
-                      "start": 48,
-                      "end": 51
+                      "start": 18,
+                      "end": 18
                     },
-                    "value": 1.2
+                    "value": 0
                   }
                 ],
                 "range": {
-                  "start": 48,
-                  "end": 51
+                  "start": 18,
+                  "end": 18
                 }
               }
             ],
             "range": {
-              "start": 25,
-              "end": 51
-            }
-          },
-          {
-            "type": "mcdoc:enum/field",
-            "children": [
-              {
-                "type": "mcdoc:doc_comments",
-                "children": [
-                  {
-                    "type": "comment",
-                    "range": {
-                      "start": 58,
-                      "end": 70
-                    },
-                    "comment": " Boo doc\\n",
-                    "prefix": "///"
-                  },
-                  {
-                    "type": "comment",
-                    "range": {
-                      "start": 75,
-                      "end": 92
-                    },
-                    "comment": " Another line\\n",
-                    "prefix": "///"
-                  }
-                ],
-                "range": {
-                  "start": 58,
-                  "end": 97
-                }
-              },
-              {
-                "type": "mcdoc:identifier",
-                "range": {
-                  "start": 97,
-                  "end": 100
-                },
-                "value": "Boo"
-              },
-              {
-                "type": "mcdoc:typed_number",
-                "children": [
-                  {
-                    "type": "float",
-                    "range": {
-                      "start": 103,
-                      "end": 106
-                    },
-                    "value": 4.2
-                  },
-                  {
-                    "type": "mcdoc:literal",
-                    "range": {
-                      "start": 106,
-                      "end": 107
-                    },
-                    "value": "d",
-                    "colorTokenType": "keyword"
-                  }
-                ],
-                "range": {
-                  "start": 103,
-                  "end": 107
-                }
-              }
-            ],
-            "range": {
-              "start": 58,
-              "end": 107
-            }
-          },
-          {
-            "type": "mcdoc:enum/field",
-            "children": [
-              {
-                "type": "mcdoc:doc_comments",
-                "children": [
-                  {
-                    "type": "comment",
-                    "range": {
-                      "start": 114,
-                      "end": 126
-                    },
-                    "comment": " Qux doc\\n",
-                    "prefix": "///"
-                  }
-                ],
-                "range": {
-                  "start": 114,
-                  "end": 131
-                }
-              },
-              {
-                "type": "mcdoc:identifier",
-                "range": {
-                  "start": 131,
-                  "end": 134
-                },
-                "value": "Qux"
-              },
-              {
-                "type": "mcdoc:typed_number",
-                "children": [
-                  {
-                    "type": "float",
-                    "range": {
-                      "start": 137,
-                      "end": 141
-                    },
-                    "value": 12000
-                  }
-                ],
-                "range": {
-                  "start": 137,
-                  "end": 141
-                }
-              }
-            ],
-            "range": {
-              "start": 114,
-              "end": 141
+              "start": 14,
+              "end": 18
             }
           }
         ],
         "range": {
-          "start": 18,
-          "end": 148
+          "start": 14,
+          "end": 18
         }
       }
     ],
     "range": {
       "start": 0,
-      "end": 148
+      "end": 18
     }
   },
-  "errors": []
+  "errors": [
+    {
+      "range": {
+        "start": 14,
+        "end": 14
+      },
+      "message": "Expected “{” but got “F”",
+      "severity": 3
+    },
+    {
+      "range": {
+        "start": 18,
+        "end": 18
+      },
+      "message": "Expected “=” but got “{”",
+      "severity": 3
+    },
+    {
+      "range": {
+        "start": 18,
+        "end": 18
+      },
+      "message": "Expected a float",
+      "severity": 3
+    },
+    {
+      "range": {
+        "start": 18,
+        "end": 18
+      },
+      "message": "Expected “}” but got “{”",
+      "severity": 3
+    }
+  ]
 }
 `;
 
@@ -395,28 +264,88 @@ exports[`mcdoc parser > enum_ > Parse 'enum (int) Foo {}' 1`] = `
         "colorTokenType": "type"
       },
       {
-        "type": "mcdoc:identifier",
+        "type": "mcdoc:enum/block",
+        "children": [
+          {
+            "type": "mcdoc:enum/field",
+            "children": [
+              {
+                "type": "mcdoc:identifier",
+                "range": {
+                  "start": 11,
+                  "end": 14
+                },
+                "value": "Foo"
+              },
+              {
+                "type": "mcdoc:typed_number",
+                "children": [
+                  {
+                    "type": "float",
+                    "range": {
+                      "start": 15,
+                      "end": 15
+                    },
+                    "value": 0
+                  }
+                ],
+                "range": {
+                  "start": 15,
+                  "end": 15
+                }
+              }
+            ],
+            "range": {
+              "start": 11,
+              "end": 15
+            }
+          }
+        ],
         "range": {
           "start": 11,
-          "end": 14
-        },
-        "value": "Foo"
-      },
-      {
-        "type": "mcdoc:enum/block",
-        "children": [],
-        "range": {
-          "start": 15,
-          "end": 17
+          "end": 15
         }
       }
     ],
     "range": {
       "start": 0,
-      "end": 17
+      "end": 15
     }
   },
-  "errors": []
+  "errors": [
+    {
+      "range": {
+        "start": 11,
+        "end": 11
+      },
+      "message": "Expected “{” but got “F”",
+      "severity": 3
+    },
+    {
+      "range": {
+        "start": 15,
+        "end": 15
+      },
+      "message": "Expected “=” but got “{”",
+      "severity": 3
+    },
+    {
+      "range": {
+        "start": 15,
+        "end": 15
+      },
+      "message": "Expected a float",
+      "severity": 3
+    },
+    {
+      "range": {
+        "start": 15,
+        "end": 15
+      },
+      "message": "Expected “}” but got “{”",
+      "severity": 3
+    }
+  ]
 }
 `;
 
@@ -444,14 +373,6 @@ exports[`mcdoc parser > enum_ > Parse 'enum (int) Foo' 1`] = `
         "colorTokenType": "type"
       },
       {
-        "type": "mcdoc:identifier",
-        "range": {
-          "start": 11,
-          "end": 14
-        },
-        "value": "Foo"
-      },
-      {
         "type": "mcdoc:enum/block",
         "children": [
           {
@@ -460,10 +381,10 @@ exports[`mcdoc parser > enum_ > Parse 'enum (int) Foo' 1`] = `
               {
                 "type": "mcdoc:identifier",
                 "range": {
-                  "start": 14,
+                  "start": 11,
                   "end": 14
                 },
-                "value": ""
+                "value": "Foo"
               },
               {
                 "type": "mcdoc:typed_number",
@@ -484,13 +405,13 @@ exports[`mcdoc parser > enum_ > Parse 'enum (int) Foo' 1`] = `
               }
             ],
             "range": {
-              "start": 14,
+              "start": 11,
               "end": 14
             }
           }
         ],
         "range": {
-          "start": 14,
+          "start": 11,
           "end": 14
         }
       }
@@ -503,18 +424,10 @@ exports[`mcdoc parser > enum_ > Parse 'enum (int) Foo' 1`] = `
   "errors": [
     {
       "range": {
-        "start": 14,
-        "end": 14
+        "start": 11,
+        "end": 11
       },
-      "message": "Expected “{” but got “”",
-      "severity": 3
-    },
-    {
-      "range": {
-        "start": 14,
-        "end": 14
-      },
-      "message": "Expected an identifier",
+      "message": "Expected “{” but got “F”",
       "severity": 3
     },
     {

--- a/packages/mcdoc/test/parser/syntax/type/struct.spec.ts.snapshot
+++ b/packages/mcdoc/test/parser/syntax/type/struct.spec.ts.snapshot
@@ -575,6 +575,49 @@ exports[`mcdoc parser > struct > Parse 'struct Foo {↓⮀⮀⮀⮀⮀/// Hello 
               "start": 160,
               "end": 185
             }
+          },
+          {
+            "type": "mcdoc:struct/field/pair",
+            "children": [
+              {
+                "type": "mcdoc:identifier",
+                "range": {
+                  "start": 191,
+                  "end": 191
+                },
+                "value": ""
+              },
+              {
+                "type": "mcdoc:type/reference",
+                "children": [
+                  {
+                    "type": "mcdoc:path",
+                    "children": [
+                      {
+                        "type": "mcdoc:identifier",
+                        "range": {
+                          "start": 191,
+                          "end": 191
+                        },
+                        "value": ""
+                      }
+                    ],
+                    "range": {
+                      "start": 191,
+                      "end": 191
+                    }
+                  }
+                ],
+                "range": {
+                  "start": 191,
+                  "end": 191
+                }
+              }
+            ],
+            "range": {
+              "start": 191,
+              "end": 191
+            }
           }
         ],
         "range": {
@@ -588,7 +631,32 @@ exports[`mcdoc parser > struct > Parse 'struct Foo {↓⮀⮀⮀⮀⮀/// Hello 
       "end": 192
     }
   },
-  "errors": []
+  "errors": [
+    {
+      "range": {
+        "start": 191,
+        "end": 191
+      },
+      "message": "Expected an identifier",
+      "severity": 3
+    },
+    {
+      "range": {
+        "start": 191,
+        "end": 191
+      },
+      "message": "Expected “:” but got “}”",
+      "severity": 3
+    },
+    {
+      "range": {
+        "start": 191,
+        "end": 191
+      },
+      "message": "Expected an identifier",
+      "severity": 3
+    }
+  ]
 }
 `;
 

--- a/packages/mcdoc/test/parser/syntax/type/unionType.spec.ts.snapshot
+++ b/packages/mcdoc/test/parser/syntax/type/unionType.spec.ts.snapshot
@@ -117,6 +117,32 @@ exports[`mcdoc parser > unionType > Parse '(boolean | string | )' 1`] = `
           "start": 11,
           "end": 18
         }
+      },
+      {
+        "type": "mcdoc:type/reference",
+        "children": [
+          {
+            "type": "mcdoc:path",
+            "children": [
+              {
+                "type": "mcdoc:identifier",
+                "range": {
+                  "start": 20,
+                  "end": 20
+                },
+                "value": ""
+              }
+            ],
+            "range": {
+              "start": 20,
+              "end": 20
+            }
+          }
+        ],
+        "range": {
+          "start": 20,
+          "end": 20
+        }
       }
     ],
     "range": {
@@ -124,7 +150,16 @@ exports[`mcdoc parser > unionType > Parse '(boolean | string | )' 1`] = `
       "end": 21
     }
   },
-  "errors": []
+  "errors": [
+    {
+      "range": {
+        "start": 20,
+        "end": 20
+      },
+      "message": "Expected an identifier",
+      "severity": 3
+    }
+  ]
 }
 `;
 
@@ -397,6 +432,32 @@ exports[`mcdoc parser > unionType > Parse '(↓⮀⮀⮀⮀⮀#[until=1.16]↓�
           "start": 48,
           "end": 85
         }
+      },
+      {
+        "type": "mcdoc:type/reference",
+        "children": [
+          {
+            "type": "mcdoc:path",
+            "children": [
+              {
+                "type": "mcdoc:identifier",
+                "range": {
+                  "start": 91,
+                  "end": 91
+                },
+                "value": ""
+              }
+            ],
+            "range": {
+              "start": 91,
+              "end": 91
+            }
+          }
+        ],
+        "range": {
+          "start": 91,
+          "end": 91
+        }
       }
     ],
     "range": {
@@ -404,7 +465,16 @@ exports[`mcdoc parser > unionType > Parse '(↓⮀⮀⮀⮀⮀#[until=1.16]↓�
       "end": 92
     }
   },
-  "errors": []
+  "errors": [
+    {
+      "range": {
+        "start": 91,
+        "end": 91
+      },
+      "message": "Expected an identifier",
+      "severity": 3
+    }
+  ]
 }
 `;
 
@@ -560,6 +630,49 @@ exports[`mcdoc parser > unionType > Parse '(↓⮀⮀⮀⮀⮀int |↓⮀⮀⮀�
                   "start": 67,
                   "end": 75
                 }
+              },
+              {
+                "type": "mcdoc:struct/field/pair",
+                "children": [
+                  {
+                    "type": "mcdoc:identifier",
+                    "range": {
+                      "start": 82,
+                      "end": 82
+                    },
+                    "value": ""
+                  },
+                  {
+                    "type": "mcdoc:type/reference",
+                    "children": [
+                      {
+                        "type": "mcdoc:path",
+                        "children": [
+                          {
+                            "type": "mcdoc:identifier",
+                            "range": {
+                              "start": 82,
+                              "end": 82
+                            },
+                            "value": ""
+                          }
+                        ],
+                        "range": {
+                          "start": 82,
+                          "end": 82
+                        }
+                      }
+                    ],
+                    "range": {
+                      "start": 82,
+                      "end": 82
+                    }
+                  }
+                ],
+                "range": {
+                  "start": 82,
+                  "end": 82
+                }
               }
             ],
             "range": {
@@ -572,6 +685,32 @@ exports[`mcdoc parser > unionType > Parse '(↓⮀⮀⮀⮀⮀int |↓⮀⮀⮀�
           "start": 36,
           "end": 84
         }
+      },
+      {
+        "type": "mcdoc:type/reference",
+        "children": [
+          {
+            "type": "mcdoc:path",
+            "children": [
+              {
+                "type": "mcdoc:identifier",
+                "range": {
+                  "start": 90,
+                  "end": 90
+                },
+                "value": ""
+              }
+            ],
+            "range": {
+              "start": 90,
+              "end": 90
+            }
+          }
+        ],
+        "range": {
+          "start": 90,
+          "end": 90
+        }
       }
     ],
     "range": {
@@ -579,6 +718,39 @@ exports[`mcdoc parser > unionType > Parse '(↓⮀⮀⮀⮀⮀int |↓⮀⮀⮀�
       "end": 91
     }
   },
-  "errors": []
+  "errors": [
+    {
+      "range": {
+        "start": 82,
+        "end": 82
+      },
+      "message": "Expected an identifier",
+      "severity": 3
+    },
+    {
+      "range": {
+        "start": 82,
+        "end": 82
+      },
+      "message": "Expected “:” but got “}”",
+      "severity": 3
+    },
+    {
+      "range": {
+        "start": 82,
+        "end": 82
+      },
+      "message": "Expected an identifier",
+      "severity": 3
+    },
+    {
+      "range": {
+        "start": 90,
+        "end": 90
+      },
+      "message": "Expected an identifier",
+      "severity": 3
+    }
+  ]
 }
 `;

--- a/packages/mcdoc/test/parser/syntax/useStatement.spec.ts.snapshot
+++ b/packages/mcdoc/test/parser/syntax/useStatement.spec.ts.snapshot
@@ -223,11 +223,20 @@ exports[`mcdoc parser > useStatement > Parse 'use foo::bar as qux// Trailing com
           "end": 19
         },
         "value": "qux"
+      },
+      {
+        "type": "comment",
+        "range": {
+          "start": 19,
+          "end": 39
+        },
+        "comment": " Trailing comment.",
+        "prefix": "//"
       }
     ],
     "range": {
       "start": 0,
-      "end": 19
+      "end": 39
     }
   },
   "errors": []


### PR DESCRIPTION
This change allows the `gapParser` to be used to show context errors, like "expected space", between arguments, while also allowing for optional arguments in a sequence with such a `gapParser`.

The current behavior is gap parser will run between every item in the sequence, whether or not those parsers actually moved the cursor or returned nodes. So multiple chained optional arguments are fiddley to implement.
```ts
function sequenceDemo(): core.Parser<core.AstNode> {
    // An InfallableParser that produces an error if it encounters a gap that isn't exaclty one space.
    const sep = core.map(mcf.sep, () => [])

    return core.setType(
        'sequence_demo',
        core.sequence([
            core.literal('sequence'),
            // gapParser is called
            core.optional(
                core.failOnEmpty(
                    core.resourceLocation({
                        category: 'tag/function',
                        usageType: 'reference',
                        allowTag: false,
                    }),
                ),
            ),
            // In the current implementation, the gapParser (sep) is called again between these
            // two parsers, whether or not the optional parser actually captured anything.
            // Because the gapParser shows an error if the gap isn't exactly one space,
            // it will always show an error when the optional parser returns `undefined`, as
            // the space has already been consumed by the previous gapParser call.
            core.literal('test'),
        ], sep),
    )
}
```
To work around this issue with the current parser, we need to put `sep` between every argument (tedious code duplication), and add an extra `core.sequence` call inside the optional parser in order to only check for that `sep` when it's actually needed creating extra tree depth that could be avoided. (adds more indentation levels. :nauseated_face:)
```ts
function sequenceDemo(): core.Parser<core.AstNode> {
    // An InfallableParser that produces an error if it encounters a gap that isn't exaclty one space.
    const sep = core.map(mcf.sep, () => undefined)

    return core.setType(
        'sequence_demo',
        core.sequence([
            core.literal('sequence'),
            sep,
            core.optional(
                core.sequence([
                    core.failOnEmpty(
                        core.resourceLocation({
                            category: 'tag/function',
                            usageType: 'reference',
                            allowTag: false,
                        }),
                    ),
                    sep,
                ]),
            ),
            core.literal('test'),
        ]),
    )
}
```
