### PR TITLE
🐛 De-duplicate primitive type name results in mcdoc/runtime errors, fixes #1889

### DIFF
--- a/packages/mcdoc/src/runtime/checker/error.ts
+++ b/packages/mcdoc/src/runtime/checker/error.ts
@@ -548,7 +548,7 @@ export function getDefaultErrorReporter<T>(
 								: e.kind === 'literal'
 								? localeQuote(e.value.value.toString())
 								: localize(`mcdoc.type.${e.kind}`)
-						),
+						).filter((s, i, self) => self.indexOf(s) === i),
 						false,
 					),
 				)


### PR DESCRIPTION
Fixes #1889