### PR TITLE
✨ Implement 26.3 snapshot 9 changes

### DIFF
--- a/packages/java-edition/src/mcfunction/parser/argument.ts
+++ b/packages/java-edition/src/mcfunction/parser/argument.ts
@@ -1508,8 +1508,8 @@ export function scoreHolder(
 	)
 }
 
-const slotSource: core.Parser<core.LiteralNode | nbt.TypedNbtNode | core.ResourceLocationNode> = core
-	.any([
+const slotSource: core.Parser<core.LiteralNode | nbt.TypedNbtNode | core.ResourceLocationNode> =
+	core.any([
 		(src, ctx) => {
 			return commandLiteral({ pool: getItemSlotsArgumentValues(ctx) })(src, ctx)
 		},

--- a/packages/java-edition/src/mcfunction/parser/argument.ts
+++ b/packages/java-edition/src/mcfunction/parser/argument.ts
@@ -162,7 +162,7 @@ export const argument: mcf.ArgumentParserGetter = (
 		case 'minecraft:column_pos':
 			return wrap(vector({ dimension: 2, integersOnly: true }))
 		case 'minecraft:component':
-			return wrap(typeRefParser(mcdoc.typeRefPath('text_component')))
+			return wrap(typeRefParser(mcdoc.typeRef('text_component')))
 		case 'minecraft:dialog':
 			return wrap(resourceOrInline('dialog'))
 		case 'minecraft:dimension':
@@ -218,7 +218,7 @@ export const argument: mcf.ArgumentParserGetter = (
 		case 'minecraft:item_stack':
 			return wrap(itemStack)
 		case 'minecraft:loot_modifier':
-			return wrap(resourceOrInline('item_modifier'))
+			return wrap(resourceOrTypedNbt('item_modifier', mcdoc.typeRef('item_modifier')))
 		case 'minecraft:loot_predicate':
 			return wrap(resourceOrInline('predicate'))
 		case 'minecraft:loot_table':
@@ -278,7 +278,7 @@ export const argument: mcf.ArgumentParserGetter = (
 		case 'minecraft:slot_source':
 			return wrap(slotSource)
 		case 'minecraft:style':
-			return wrap(typeRefParser(mcdoc.typeRefPath('text_style')))
+			return wrap(typeRefParser(mcdoc.typeRef('text_style')))
 		case 'minecraft:swizzle':
 			return wrap(commandLiteral({ pool: SwizzleArgumentValues }))
 		case 'minecraft:team':
@@ -549,7 +549,7 @@ const itemPredicate: core.InfallibleParser<ItemPredicateNode> = (src, ctx) => {
 }
 
 export function typeRefParser(
-	typeRef: `::${string}::${string}`,
+	typeRef: mcdoc.ReferenceType,
 ): core.Parser<json.TypedJsonNode | nbt.TypedNbtNode> {
 	return (src, ctx) => {
 		const release = ctx.project['loadedVersion'] as ReleaseVersion | undefined
@@ -560,21 +560,21 @@ export function typeRefParser(
 	}
 }
 
-export function jsonParser(typeRef: `::${string}::${string}`): core.Parser<json.TypedJsonNode> {
+export function jsonParser(typeRef: mcdoc.ReferenceType): core.Parser<json.TypedJsonNode> {
 	return core.map(json.parser.entry, (res) => ({
 		type: 'json:typed',
 		range: res.range,
 		children: [res],
-		targetType: { kind: 'reference', path: typeRef },
+		targetType: typeRef,
 	} satisfies json.TypedJsonNode))
 }
 
-export function nbtParser(typeRef: `::${string}::${string}`): core.Parser<nbt.TypedNbtNode> {
+export function nbtParser(typeRef: mcdoc.ReferenceType): core.Parser<nbt.TypedNbtNode> {
 	return core.map(nbt.parser.entry, (res) => ({
 		type: 'nbt:typed',
 		range: res.range,
 		children: [res],
-		targetType: { kind: 'reference', path: typeRef },
+		targetType: typeRef,
 	} satisfies nbt.TypedNbtNode))
 }
 
@@ -813,6 +813,18 @@ function resourceOrInline(category: core.FileCategory) {
 			}
 			return ans
 		}),
+	}])
+}
+
+function resourceOrTypedNbt(
+	category: core.FileCategory,
+	typeRef: mcdoc.ReferenceType,
+) {
+	return core.select([{
+		predicate: (src) => core.LegalResourceLocationCharacters.has(src.peek()),
+		parser: core.resourceLocation({ category }),
+	}, {
+		parser: nbtParser(typeRef),
 	}])
 }
 
@@ -1496,12 +1508,12 @@ export function scoreHolder(
 	)
 }
 
-const slotSource: core.Parser<core.LiteralNode | NbtResourceNode | core.ResourceLocationNode> = core
+const slotSource: core.Parser<core.LiteralNode | nbt.TypedNbtNode | core.ResourceLocationNode> = core
 	.any([
 		(src, ctx) => {
 			return commandLiteral({ pool: getItemSlotsArgumentValues(ctx) })(src, ctx)
 		},
-		resourceOrInline('slot_source'),
+		resourceOrTypedNbt('slot_source', mcdoc.typeRef('slot_source')),
 	])
 
 function symbol(

--- a/packages/java-edition/test/mcfunction/parser/argument/minecraftLootModifier.spec.ts.snapshot
+++ b/packages/java-edition/test/mcfunction/parser/argument/minecraftLootModifier.spec.ts.snapshot
@@ -1,7 +1,7 @@
 exports[`mcfunction argument parser > minecraft:loot_modifier > Parse '[{function:\"furnace_smelt\"}]' 1`] = `
 {
   "node": {
-    "type": "mcfunction:nbt_resource",
+    "type": "nbt:typed",
     "range": {
       "start": 0,
       "end": 28
@@ -243,7 +243,10 @@ exports[`mcfunction argument parser > minecraft:loot_modifier > Parse '[{functio
         "valueType": "nbt:compound"
       }
     ],
-    "category": "item_modifier"
+    "targetType": {
+      "kind": "reference",
+      "path": "::java::data::item_modifier::ItemModifierArgument"
+    }
   },
   "errors": []
 }

--- a/packages/mcdoc/src/type/reference.ts
+++ b/packages/mcdoc/src/type/reference.ts
@@ -2,16 +2,14 @@ import type { ReferenceType } from './index.js'
 
 const TypeReferences = {
 	'item_count_predicate': '::java::world::component::predicate::ItemCountPseudoPredicate',
+	'item_modifier': '::java::data::item_modifier::ItemModifierArgument',
 	'pack_meta': '::java::pack::Pack',
+	'slot_source': '::java::data::slot_source::SlotSourceArgument',
 	'tag': '::java::data::tag::Tag',
 	'text_component': '::java::util::text::Text',
 	'text_style': '::java::util::text::TextStyle',
-} as const satisfies Record<string, string>
+} as const satisfies Record<string, `::${string}::${string}`>
 export type TypeReferenceKey = keyof typeof TypeReferences
-
-export function typeRefPath(key: TypeReferenceKey): `::${string}::${string}` {
-	return TypeReferences[key]
-}
 
 export function typeRef(key: TypeReferenceKey): ReferenceType {
 	return { kind: 'reference', path: TypeReferences[key] }


### PR DESCRIPTION
`minecraft:loot_modifier` parser and `minecraft:slot_source` parser now use mcdoc type references instead of resource types.
This reflects the change made in 26.3 snapshot 9, where the two argument types no longer share the same codecs with resource files.

The referenced mcdoc types are added in SpyglassMC/vanilla-mcdoc#122.